### PR TITLE
Add instrumented test cases for signup

### DIFF
--- a/koin/src/androidTest/java/in/koreatech/koin/SignupInstrumentedTest.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/SignupInstrumentedTest.java
@@ -32,7 +32,7 @@ import static org.hamcrest.core.IsNot.not;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest
-public class SignupTest {
+public class SignupInstrumentedTest {
     @Rule
     public IntentsTestRule<SignupActivity> activityRule =
             new IntentsTestRule<>(SignupActivity.class);

--- a/koin/src/androidTest/java/in/koreatech/koin/SignupTest.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/SignupTest.java
@@ -1,0 +1,242 @@
+package in.koreatech.koin;
+
+import android.view.View;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.intent.rule.IntentsTestRule;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.filters.LargeTest;
+
+import org.hamcrest.Matcher;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Random;
+
+import in.koreatech.koin.ui.signup.SignupActivity;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+import static androidx.test.espresso.action.ViewActions.typeText;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.isRoot;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
+
+@RunWith(AndroidJUnit4.class)
+@LargeTest
+public class SignupTest {
+    @Rule
+    public IntentsTestRule<SignupActivity> activityRule =
+            new IntentsTestRule<>(SignupActivity.class);
+
+    @Test
+    public void testCaseForEmailWithoutAnything() { //아무것도 입력하지 않고 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("이메일을 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithOnlyEmail() { //이메일만 입력하고 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithNotMatchingPasswords() { //비밀번호가 일치하지 않은 상태에서 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password12*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("passvvord12*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithPasswordsUnder5() { //비밀번호가 5자리 이하일 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("abc1*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("abc1*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithPasswordsOver17() { //비밀번호가 19자리 이상일 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("verylongpassword1234*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("verylongpassword1234*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithPasswordsNotIncludingSpecialMarks() { //비밀번호에 특수문자가 없을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password1234"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password1234"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithPasswordsNotIncludingEnglish() { //비밀번호에 영어가 없을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("12345678"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("12345678"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithPasswordsNotIncludingNumbers() { //비밀번호에 숫자가 없을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("입력한 정보를 다시 확인해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithoutTerms() { //조건에 맞는 이메일과 비밀번호를 입력하고 약관 동의 체크를 하지 않았을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password123*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password123*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("이용약관에 동의해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithOnlyTermsOfUse() { //조건에 맞는 이메일과 비밀번호를 입력하고 이용 약관 동의만 체크했을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password123*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password123*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_check_box_personal_info_terms)).perform(click());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("이용약관에 동의해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmailWithOnlyTermsOfKoin() { //조건에 맞는 이메일과 비밀번호를 입력하고 코인 약관 동의만 체크했을 때 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText("abc"));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password123*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password123*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_check_box_signup_terms)).perform(click());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("이용약관에 동의해 주세요")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForEmail() { //모든 조건을 만족하고 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText(generateRandomId()));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password123*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password123*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_check_box_personal_info_terms)).perform(click());
+        onView(withId(R.id.signup_check_box_signup_terms)).perform(click());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("10분안에 학교 메일로 인증을 완료해 주세요. 이동하실래요?"))
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testCaseForAlreadySignedUpEmail() { //모든 조건을 만족하고 이메일 인증 버튼 클릭
+        onView(withId(R.id.signup_edittext_id)).perform(typeText(generateRandomId()));
+        onView(withId(R.id.signup_edittext_pw)).perform(typeText("password123*"));
+        onView(withId(R.id.signup_edittext_pw_confirm)).perform(typeText("password123*"));
+        onView(isRoot()).perform(closeSoftKeyboard());
+        onView(withId(R.id.signup_check_box_personal_info_terms)).perform(click());
+        onView(withId(R.id.signup_check_box_signup_terms)).perform(click());
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(isRoot()).perform(waitFor(3000));
+
+        onView(withId(R.id.signup_send_verification_button)).perform(click());
+        onView(withText("이미 가입한 계정이거나\n이메일 전송을 요청하였습니다.")).inRoot(withDecorView(not(is(activityRule.getActivity().getWindow().getDecorView()))))
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(3000));
+    }
+
+    @Test
+    public void testCaseForClickTerms() { //개인정보 이용약관 클릭
+        onView(withId(R.id.signup_textview_personal_info_terms)).perform(click());
+        onView(withId(android.R.id.button1)).check(matches(isDisplayed()));
+    }
+
+    @Test
+    public void testCaseForClickTermsOfKoin() { //코인 이용약관 클릭
+        onView(withId(R.id.signup_textview_signup_terms)).perform(click());
+        onView(withId(android.R.id.button1)).check(matches(isDisplayed()));
+    }
+
+    public static ViewAction waitFor(final long millis) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return isRoot();
+            }
+
+            @Override
+            public String getDescription() {
+                return "Wait for " + millis + " milliseconds.";
+            }
+
+            @Override
+            public void perform(UiController uiController, final View view) {
+                uiController.loopMainThreadForAtLeast(millis);
+            }
+        };
+    }
+
+    private String generateRandomId() {
+        String availableChars = "abcdefghijklmnopqrstuvwxyz";
+        StringBuilder id = new StringBuilder();
+        Random random = new Random();
+        for(int i = 0; i < random.nextInt(7) + 1; i++)
+            id.append(availableChars.charAt(random.nextInt(availableChars.length())));
+
+        return id.toString();
+    }
+
+}
+
+
+

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/ImageViewSrcMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/ImageViewSrcMatcher.java
@@ -1,0 +1,35 @@
+package in.koreatech.koin.matcher;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.view.View;
+import android.widget.ImageView;
+import androidx.test.espresso.matcher.BoundedMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import static org.hamcrest.Matchers.is;
+public class ImageViewSrcMatcher extends BoundedMatcher<View, ImageView> {
+    BitmapDrawable drawable;
+    private ImageViewSrcMatcher(BitmapDrawable drawable) {
+        super(ImageView.class);
+        this.drawable = drawable;
+    }
+    public static Matcher<View> withDrawable(Drawable drawable) {
+        return new ImageViewSrcMatcher((BitmapDrawable) drawable);
+    }
+    @Override
+    protected boolean matchesSafely(ImageView item) {
+        return drawable.getBitmap().equals(((BitmapDrawable) item.getDrawable()).getBitmap());
+    }
+    @Override
+    public void describeMismatch(Object item, Description mismatchDescription) {
+        mismatchDescription.appendText("ImageView with src: " +
+                ((ImageView) item).getDrawable().toString() + ", expected: ");
+        is(drawable).describeMismatch(item, mismatchDescription);
+    }
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("with src ");
+        is(drawable).describeTo(description);
+    }
+}
+//onView(withId(R.id.YOUR_VIEW_ID)).check(matches(ImageViewSrcMatcher.withDrawable(YOUR_DRAWABLE));

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/RecyclerViewMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/RecyclerViewMatcher.java
@@ -1,0 +1,57 @@
+package in.koreatech.koin.matcher;
+
+import android.content.res.Resources;
+import android.view.View;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static org.hamcrest.Matchers.is;
+
+public class RecyclerViewMatcher {
+
+    public static Matcher<View> atPositionOnView(final int recyclerViewId, final int position, final int viewId) {
+        return new TypeSafeMatcher<View>() {
+            Resources resources = null;
+            View childView;
+            @Override
+            public void describeTo(Description description) {
+                String idDescription = Integer.toString(recyclerViewId);
+                if (this.resources != null) {
+                    try {
+                        idDescription = this.resources.getResourceName(recyclerViewId);
+                    } catch (Resources.NotFoundException exception) {
+                        idDescription = String.format("%s not found", recyclerViewId);
+                    }
+                }
+                description.appendText("with id " + idDescription);
+                is(viewId).describeTo(description);
+            }
+            @Override
+            protected boolean matchesSafely(View item) {
+                this.resources = item.getResources();
+                if (childView == null) {
+                    RecyclerView recyclerView = item.getRootView().findViewById(recyclerViewId);
+                    if (recyclerView != null && recyclerView.getId() == recyclerViewId) {
+                        childView = recyclerView.findViewHolderForAdapterPosition(position).itemView;
+                    }
+                    else {
+                        return false;
+                    }
+                }
+                if (viewId == -1) {
+                    return item == childView;
+                } else {
+                    View targetView = childView.findViewById(viewId);
+                    return item == targetView;
+                }
+            }
+        };
+    }
+}
+//onView(RecyclerViewMatcher.atPositionOnView(R.id.recycdlerview_id, 0, R.id.asdf, )).perform(click());
+
+

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/TabLayoutMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/TabLayoutMatcher.java
@@ -1,0 +1,35 @@
+package in.koreatech.koin.matcher;
+
+import android.view.View;
+
+import androidx.annotation.IdRes;
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.matcher.BoundedMatcher;
+
+import com.google.android.material.tabs.TabLayout;
+
+import org.hamcrest.Description;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.matcher.ViewMatchers.withId;
+import static org.hamcrest.Matchers.is;
+
+public class TabLayoutMatcher {
+    private static BoundedMatcher<View, TabLayout> checkTabSelectedAndText(@IdRes int tabLayoutId, int position, String tabText, boolean isSelected) {
+        return new BoundedMatcher<View, TabLayout>(TabLayout.class) {
+            @Override
+            protected boolean matchesSafely(TabLayout item) {
+                TabLayout.Tab tab = item.getTabAt(position);
+                if(tab == null) throw new PerformException.Builder()
+                        .withCause(new Throwable("No tab at index" + position))
+                        .build();
+                else return tab.isSelected() == isSelected && tab.getText().equals(tabText);
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with selected tab check");
+                is(onView(withId(tabLayoutId))).describeTo(description);
+            }
+        };
+    }
+}

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/TabLayoutMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/TabLayoutMatcher.java
@@ -15,7 +15,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.withId;
 import static org.hamcrest.Matchers.is;
 
 public class TabLayoutMatcher {
-    private static BoundedMatcher<View, TabLayout> checkTabSelectedAndText(@IdRes int tabLayoutId, int position, String tabText, boolean isSelected) {
+    public static BoundedMatcher<View, TabLayout> checkTabSelectedAndText(@IdRes int tabLayoutId, int position, String tabText, boolean isSelected) {
         return new BoundedMatcher<View, TabLayout>(TabLayout.class) {
             @Override
             protected boolean matchesSafely(TabLayout item) {

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/TextColorMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/TextColorMatcher.java
@@ -1,0 +1,27 @@
+package in.koreatech.koin.matcher;
+
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.test.espresso.matcher.BoundedMatcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+
+public class TextColorMatcher {
+    public static Matcher<View> textViewTextColorMatcher(final int matcherColor) {
+        return new BoundedMatcher<View, TextView>(TextView.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with text color: " + matcherColor);
+            }
+            @Override
+            protected boolean matchesSafely(TextView textView) {
+                return matcherColor == textView.getCurrentTextColor();
+            }
+        };
+    }
+}
+//ex)
+//onView(withId(R.id.asd)).check(matches(textViewTextColorMatcher(context.getResources().getColor(R.color.red1))));

--- a/koin/src/androidTest/java/in/koreatech/koin/matcher/ToastMatcher.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/matcher/ToastMatcher.java
@@ -1,0 +1,40 @@
+package in.koreatech.koin.matcher;
+
+import android.os.IBinder;
+import android.view.WindowManager;
+
+import androidx.test.espresso.Root;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+public class ToastMatcher extends TypeSafeMatcher<Root> {
+    private String message;
+
+    private ToastMatcher(String message) {
+        this.message = message;
+    }
+
+    public static ToastMatcher withMessage(String message){
+        return new ToastMatcher(message);
+    }
+    @Override
+    protected boolean matchesSafely(Root root) {
+        int type = root.getWindowLayoutParams().get().type;
+        if (type == WindowManager.LayoutParams.TYPE_TOAST) {
+            IBinder windowToken = root.getDecorView().getWindowToken();
+            IBinder appToken = root.getDecorView().getApplicationWindowToken();
+            if (windowToken == appToken) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText(message);
+    }
+}
+//ex)
+// onView(withText("토스트메시지")).inRoot(withMessage("토스트메시지")).check(matches(isDisplayed()));

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/KoinRichEditorViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/KoinRichEditorViewAction.java
@@ -1,0 +1,36 @@
+package in.koreatech.koin.viewaction;
+
+import android.view.View;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import org.hamcrest.Matcher;
+
+import in.koreatech.koin.ui.board.KoinRichEditor;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static org.hamcrest.Matchers.allOf;
+
+public class KoinRichEditorViewAction {
+    public static ViewAction koinRichEditorTypeText(final String text){
+        return new ViewAction(){
+            @Override
+            public Matcher<View> getConstraints() {
+                return allOf(isDisplayed(), isAssignableFrom(KoinRichEditor.class));
+            }
+
+            @Override
+            public String getDescription() {
+                return "Change view text";
+            }
+
+            @Override
+            public void perform(UiController uiController, View view) {
+                ((KoinRichEditor) view).render("<p>"+text+"</P>");
+            }
+
+        };
+    }
+}

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/NestedScrollViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/NestedScrollViewAction.java
@@ -1,0 +1,82 @@
+package in.koreatech.koin.viewaction;
+
+import android.view.View;
+import android.view.ViewParent;
+import android.widget.FrameLayout;
+
+import androidx.core.widget.NestedScrollView;
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+import androidx.test.espresso.matcher.ViewMatchers;
+import androidx.test.espresso.util.HumanReadables;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDescendantOfA;
+import static androidx.test.espresso.matcher.ViewMatchers.withEffectiveVisibility;
+
+public class NestedScrollViewAction {
+    public  static ViewAction nestedScrollTo() {
+        return new ViewAction() {
+
+            @Override
+            public Matcher<View> getConstraints() {
+                return Matchers.allOf(
+                        isDescendantOfA(isAssignableFrom(NestedScrollView.class)),
+                        withEffectiveVisibility(ViewMatchers.Visibility.VISIBLE));
+            }
+
+            @Override
+            public String getDescription() {
+                return "Change view text";
+            }
+
+            @Override
+            public void perform(UiController uiController, View view) {
+
+                try {
+                    NestedScrollView nestedScrollView = (NestedScrollView)
+                            findFirstParentLayoutOfClass(view, NestedScrollView.class);
+                    if (nestedScrollView != null) {
+                        nestedScrollView.scrollTo(0, view.getTop());
+                    } else {
+                        throw new Exception("Unable to find NestedScrollView parent.");
+                    }
+                } catch (Exception e) {
+                    throw new PerformException.Builder()
+                            .withActionDescription(this.getDescription())
+                            .withViewDescription(HumanReadables.describe(view))
+                            .withCause(e)
+                            .build();
+                }
+                uiController.loopMainThreadUntilIdle();
+            }
+        };
+    }
+    private static View findFirstParentLayoutOfClass(View view, Class<? extends View> parentClass) {
+        ViewParent parent = new FrameLayout(view.getContext());
+        ViewParent incrementView = null;
+        int i = 0;
+        while (parent != null && !(parent.getClass() == parentClass)) {
+            if (i == 0) {
+                parent = findParent(view);
+            } else {
+                parent = findParent(incrementView);
+            }
+            incrementView = parent;
+            i++;
+        }
+        return (View) parent;
+    }
+
+    private static ViewParent findParent(View view) {
+        return view.getParent();
+    }
+
+    private static ViewParent findParent(ViewParent view) {
+        return view.getParent();
+    }
+}

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/SpinnerViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/SpinnerViewAction.java
@@ -13,7 +13,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 public class SpinnerViewAction {
-    private static ViewAction selectSpinnerPosition(int position) {
+    public static ViewAction selectSpinnerPosition(int position) {
         return new ViewAction() {
             @Override
             public Matcher<View> getConstraints() {

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/SpinnerViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/SpinnerViewAction.java
@@ -1,0 +1,33 @@
+package in.koreatech.koin.viewaction;
+
+import android.view.View;
+import android.widget.Spinner;
+
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+public class SpinnerViewAction {
+    private static ViewAction selectSpinnerPosition(int position) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return Matchers.allOf(isDisplayed(), isAssignableFrom(Spinner.class));
+            }
+            @Override
+            public String getDescription() {
+                return "with spinner at index" + position;
+            }
+            @Override
+            public void perform(UiController uiController, View view) {
+                Spinner spinner = (Spinner) view;
+                spinner.setSelection(position);
+            }
+        };
+    }
+}

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/TabLayoutViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/TabLayoutViewAction.java
@@ -15,7 +15,7 @@ import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
 
 public class TabLayoutViewAction {
-    private static ViewAction selectTabAtPosition(int position) {
+    public static ViewAction selectTabAtPosition(int position) {
         return new ViewAction() {
             @Override
             public Matcher<View> getConstraints() {
@@ -30,7 +30,7 @@ public class TabLayoutViewAction {
                 TabLayout tabLayout = (TabLayout) view;
                 TabLayout.Tab tab = tabLayout.getTabAt(position);
                 if(tab == null) throw new PerformException.Builder()
-                        .withCause(new Throwable("No tab at index $tabIndex"))
+                        .withCause(new Throwable("No tab at index" + position))
                         .build();
                 else tab.select();
             }

--- a/koin/src/androidTest/java/in/koreatech/koin/viewaction/TabLayoutViewAction.java
+++ b/koin/src/androidTest/java/in/koreatech/koin/viewaction/TabLayoutViewAction.java
@@ -1,0 +1,39 @@
+package in.koreatech.koin.viewaction;
+
+import android.view.View;
+
+import androidx.test.espresso.PerformException;
+import androidx.test.espresso.UiController;
+import androidx.test.espresso.ViewAction;
+
+import com.google.android.material.tabs.TabLayout;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+
+public class TabLayoutViewAction {
+    private static ViewAction selectTabAtPosition(int position) {
+        return new ViewAction() {
+            @Override
+            public Matcher<View> getConstraints() {
+                return Matchers.allOf(isDisplayed(), isAssignableFrom(TabLayout.class));
+            }
+            @Override
+            public String getDescription() {
+                return "with tab at index" + position;
+            }
+            @Override
+            public void perform(UiController uiController, View view) {
+                TabLayout tabLayout = (TabLayout) view;
+                TabLayout.Tab tab = tabLayout.getTabAt(position);
+                if(tab == null) throw new PerformException.Builder()
+                        .withCause(new Throwable("No tab at index $tabIndex"))
+                        .build();
+                else tab.select();
+            }
+        };
+    }
+}


### PR DESCRIPTION
### SignupActivity에 대한 UI Test Case 추가

#### Test scenarios

1. 아무것도 입력하지 않고 이메일 인증 버튼 클릭
2. 이메일만 입력하고 이메일 인증 버튼 클릭
3. 비밀번호가 일치하지 않은 상태에서 이메일 인증 버튼 클릭
4. 비밀번호 길이가 5자 이하일 때 이메일 인증 버튼 클릭
5. 비밀번호 길이가 19자 이상일 때 이메일 인증 버튼 클릭
6. 비밀번호에 특수문자가 포함되지 않은 상태에서 이메일 인증 버튼 클릭
7. 비밀번호에 영어가 포함되지 않은 상태에서 이메일 인증 버튼 클릭
8. 비밀번호에 숫자가 포함되지 않은 상태에서 이메일 인증 버튼 클릭
9. 조건에 맞는 이메일과 비밀번호를 입력하고 약관 동의 체크를 하지 않았을 때 이메일 인증 버튼 클릭
10. 조건에 맞는 이메일과 비밀번호를 입력하고 이용 약관 동의만 체크했을 때 이메일 인증 버튼 클릭
11. 조건에 맞는 이메일과 비밀번호를 입력하고 koin 약관 동의만 체크했을 때 이메일 인증 버튼 클릭
12. 모든 조건을 만족하고 이메일 인증 버튼 클릭
13. 개인정보 이용약관 클릭
14. 코인 이용약관 클릭
15. 이미 가입하거나 인증 메일을 보낸 이메일 주소를 사용하여 인증 시도

