### PR TITLE
Bugfix/fix main dining error

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/util/DiningUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/DiningUtil.kt
@@ -6,6 +6,6 @@ import android.content.Context
 
 fun DiningType.localized(context: Context) = when(this) {
     DiningType.Breakfast -> context.getString(R.string.dining_breakfast)
-    DiningType.Dinner -> context.getString(R.string.dining_lunch)
-    DiningType.Lunch -> context.getString(R.string.dining_dinner)
+    DiningType.Lunch -> context.getString(R.string.dining_lunch)
+    DiningType.Dinner -> context.getString(R.string.dining_dinner)
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
@@ -4,8 +4,19 @@ sealed class DiningType(
     val typeCode: Int,
     val typeEnglish: String,
     val typeKorean: String
-) {
+) : Comparable<DiningType> {
     object Breakfast : DiningType(0, "BREAKFAST", "아침")
     object Lunch : DiningType(1, "LUNCH", "점심")
     object Dinner : DiningType(2, "DINNER", "저녁")
+
+    override fun compareTo(other: DiningType): Int {
+        return typeCode.compareTo(other.typeCode)
+    }
+}
+
+fun String.toDiningType() = when(this) {
+    "BREAKFAST" -> DiningType.Breakfast
+    "LUNCH" -> DiningType.Lunch
+    "DINNER" -> DiningType.Dinner
+    else -> throw IllegalArgumentException("Invalid dining type string")
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
@@ -12,6 +12,7 @@ import `in`.koreatech.koin.domain.util.TimeUtil
 import androidx.lifecycle.*
 import com.naver.maps.map.style.light.Position
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.model.dining.toDiningType
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
@@ -78,6 +79,9 @@ class MainActivityViewModel @Inject constructor(
         viewModelScope.launchWithLoading {
             diningUseCase(DiningUtil.getCurrentDate())
                 .onSuccess {
+                    if(it.isNotEmpty()) {
+                        _selectedType.value = it.first().type.toDiningType()
+                    }
                     _diningData.value = it
                     _selectedPosition.value = 0
                     _isLoading.value = false

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
@@ -19,18 +19,19 @@ class KoinNavigationDrawerViewModel @Inject constructor(
 
     private val _userState = MutableLiveData<UserState>()
     val userState: LiveData<UserState> get() = _userState
-    val isAnonymous get() = userState.value?.let { (user, isAnonymous) ->
-        isAnonymous || user == null
-    } ?: true
+    val isAnonymous
+        get() = userState.value?.let { (user, isAnonymous) ->
+            isAnonymous || user == null
+        } ?: true
 
     private val _getUserInfoErrorMessage = SingleLiveEvent<String>()
     val getUserInfoErrorMessage: LiveData<String> get() = _getUserInfoErrorMessage
 
     private val _selectedMenu = MutableLiveData<MenuState>(MenuState.Main)
-    val selectedMenu : LiveData<MenuState> get() = _selectedMenu
+    val selectedMenu: LiveData<MenuState> get() = _selectedMenu
 
     private val _menuEvent = SingleLiveEvent<MenuState>()
-    val menuEvent : LiveData<MenuState> get() = _menuEvent
+    val menuEvent: LiveData<MenuState> get() = _menuEvent
 
     fun getUser() {
         viewModelScope.launch {
@@ -49,9 +50,7 @@ class KoinNavigationDrawerViewModel @Inject constructor(
     }
 
     fun selectMenu(menuState: MenuState) {
-        if(_selectedMenu.value == MenuState.UserInfo || _selectedMenu.value != menuState) {
-            _selectedMenu.value = menuState
-            _menuEvent.value = menuState
-        }
+        _selectedMenu.value = menuState
+        _menuEvent.value = menuState
     }
 }


### PR DESCRIPTION
메인화면 식단 표시 관련 버그 수정

- 식단 화면 진입 후 뒤로가기 시 식탄 컨테이너 클릭으로 식단 화면 진입 불가
- 아침을 제공 안할 경우 메인화면 식단 표시가 이상해짐
  - 아침 제공 안할 경우 점심 식단 표시
  - 우상단에는 아침으로 표시되고 코너 정보가 사라짐
- DiningType을 string으로 변환할 때 점심 저녁이 반대로 표시