### PR TITLE
Hotfix/fix market used phone number

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyCreateActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyCreateActivity.java
@@ -192,7 +192,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
         } else {
             isPhoneOpen = false;
             marketBuyCreateEditTextPhoneNum.setText(null);
-            marketBuyCreateEditTextPhoneNum.setEnabled(false);                      //추가
+            marketBuyCreateEditTextPhoneNum.setEnabled(false);                      //핸드폰번호텍스트 비활성화
             marketBuyCreateEditTextPhoneNum.setTextIsSelectable(false);
             marketBuyCreateEditTextPhoneNum.setClickable(false);
         }
@@ -261,8 +261,8 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
                 case R.id.market_used_buy_create_is_phone_public_radiobutton:
                     setPhoneNumber();
                     marketBuyCreateEditTextPhoneNum.setFocusableInTouchMode(true);
-                    marketBuyCreateEditTextPhoneNum.requestFocus();
-                    marketBuyCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
+                    marketBuyCreateEditTextPhoneNum.requestFocus();                                                     //포커스 부여
+                    marketBuyCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //자동으로 '-' 생성
                     isPhoneOpen = true;
                     break;
                 case R.id.market_used_buy_create_is_phone_private_radiobutton:
@@ -298,7 +298,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
     public void setPhoneNumber() {
         if (phoneNumber == null)
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
-        marketBuyCreateEditTextPhoneNum.setEnabled(true);                               //추가
+        marketBuyCreateEditTextPhoneNum.setEnabled(true);                               //핸드폰번호텍스트 활성화
         marketBuyCreateEditTextPhoneNum.setTextIsSelectable(true);
         marketBuyCreateEditTextPhoneNum.setClickable(true);
         marketBuyCreateEditTextPhoneNum.setText(phoneNumber);
@@ -311,16 +311,19 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
     public void unSetPhoneNumber() {
         phoneNumber = marketBuyCreateEditTextPhoneNum.getText().toString();
         marketBuyCreateEditTextPhoneNum.setText(null);
-        marketBuyCreateEditTextPhoneNum.setEnabled(false);                              //추가
+        marketBuyCreateEditTextPhoneNum.setEnabled(false);                              //핸드폰번호텍스트 비활성화
         marketBuyCreateEditTextPhoneNum.setTextIsSelectable(false);
         marketBuyCreateEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
     }
 
-
+    /**
+     * 키보드를 사라지게 하는 함수
+     * @param activity
+     */
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-        im.hideSoftInputFromWindow(marketBuyCreateEditTextPhoneNum.getWindowToken(), 0);            //수정
+        im.hideSoftInputFromWindow(marketBuyCreateEditTextPhoneNum.getWindowToken(), 0);
     }
 
     /**

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyCreateActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyCreateActivity.java
@@ -24,6 +24,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
+import android.telephony.PhoneNumberFormattingTextWatcher;
 import android.text.*;
 import android.util.Log;
 import android.view.View;
@@ -191,6 +192,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
         } else {
             isPhoneOpen = false;
             marketBuyCreateEditTextPhoneNum.setText(null);
+            marketBuyCreateEditTextPhoneNum.setEnabled(false);                      //추가
             marketBuyCreateEditTextPhoneNum.setTextIsSelectable(false);
             marketBuyCreateEditTextPhoneNum.setClickable(false);
         }
@@ -258,6 +260,9 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
             switch (button.getId()) {
                 case R.id.market_used_buy_create_is_phone_public_radiobutton:
                     setPhoneNumber();
+                    marketBuyCreateEditTextPhoneNum.setFocusableInTouchMode(true);
+                    marketBuyCreateEditTextPhoneNum.requestFocus();
+                    marketBuyCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
                     isPhoneOpen = true;
                     break;
                 case R.id.market_used_buy_create_is_phone_private_radiobutton:
@@ -293,6 +298,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
     public void setPhoneNumber() {
         if (phoneNumber == null)
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
+        marketBuyCreateEditTextPhoneNum.setEnabled(true);                               //추가
         marketBuyCreateEditTextPhoneNum.setTextIsSelectable(true);
         marketBuyCreateEditTextPhoneNum.setClickable(true);
         marketBuyCreateEditTextPhoneNum.setText(phoneNumber);
@@ -305,6 +311,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
     public void unSetPhoneNumber() {
         phoneNumber = marketBuyCreateEditTextPhoneNum.getText().toString();
         marketBuyCreateEditTextPhoneNum.setText(null);
+        marketBuyCreateEditTextPhoneNum.setEnabled(false);                              //추가
         marketBuyCreateEditTextPhoneNum.setTextIsSelectable(false);
         marketBuyCreateEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
@@ -313,7 +320,7 @@ public class MarketUsedBuyCreateActivity extends ActivityBase implements MarketU
 
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-        im.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        im.hideSoftInputFromWindow(marketBuyCreateEditTextPhoneNum.getWindowToken(), 0);            //수정
     }
 
     /**

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyDetailActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyDetailActivity.java
@@ -109,7 +109,7 @@ public class MarketUsedBuyDetailActivity extends KoinNavigationDrawerActivity im
     protected void onStart() {
         super.onStart();
         marketDetailPresenter.readMarketDetail(item.getId());
-
+        this.marketDetailPresenter.checkGranted(this.item.getId());
 
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyEditActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyEditActivity.java
@@ -326,8 +326,8 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
                 case R.id.market_used_buy_edit_is_phone_public_radiobutton:
                     setPhoneNumber();
                     marketBuyEditEditTextPhoneNum.setFocusableInTouchMode(true);
-                    marketBuyEditEditTextPhoneNum.requestFocus();
-                    marketBuyEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
+                    marketBuyEditEditTextPhoneNum.requestFocus();                                                     //포커스를 부여
+                    marketBuyEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //자동으로 '-' 생성
 
                     this.isPhoneOpen = true;
                     break;
@@ -362,7 +362,7 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
      * 번호 입력 Edittext 수정가능하도록 set
      */
     public void setPhoneNumber() {
-        marketBuyEditEditTextPhoneNum.setEnabled(true);
+        marketBuyEditEditTextPhoneNum.setEnabled(true);                                     //핸드폰번호텍스트 활성화
         marketBuyEditEditTextPhoneNum.setTextIsSelectable(true);
         marketBuyEditEditTextPhoneNum.setClickable(true);
         if (this.phoneNumber == null)
@@ -377,13 +377,16 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
     public void unSetPhoneNumber() {
         this.phoneNumber = marketBuyEditEditTextPhoneNum.getText().toString();
         marketBuyEditEditTextPhoneNum.setText(null);
-        marketBuyEditEditTextPhoneNum.setEnabled(false);
+        marketBuyEditEditTextPhoneNum.setEnabled(false);                                //핸드폰번호텍스트 비활성화
         marketBuyEditEditTextPhoneNum.setTextIsSelectable(false);
         marketBuyEditEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
     }
 
-
+    /**
+     * 키보드를 사라지게 하는 함수
+     * @param activity
+     */
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
         im.hideSoftInputFromWindow(marketBuyEditEditTextPhoneNum.getWindowToken(), 0);

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyEditActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedBuyEditActivity.java
@@ -26,6 +26,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
+import android.telephony.PhoneNumberFormattingTextWatcher;
 import android.text.*;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -112,7 +113,7 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
     RadioButton mMarketBuyEditIsPhonePrivateRadioButton;
 
     @BindView(R.id.market_used_buy_edit_edittext_phone_num)
-    EditText mMarketBuyEditEditTextPhoneNum;
+    EditText marketBuyEditEditTextPhoneNum;
 
 
     @BindView(R.id.market_used_buy_edit_buying_status_radiobutton_group)
@@ -203,8 +204,8 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
         mMarketBuyEditMoneyEditText.setText(changeMoneyFormatToStringWithComma(this.price));
 
 
-        mMarketBuyEditEditTextPhoneNum.setFocusable(false);
-        mMarketBuyEditEditTextPhoneNum.setClickable(false);
+        marketBuyEditEditTextPhoneNum.setFocusable(false);
+        marketBuyEditEditTextPhoneNum.setClickable(false);
 
 
         if (this.isPhoneOpen) {
@@ -324,6 +325,10 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
             switch (button.getId()) {
                 case R.id.market_used_buy_edit_is_phone_public_radiobutton:
                     setPhoneNumber();
+                    marketBuyEditEditTextPhoneNum.setFocusableInTouchMode(true);
+                    marketBuyEditEditTextPhoneNum.requestFocus();
+                    marketBuyEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
+
                     this.isPhoneOpen = true;
                     break;
                 case R.id.market_used_buy_edit_is_phone_private_radiobutton:
@@ -357,29 +362,31 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
      * 번호 입력 Edittext 수정가능하도록 set
      */
     public void setPhoneNumber() {
-        mMarketBuyEditEditTextPhoneNum.setTextIsSelectable(true);
-        mMarketBuyEditEditTextPhoneNum.setClickable(true);
+        marketBuyEditEditTextPhoneNum.setEnabled(true);
+        marketBuyEditEditTextPhoneNum.setTextIsSelectable(true);
+        marketBuyEditEditTextPhoneNum.setClickable(true);
         if (this.phoneNumber == null)
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
 
-        mMarketBuyEditEditTextPhoneNum.setText(this.phoneNumber);
+        marketBuyEditEditTextPhoneNum.setText(this.phoneNumber);
     }
 
     /**
      * 번호 입력 Edittext 수정 못하도록 set
      */
     public void unSetPhoneNumber() {
-        this.phoneNumber = mMarketBuyEditEditTextPhoneNum.getText().toString();
-        mMarketBuyEditEditTextPhoneNum.setText(null);
-        mMarketBuyEditEditTextPhoneNum.setTextIsSelectable(false);
-        mMarketBuyEditEditTextPhoneNum.setClickable(false);
+        this.phoneNumber = marketBuyEditEditTextPhoneNum.getText().toString();
+        marketBuyEditEditTextPhoneNum.setText(null);
+        marketBuyEditEditTextPhoneNum.setEnabled(false);
+        marketBuyEditEditTextPhoneNum.setTextIsSelectable(false);
+        marketBuyEditEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
     }
 
 
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-        im.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        im.hideSoftInputFromWindow(marketBuyEditEditTextPhoneNum.getWindowToken(), 0);
     }
 
     //TODO -> content edit
@@ -750,7 +757,7 @@ public class MarketUsedBuyEditActivity extends KoinNavigationDrawerActivity impl
      */
     public void onClickEditButton() {
         SpannableStringBuilder spannableStringBuilder = new SpannableStringBuilder(mMarketBuyEditContent.getText().toString().trim());
-        this.phoneNumber = mMarketBuyEditEditTextPhoneNum.getText().toString().trim();
+        this.phoneNumber = marketBuyEditEditTextPhoneNum.getText().toString().trim();
 
 
         if (this.isPhoneOpen) {

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellCreateActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellCreateActivity.java
@@ -24,6 +24,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
+import android.telephony.PhoneNumberFormattingTextWatcher;
 import android.text.*;
 import android.util.Log;
 import android.view.View;
@@ -192,6 +193,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
         } else {
             this.isPhoneOpen = false;
             marketSellCreateEditTextPhoneNum.setText(null);
+            marketSellCreateEditTextPhoneNum.setEnabled(false);
             marketSellCreateEditTextPhoneNum.setTextIsSelectable(false);
             marketSellCreateEditTextPhoneNum.setClickable(false);
         }
@@ -260,6 +262,9 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
             switch (button.getId()) {
                 case R.id.market_used_sell_create_is_phone_public_radiobutton:
                     setPhoneNumber();
+                    marketSellCreateEditTextPhoneNum.setFocusableInTouchMode(true);
+                    marketSellCreateEditTextPhoneNum.requestFocus();
+                    marketSellCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
                     this.isPhoneOpen = true;
                     break;
                 case R.id.market_used_sell_create_is_phone_private_radiobutton:
@@ -295,6 +300,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
     public void setPhoneNumber() {
         marketSellCreateEditTextPhoneNum.setTextIsSelectable(true);
         marketSellCreateEditTextPhoneNum.setClickable(true);
+        marketSellCreateEditTextPhoneNum.setEnabled(true);
         if (this.phoneNumber == null) {
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
             return;
@@ -309,6 +315,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
     public void unSetPhoneNumber() {
         this.phoneNumber = marketSellCreateEditTextPhoneNum.getText().toString();
         marketSellCreateEditTextPhoneNum.setText(null);
+        marketSellCreateEditTextPhoneNum.setEnabled(false);
         marketSellCreateEditTextPhoneNum.setTextIsSelectable(false);
         marketSellCreateEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
@@ -317,7 +324,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
 
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-        im.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        im.hideSoftInputFromWindow(marketSellCreateEditTextPhoneNum.getWindowToken(), 0);
     }
 
     /**

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellCreateActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellCreateActivity.java
@@ -193,7 +193,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
         } else {
             this.isPhoneOpen = false;
             marketSellCreateEditTextPhoneNum.setText(null);
-            marketSellCreateEditTextPhoneNum.setEnabled(false);
+            marketSellCreateEditTextPhoneNum.setEnabled(false);                             //핸드폰번호 터치 불가능
             marketSellCreateEditTextPhoneNum.setTextIsSelectable(false);
             marketSellCreateEditTextPhoneNum.setClickable(false);
         }
@@ -263,8 +263,8 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
                 case R.id.market_used_sell_create_is_phone_public_radiobutton:
                     setPhoneNumber();
                     marketSellCreateEditTextPhoneNum.setFocusableInTouchMode(true);
-                    marketSellCreateEditTextPhoneNum.requestFocus();
-                    marketSellCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
+                    marketSellCreateEditTextPhoneNum.requestFocus();                                                        //포커스 부여
+                    marketSellCreateEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //자동으로 '-' 생성
                     this.isPhoneOpen = true;
                     break;
                 case R.id.market_used_sell_create_is_phone_private_radiobutton:
@@ -300,7 +300,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
     public void setPhoneNumber() {
         marketSellCreateEditTextPhoneNum.setTextIsSelectable(true);
         marketSellCreateEditTextPhoneNum.setClickable(true);
-        marketSellCreateEditTextPhoneNum.setEnabled(true);
+        marketSellCreateEditTextPhoneNum.setEnabled(true);                              //핸드폰번호텍스트 활성화
         if (this.phoneNumber == null) {
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
             return;
@@ -315,7 +315,7 @@ public class MarketUsedSellCreateActivity extends ActivityBase implements Market
     public void unSetPhoneNumber() {
         this.phoneNumber = marketSellCreateEditTextPhoneNum.getText().toString();
         marketSellCreateEditTextPhoneNum.setText(null);
-        marketSellCreateEditTextPhoneNum.setEnabled(false);
+        marketSellCreateEditTextPhoneNum.setEnabled(false);                             //핸드폰번호텍스트 비활성화
         marketSellCreateEditTextPhoneNum.setTextIsSelectable(false);
         marketSellCreateEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellEditActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellEditActivity.java
@@ -318,8 +318,8 @@ public class MarketUsedSellEditActivity extends KoinNavigationDrawerActivity imp
                 case R.id.market_used_sell_edit_is_phone_public_radiobutton:
                     setPhoneNumber();
                     marketSellEditEditTextPhoneNum.setFocusableInTouchMode(true);
-                    marketSellEditEditTextPhoneNum.requestFocus();
-                    marketSellEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
+                    marketSellEditEditTextPhoneNum.requestFocus();                                                      //포커스 부여
+                    marketSellEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //자동으로 '-' 생성
                     isPhoneOpen = true;
                     break;
                 case R.id.market_used_sell_edit_is_phone_private_radiobutton:
@@ -355,6 +355,7 @@ public class MarketUsedSellEditActivity extends KoinNavigationDrawerActivity imp
     public void setPhoneNumber() {
         marketSellEditEditTextPhoneNum.setTextIsSelectable(true);
         marketSellEditEditTextPhoneNum.setClickable(true);
+        marketSellEditEditTextPhoneNum.setEnabled(true);
         if (phoneNumber == null) {
             ToastUtil.getInstance().makeShort("휴대폰 번호를 기입해주세요");
             return;
@@ -369,6 +370,7 @@ public class MarketUsedSellEditActivity extends KoinNavigationDrawerActivity imp
         phoneNumber = marketSellEditEditTextPhoneNum.getText().toString();
         marketSellEditEditTextPhoneNum.setText(null);
         marketSellEditEditTextPhoneNum.setTextIsSelectable(false);
+        marketSellEditEditTextPhoneNum.setEnabled(false);                                   ////핸드폰번호텍스트 비활성화
         marketSellEditEditTextPhoneNum.setClickable(false);
         hideKeyboard(this);
     }
@@ -376,7 +378,7 @@ public class MarketUsedSellEditActivity extends KoinNavigationDrawerActivity imp
 
     public void hideKeyboard(Activity activity) {
         InputMethodManager im = (InputMethodManager) activity.getSystemService(activity.INPUT_METHOD_SERVICE);
-        im.hideSoftInputFromWindow(activity.getCurrentFocus().getWindowToken(), 0);
+        im.hideSoftInputFromWindow(marketSellEditEditTextPhoneNum.getWindowToken(), 0);
     }
 
     //TODO -> content edit

--- a/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellEditActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/usedmarket/MarketUsedSellEditActivity.java
@@ -26,6 +26,7 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 
+import android.telephony.PhoneNumberFormattingTextWatcher;
 import android.text.*;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -316,6 +317,9 @@ public class MarketUsedSellEditActivity extends KoinNavigationDrawerActivity imp
             switch (button.getId()) {
                 case R.id.market_used_sell_edit_is_phone_public_radiobutton:
                     setPhoneNumber();
+                    marketSellEditEditTextPhoneNum.setFocusableInTouchMode(true);
+                    marketSellEditEditTextPhoneNum.requestFocus();
+                    marketSellEditEditTextPhoneNum.addTextChangedListener(new PhoneNumberFormattingTextWatcher());     //추가
                     isPhoneOpen = true;
                     break;
                 case R.id.market_used_sell_edit_is_phone_private_radiobutton:


### PR DESCRIPTION
핸드폰 번호 공개여부 버튼을 공개하였다가 다시 비공개로 했을 때 activity.getCurrentFocus()이 null이여서 앱이 종료되는 버그가 있었습니다.

핸드폰 번호를 입력하는 EditText로 지정해주어서 해결하였습니다.

핸드폰 번호 비공개시 EditText에 입력이 가능한 버그를 EditText.setEnable(false)로 하여 입력 불가능하게 하였습니다

추가변경
MarketUsedBuyDetailActivity에서 checkGrant를 하지 않아 수정 및 삭제버튼이 보이지 않아  grant를 체크하도록 수정하였습니다.

