### PR TITLE
Bugfix/fix nickname change error

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -6,7 +6,7 @@ import java.util.*
 fun String.toSHA256() = PasswordUtil.generateSHA256(this)
 
 val String.isValidStudentId: Boolean get() {
-    if (this.trim().length < 10) {
+    if (this.trim().length != 10) {
         return false
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
@@ -49,10 +49,9 @@ class KoinNavigationDrawerViewModel @Inject constructor(
     }
 
     fun selectMenu(menuState: MenuState) {
-        if(_selectedMenu.value != menuState) {
+        if(_selectedMenu.value == MenuState.UserInfo || _selectedMenu.value != menuState) {
             _selectedMenu.value = menuState
             _menuEvent.value = menuState
         }
-
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
@@ -108,10 +108,10 @@ class UserInfoEditActivity : KoinNavigationDrawerActivity() {
 
                         when (user.gender) {
                             Gender.Man -> userinfoeditedRadiobuttonGenderMan.isChecked = true
-                            Gender.Woman -> userinfoeditedRadiobuttonGenderMan.isChecked = true
+                            Gender.Woman -> userinfoeditedRadiobuttonGenderWoman.isChecked = true
                             else -> {
                                 userinfoeditedRadiobuttonGenderMan.isChecked = false
-                                userinfoeditedRadiobuttonGenderMan.isChecked = false
+                                userinfoeditedRadiobuttonGenderWoman.isChecked = false
                             }
                         }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
@@ -57,6 +57,10 @@ class UserInfoEditActivity : KoinNavigationDrawerActivity() {
             }
         )
 
+        userinfoeditedEdittextName.addTextChangedListener {
+            userInfoEditViewModel
+        }
+
         userinfoeditedEdittextStudentId.addTextChangedListener {
             userInfoEditViewModel.getDept(it.toString())
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/userinfo/viewmodel/UserInfoEditViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/userinfo/viewmodel/UserInfoEditViewModel.kt
@@ -42,12 +42,17 @@ class UserInfoEditViewModel @Inject constructor(
     val toastErrorMessage: LiveData<String> get() = _toastErrorMessage
 
     private val _userInfoEditedEvent = SingleLiveEvent<Unit>()
-    val userInfoEditedEvent : LiveData<Unit> get() = _userInfoEditedEvent
+    val userInfoEditedEvent: LiveData<Unit> get() = _userInfoEditedEvent
 
     fun getUserInfo() = viewModelScope.launchWithLoading {
         getUserInfoUseCase().let { (user, error) ->
             if (error != null) _toastErrorMessage.value = error.message
-            else _user.value = user
+            else {
+                _user.value = user
+                _nicknameState.value = user?.nickname?.let {
+                    NicknameState(it, false)
+                } ?: NicknameState.newNickname("")
+            }
         }
     }
 
@@ -70,6 +75,10 @@ class UserInfoEditViewModel @Inject constructor(
         }
     }
 
+    fun setNickname(nickname: String) {
+        _nicknameState.value = NicknameState.newNickname(nickname)
+    }
+
     fun updateUserInfo(
         name: String,
         nickname: String,
@@ -77,7 +86,7 @@ class UserInfoEditViewModel @Inject constructor(
         gender: Gender?,
         studentId: String
     ) {
-        if(isLoading.value == false) {
+        if (isLoading.value == false) {
             viewModelScope.launchWithLoading {
                 user.value?.let { user ->
                     updateUserInfoUseCase(


### PR DESCRIPTION
사용자 정보 화면 관련 버그 수정

1. 학번 글자수 제한이 10글자를 넘어갈 경우에도 클라이언트에서 오류를 처리하도록 변경
2. 메인 -> 사용자 정보 화면 후 뒤로가기 시 사용자 정보 화면을 열 수 없는 문제 해결
3. 사용자 정보 수정 화면에서 선택한 성별에 관계 없이 남자로 설정되어 표시되는 문제 해결
4. 사용자 정보 수정 시 닉네임 변경이 없을 경우 수정 가능하게 변경