### PR TITLE
Feature/fragment data binding property

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.java
+++ b/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.os.Bundle;
 
+import androidx.annotation.LayoutRes;
 import androidx.annotation.Nullable;
 import androidx.annotation.StringRes;
 import androidx.appcompat.app.AppCompatActivity;
@@ -17,6 +18,14 @@ import in.koreatech.koin.core.toast.ToastUtil;
 public class ActivityBase extends AppCompatActivity implements IProgressDialog {
     private CustomProgressDialog customProgressDialog;
     private Context context;
+
+    public ActivityBase() {
+        super();
+    }
+
+    public ActivityBase(@LayoutRes int contentLayoutId) {
+        super(contentLayoutId);
+    }
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/core/src/main/java/in/koreatech/koin/core/activity/DataBindingActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/DataBindingActivity.kt
@@ -5,7 +5,7 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
-@Deprecated("Use AppCompatActivity.activityDataBinding instead.")
+@Deprecated("Use AppCompatActivity.dataBinding delegate property instead.")
 abstract class DataBindingActivity<T : ViewDataBinding> : ActivityBase() {
     @get:LayoutRes
     abstract val layoutId: Int

--- a/core/src/main/java/in/koreatech/koin/core/fragment/DataBindingFragment.kt
+++ b/core/src/main/java/in/koreatech/koin/core/fragment/DataBindingFragment.kt
@@ -8,6 +8,7 @@ import androidx.annotation.LayoutRes
 import androidx.databinding.DataBindingUtil
 import androidx.databinding.ViewDataBinding
 
+@Deprecated("Use Fragment.dataBinding delegate property instead.")
 abstract class DataBindingFragment<T : ViewDataBinding> : BaseFragment() {
     @get:LayoutRes
     abstract val layoutId: Int

--- a/core/src/main/java/in/koreatech/koin/core/util/FragmentDataBinding.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/FragmentDataBinding.kt
@@ -1,0 +1,53 @@
+package `in`.koreatech.koin.core.util
+
+import android.util.Log
+import androidx.annotation.MainThread
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlin.properties.ReadOnlyProperty
+import kotlin.reflect.KProperty
+
+class FragmentDataBindingProperty<T : ViewDataBinding> :
+    ReadOnlyProperty<Fragment, T> {
+
+    private var binding: T? = null
+
+    override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
+        if (!isMainThread) {
+            throw IllegalAccessException("You should call data binding property delegate only on main thread")
+        }
+
+        if(binding != null) return binding!!
+
+        thisRef.viewLifecycleOwner.lifecycle.addObserver(BindingLifeCycleObserver())
+
+        val view = checkNotNull(thisRef.view) {
+            throw IllegalAccessException("Fragment binding property can be called after onCreateView.")
+        }
+
+        binding = DataBindingUtil.bind(view)
+
+        return checkNotNull(binding) {
+            throw IllegalAccessException("Fragment binding property can be called after onCreateView.")
+        }
+    }
+
+    private inner class BindingLifeCycleObserver : DefaultLifecycleObserver {
+
+        @MainThread
+        override fun onDestroy(owner: LifecycleOwner) {
+            super.onDestroy(owner)
+            binding = null
+            owner.lifecycle.removeObserver(this)
+        }
+    }
+}
+
+@Suppress("unused")
+inline fun <reified T : ViewDataBinding> Fragment.dataBinding():
+        ReadOnlyProperty<Fragment, T> {
+    return FragmentDataBindingProperty()
+}

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
@@ -18,14 +18,17 @@ import `in`.koreatech.koin.util.ext.setOnItemSelectedListener
 import `in`.koreatech.koin.util.ext.withLoading
 import `in`.koreatech.koin.util.ext.withToastError
 import android.os.Bundle
+import android.util.Log
 import android.view.View
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.koreatech.koin.core.util.dataBinding
 
 @AndroidEntryPoint
-class BusMainFragment : DataBindingFragment<BusMainFragmentBinding>() {
-    override val layoutId: Int = R.layout.bus_main_fragment
+class BusMainFragment : Fragment(R.layout.bus_main_fragment) {
+    private val binding by dataBinding<BusMainFragmentBinding>()
 
     private val viewModel by viewModels<BusMainFragmentViewModel>()
 

--- a/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
@@ -20,14 +20,13 @@ import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 
 @AndroidEntryPoint
-class LoginActivity : ActivityBase() {
-    private val binding by dataBinding<ActivityLoginBinding>(R.layout.activity_login)
+class LoginActivity : ActivityBase(R.layout.activity_login) {
+    private val binding by dataBinding<ActivityLoginBinding>()
 
     private val loginViewModel by viewModels<LoginViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(binding.root)
 
         initView()
         initViewModel()

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
@@ -39,9 +39,6 @@ class SplashActivity : ActivityBase() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_start)
-        findViewById<Button>(R.id.login_button).setOnClickListener {
-            Log.i("asdf", "asdf")
-        }
         WindowInsetsControllerCompat(window, window.decorView).let { controller ->
             controller.hide(WindowInsetsCompat.Type.systemBars())
             controller.systemBarsBehavior =


### PR DESCRIPTION
Kotlin delegate property를 이용한 액티비티 및 프래그먼트 데이터 바인딩 프로퍼티

## Activity
1. ComponentActivity의 확장 프로퍼티로 변경
2. setContentView(R.layout.xxx) 및 Activity secondary constructor layout id 대응
3. 기존 방식으로 사용할 수도 있습니다.

```Kotlin
//기존 방식
class LoginActivity : ActivityBase() {
    private val binding by dataBinding<ActivityLoginBinding>(R.layout.activity_login)
    /* ... */
}
```
```Kotlin
// Secondary constructor(ActivityBase에 추가 완료)
class LoginActivity : ActivityBase(R.layout.activity_login) {
    private val binding by dataBinding<ActivityLoginBinding>()
    /* ... */
}
```
```Kotlin
// setContentView에 Layout id를 넘길 때에는 아래와 같이 바인딩 사용
class LoginActivity : ActivityBase() {
    private val binding by dataBinding<ActivityLoginBinding>()
    /* ... */
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_login)
        /* ... */
    }
    /* ... */
}
```

## Fragment
1. delegate property를 사용할 수 있도록 dataBinding 확장 함수 제공
2. Fragment의 onDestroyView가 호출될 때 자동으로 binding null 처리
    <img width="1012" alt="스크린샷 2023-02-07 오전 12 45 21" src="https://user-images.githubusercontent.com/23609119/217017354-6c31a8ce-634b-418f-8251-7c695bc17327.png">
3. DataBindingFragment is deprecated
5. onViewCreated에서 binding 사용 가능


```Kotlin
// Fragment secondary constructor
class BusMainFragment : Fragment(R.layout.bus_main_fragment) {
    private val binding by dataBinding<BusMainFragmentBinding>()
    /* ... */
}
```

```Kotlin
class BusMainFragment : Fragment() {
    private val binding by dataBinding<BusMainFragmentBinding>()

    override fun onCreateView(
        inflater: LayoutInflater,
        container: ViewGroup?,
        savedInstanceState: Bundle?
    ): View? {
        return /* inflate view */
    }
    /* ... */
}
```