### PR TITLE
Feature/add binding delegate

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,9 @@ buildscript {
         androidxRecyclerView = "androidx.recyclerview:recyclerview:$android_x_version"
         androidxCardView = "androidx.cardview:cardview:$android_x_version"
 
+        def lifecycle_version = "2.5.1"
+        androidXLifecycle = "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
+
         def activity_version = "1.4.0"
         androidXActivityKtx = "androidx.activity:activity-ktx:$activity_version"
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     api project.androidxRecyclerView
     api project.androidxCardView
     api project.androidxMaterial
+    api project.androidXLifecycle
 
     /* Dependency - Firebase */
     api project.firebaseCore

--- a/core/src/main/java/in/koreatech/koin/core/activity/DataBindingActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/DataBindingActivity.kt
@@ -5,6 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
+@Deprecated("Use AppCompatActivity.activityDataBinding instead.")
 abstract class DataBindingActivity<T : ViewDataBinding> : ActivityBase() {
     @get:LayoutRes
     abstract val layoutId: Int

--- a/core/src/main/java/in/koreatech/koin/core/fragment/DataBindingFragment.kt
+++ b/core/src/main/java/in/koreatech/koin/core/fragment/DataBindingFragment.kt
@@ -12,15 +12,20 @@ abstract class DataBindingFragment<T : ViewDataBinding> : BaseFragment() {
     @get:LayoutRes
     abstract val layoutId: Int
 
-    lateinit var binding: T
-        private set
+    private var _binding: T? = null
+    val binding: T get() = _binding!!
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
+        _binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
         return binding.root
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
     }
 }

--- a/core/src/main/java/in/koreatech/koin/core/util/ActivityDataBinding.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/ActivityDataBinding.kt
@@ -51,7 +51,7 @@ class ActivityDataBindingProperty<T : ViewDataBinding>(
 }
 
 @Suppress("unused")
-inline fun <reified T : ViewDataBinding> AppCompatActivity.activityDataBinding(@LayoutRes layoutId: Int):
+inline fun <reified T : ViewDataBinding> AppCompatActivity.dataBinding(@LayoutRes layoutId: Int):
         ReadOnlyProperty<AppCompatActivity, T> {
     return ActivityDataBindingProperty(layoutId)
 }

--- a/core/src/main/java/in/koreatech/koin/core/util/ActivityDataBinding.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/ActivityDataBinding.kt
@@ -1,0 +1,57 @@
+package `in`.koreatech.koin.core.util
+
+import android.app.Activity
+import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
+import androidx.activity.ComponentActivity
+import androidx.annotation.LayoutRes
+import androidx.annotation.MainThread
+import androidx.appcompat.app.AppCompatActivity
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class ActivityDataBindingProperty<T : ViewDataBinding>(
+    @LayoutRes private val layoutId: Int,
+    private val rootView: ViewGroup? = null
+) :
+    ReadOnlyProperty<AppCompatActivity, T> {
+
+    private var binding: T? = null
+
+    override fun getValue(thisRef: AppCompatActivity, property: KProperty<*>): T {
+        if (!isMainThread) {
+            throw IllegalAccessException("You should call data binding property delegate only on main thread")
+        }
+
+        binding?.let { return it }
+
+        thisRef.lifecycle.addObserver(BindingLifeCycleObserver())
+        return DataBindingUtil.inflate<T>(
+            thisRef.layoutInflater,
+            layoutId,
+            rootView ?: thisRef.findViewById(android.R.id.content),
+            false
+        ).also { binding = it }
+    }
+
+    private inner class BindingLifeCycleObserver : DefaultLifecycleObserver {
+
+        @MainThread
+        override fun onDestroy(owner: LifecycleOwner) {
+            super.onDestroy(owner)
+            binding = null
+            owner.lifecycle.removeObserver(this)
+        }
+    }
+}
+
+@Suppress("unused")
+inline fun <reified T : ViewDataBinding> AppCompatActivity.activityDataBinding(@LayoutRes layoutId: Int):
+        ReadOnlyProperty<AppCompatActivity, T> {
+    return ActivityDataBindingProperty(layoutId)
+}

--- a/core/src/main/java/in/koreatech/koin/core/util/ThreadUtils.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/ThreadUtils.kt
@@ -1,0 +1,5 @@
+package `in`.koreatech.koin.core.util
+
+import android.os.Looper
+
+val isMainThread get() =  Looper.myLooper() == Looper.getMainLooper()

--- a/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
@@ -2,7 +2,7 @@ package `in`.koreatech.koin.ui.login
 
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
-import `in`.koreatech.koin.core.util.activityDataBinding
+import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.databinding.ActivityLoginBinding
 import `in`.koreatech.koin.ui.forgotpassword.ForgotPasswordActivity
 import `in`.koreatech.koin.ui.login.viewmodel.LoginViewModel
@@ -20,7 +20,7 @@ import java.util.*
 
 @AndroidEntryPoint
 class LoginActivity : ActivityBase() {
-    private val binding by activityDataBinding<ActivityLoginBinding>(R.layout.activity_login)
+    private val binding by dataBinding<ActivityLoginBinding>(R.layout.activity_login)
 
     private val loginViewModel by viewModels<LoginViewModel>()
 

--- a/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
@@ -1,7 +1,8 @@
 package `in`.koreatech.koin.ui.login
 
 import `in`.koreatech.koin.R
-import `in`.koreatech.koin.core.activity.DataBindingActivity
+import `in`.koreatech.koin.core.activity.ActivityBase
+import `in`.koreatech.koin.core.util.activityDataBinding
 import `in`.koreatech.koin.databinding.ActivityLoginBinding
 import `in`.koreatech.koin.ui.forgotpassword.ForgotPasswordActivity
 import `in`.koreatech.koin.ui.login.viewmodel.LoginViewModel
@@ -18,14 +19,14 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
 @AndroidEntryPoint
-class LoginActivity : DataBindingActivity<ActivityLoginBinding>() {
-    override val layoutId: Int
-        get() = R.layout.activity_login
+class LoginActivity : ActivityBase() {
+    private val binding by activityDataBinding<ActivityLoginBinding>(R.layout.activity_login)
 
     private val loginViewModel by viewModels<LoginViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(binding.root)
 
         initView()
         initViewModel()


### PR DESCRIPTION
기존 DataBindingActivity를 대신하는 activityDataBinding delegation 추가, 기존 DataBindingActivity는 Deprecated 처리

### Usage
```Kotlin
class YourActivity : AppCompatActivity() {
    private val binding by activityDataBinding<ActivityYourBinding>(R.layout.activity_your)

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(binding.root) //필수!
    }
}
```

---
Fragment Data Binding delegate의 경우, lifecycle 관련 문제(root view를 binding class에서 구하기)로 계속 연구해보겠습니다