### PR TITLE
Fix Timetable image save permission

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,9 +17,9 @@ buildscript {
         android_gradle_plugin_version = "7.2.1"
 
         /* Common */
-        compileSdkVersion = 31
+        compileSdkVersion = 33
         minSdkVersion = 21
-        targetSdkVersion = 31
+        targetSdkVersion = 33
         versionName = "3.0.10"
 
         kotlinStdlib = "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
@@ -59,7 +59,7 @@ buildscript {
         retrofitRxJava = "com.squareup.retrofit2:adapter-rxjava2:$retrofit_version"
 
         /* Dependency - leakcanary */
-        def leakcanary_version = "1.6.3"
+        def leakcanary_version = "2.12"
         leakcanaryDebug = "com.squareup.leakcanary:leakcanary-android:$leakcanary_version"
 
         /* Dependency - glide */

--- a/koin/src/main/AndroidManifest.xml
+++ b/koin/src/main/AndroidManifest.xml
@@ -12,6 +12,10 @@
     <uses-permission android:name="android.permission.DIAL_PHONE" />
     <uses-permission android:name="android.permission.CAMERA" />
 
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" android:minSdkVersion="33"/>
+
     <application
         android:name=".KoinApplication"
         android:allowBackup="false"

--- a/koin/src/main/java/in/koreatech/koin/ui/timetable/TimetableActivity.java
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetable/TimetableActivity.java
@@ -10,10 +10,8 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.graphics.Bitmap;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Environment;
 import android.os.Handler;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -24,6 +22,9 @@ import android.widget.RelativeLayout;
 import android.widget.TableLayout;
 import android.widget.TextView;
 
+import androidx.activity.result.ActivityResultCallback;
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.app.ActivityCompat;
@@ -150,6 +151,37 @@ public class TimetableActivity extends KoinNavigationDrawerActivity implements T
 
     private String semester = "";
 
+    private final ActivityResultLauncher<String> saveImagePermissionLauncher = registerForActivityResult(
+            new ActivityResultContracts.RequestPermission(),
+            result -> {
+                if(result) {
+                    saveTimeTableViewInBMP(semester);
+                } else {
+                    ToastUtil.getInstance().makeShort(R.string.need_permission);
+                }
+            }
+    );
+
+    private ActivityResultLauncher<String> imagePermissionLauncher = registerForActivityResult(new ActivityResultContracts.RequestPermission(), result -> {
+        removeAllCheckSticker();
+//        this.timeTableScrollview.smoothScrollBy(0, 0);
+        Bitmap bitmap = ScreenshotUtil.getInstance().takeTimeTableScreenShot(this.timeTableScrollview, this.timeTableHeader);
+
+        if (bitmap == null) {
+            ToastUtil.getInstance().makeShort(R.string.timetable_saved_fail);
+            return;
+        }
+
+        String timeStamp = new SimpleDateFormat("HHmmss").format(new Date());
+        String fileName = semester + "_" + timeStamp + ".png";
+
+        if (FileUtil.getInstance().storeBitmap(getApplicationContext(), bitmap, fileName)) {
+            ToastUtil.getInstance().makeShort(R.string.timetable_saved);
+        }
+
+        ToastUtil.getInstance().makeShort(R.string.timetable_saved_fail);
+    });
+
     public static void hideKeyboard(Activity activity) {
         InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
         View view = activity.getCurrentFocus();
@@ -219,50 +251,25 @@ public class TimetableActivity extends KoinNavigationDrawerActivity implements T
         hideProgressDialog();
     }
 
-    public void askSaveToImagePermission() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if ((ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)
-                    || (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED))
-                ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE}, MY_REQUEST_CODE);
-        }
-
-    }
-
-    public boolean checkStoragePermisson() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            if ((ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED)
-                    || (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_DENIED))
-                return false;
-            else
-                return true;
-        } else
-            return true;
-    }
-
     public void saveTimeTableViewInBMP(String semester) {
-        File saveImageFile;
         removeAllCheckSticker();
 //        this.timeTableScrollview.smoothScrollBy(0, 0);
         Bitmap bitmap = ScreenshotUtil.getInstance().takeTimeTableScreenShot(this.timeTableScrollview, this.timeTableHeader);
-        try {
-            if (bitmap != null) {
-                String timeStamp = new SimpleDateFormat("HHmmss").format(new Date());
-                String path = Environment.getExternalStorageDirectory() + "/Pictures/" + semester + "_" + timeStamp + ".png";
-                File myDir = new File(Environment.getExternalStorageDirectory() + "/Pictures/");
-                myDir.mkdirs();
-                saveImageFile = FileUtil.getInstance().storeBitmap(bitmap, path);
-                if (saveImageFile != null) {
-                    Intent mediaIntent = new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE);
-                    mediaIntent.setData(Uri.fromFile(saveImageFile));
-                    sendBroadcast(mediaIntent);
-                    ToastUtil.getInstance().makeShort(R.string.timetable_saved);
-                } else {
-                    ToastUtil.getInstance().makeShort(R.string.timetable_saved_fail);
-                }
-            }
-        } catch (NullPointerException e) {
+
+        if (bitmap == null) {
             ToastUtil.getInstance().makeShort(R.string.timetable_saved_fail);
+            return;
         }
+
+        String timeStamp = new SimpleDateFormat("HHmmss").format(new Date());
+        String fileName = semester + "_" + timeStamp + ".png";
+
+        if (FileUtil.getInstance().storeBitmap(getApplicationContext(), bitmap, fileName)) {
+            ToastUtil.getInstance().makeShort(R.string.timetable_saved);
+            return;
+        }
+
+        ToastUtil.getInstance().makeShort(R.string.timetable_saved_fail);
     }
 
     public void initSearchEditText() {
@@ -282,28 +289,18 @@ public class TimetableActivity extends KoinNavigationDrawerActivity implements T
     }
 
     @OnClick(R.id.timetable_add_floating_button)
-    public void onClickedTimetableAddFloatingButton(View view){
+    public void onClickedTimetableAddFloatingButton(View view) {
         onAddClassButtonClicked();
     }
 
     @OnClick(R.id.timetable_save_timetable_image_linearlayout)
     public void clickedSaveTimetable() {
-        Handler handler = new Handler();
-        Runnable runnable;
-        if (checkStoragePermisson()) {
-            runnable = () -> {
-                showProgressDialog(R.string.saving);
-            };
-            handler.post(runnable);
-            handler.postDelayed(() -> {
-                saveTimeTableViewInBMP(semester);
-                hideLoading();
-            }, 2000);
+        String permission;
 
-        } else {
-            ToastUtil.getInstance().makeShort(R.string.need_permission);
-            askSaveToImagePermission();
-        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) permission = Manifest.permission.READ_MEDIA_IMAGES;
+        else permission = Manifest.permission.WRITE_EXTERNAL_STORAGE;
+
+        saveImagePermissionLauncher.launch(permission);
     }
 
     public void initSearchRecyclerview() {

--- a/koin/src/main/java/in/koreatech/koin/util/FileUtil.java
+++ b/koin/src/main/java/in/koreatech/koin/util/FileUtil.java
@@ -1,13 +1,23 @@
 package in.koreatech.koin.util;
 
 
+import android.content.ContentResolver;
+import android.content.ContentValues;
+import android.content.Context;
 import android.graphics.Bitmap;
+import android.net.Uri;
+import android.os.Build;
+import android.os.ParcelFileDescriptor;
+import android.provider.MediaStore;
+import android.util.Log;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class FileUtil {
 
@@ -30,23 +40,54 @@ public class FileUtil {
     /**
      * Stores the given {@link Bitmap} to a path on the device.
      *
+     * @param context  Android Specific context
      * @param bitmap   The {@link Bitmap} that needs to be stored
-     * @param filePath The path in which the bitmap is going to be stored.
+     * @param fileName The file name in which the bitmap is going to be stored.
+     *
+     * @return true if bitmap saved successfully
      */
-    public File storeBitmap(Bitmap bitmap, String filePath) {
-        File imageFile = new File(filePath);
-        imageFile.getParentFile().mkdirs();
+    public boolean storeBitmap(Context context, Bitmap bitmap, String fileName) {
+        // Add a specific media item.
+        ContentResolver contentResolver = context.getContentResolver();
+
+        // Find all audio files on the primary external storage device.
+        Uri imageCollection;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            imageCollection = MediaStore.Images.Media
+                    .getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY);
+        } else {
+            imageCollection = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+        }
+
+        ContentValues newImage = new ContentValues();
+        newImage.put(MediaStore.Images.Media.DISPLAY_NAME, fileName);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            newImage.put(MediaStore.Images.Media.IS_PENDING, 1);
+        }
+
+        Uri imageToSaveUri = contentResolver.insert(imageCollection, newImage);
+
         try {
-            OutputStream fout = new FileOutputStream(imageFile);
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 90, fout);
-            fout.flush();
-            fout.close();
-            return imageFile;
-        } catch (FileNotFoundException e) {
-            e.printStackTrace();
+            ParcelFileDescriptor pdf = contentResolver.openFileDescriptor(imageToSaveUri, "w", null);
+
+            if (pdf == null) {
+                return false;
+            } else {
+                FileOutputStream fos = new FileOutputStream(pdf.getFileDescriptor());
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 90, fos);
+                fos.close();
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    newImage.clear();
+                    newImage.put(MediaStore.Images.Media.IS_PENDING, 0);
+                    contentResolver.update(imageToSaveUri, newImage, null, null);
+                }
+            }
+
+            return true;
         } catch (IOException e) {
             e.printStackTrace();
+            return false;
         }
-        return imageFile;
     }
 }


### PR DESCRIPTION
Target SDK 33 대응을 하며 발생한 시간표 이미지 저장 이슈 수정

- MediaStore를 사용하여 갤러리에 이미지 저장
- API 33 이상에서 `READ_MEDIA_IMAGES` 런타임 권한을 획득
- API 23 이상에서 `WRITE_EXTERNAL_STORAGE` 런타임 권한을 획득
- 이외 API 버전은 매니페스트 권한을 자동으로 부여