### PR TITLE
Added Shop Open Time

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/model/store/Store.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/store/Store.kt
@@ -1,5 +1,11 @@
 package `in`.koreatech.koin.domain.model.store
 
+import `in`.koreatech.koin.domain.util.ext.HHMM
+import `in`.koreatech.koin.domain.util.ext.isEqualOrBigger
+import `in`.koreatech.koin.domain.util.ext.isEqualOrSmaller
+import `in`.koreatech.koin.domain.util.ext.localTimeNow
+import java.time.LocalTime
+
 data class Store(
     val uid: Int,
     val name: String,
@@ -15,5 +21,23 @@ data class Store(
         val closed: Boolean,
         val openTime: String,
         val closeTime: String,
-    )
+    ) {
+        fun openStore(): Boolean {
+            return if(openTime.isNotEmpty() && closeTime.isNotEmpty()) {
+                val openTime = LocalTime.parse(if(openTime == "24:00") "00:00" else openTime)
+                val closeTime = LocalTime.parse(if(closeTime == "24:00") "00:00" else closeTime)
+                val currentTime = LocalTime.parse(localTimeNow.HHMM)
+
+                if (openTime.isBefore(closeTime)) { // 17:00(오픈 시간) < 23:00(종료 시간)
+                    currentTime.isEqualOrBigger(openTime) && currentTime.isEqualOrSmaller(closeTime)
+                } else if (openTime.isAfter(closeTime)) { // 17:00(오픈 시간) > 02:00(종료 시간)
+                    currentTime.isEqualOrBigger(openTime) || currentTime.isEqualOrSmaller(closeTime)
+                } else { // 00:00 ~ 00:00 (하루종일 영업)
+                    true
+                }
+            } else {
+                false
+            }
+        }
+    }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetRecommendStoresUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetRecommendStoresUseCase.kt
@@ -5,22 +5,26 @@ import `in`.koreatech.koin.domain.model.store.Store
 import `in`.koreatech.koin.domain.model.store.StoreCategory
 import `in`.koreatech.koin.domain.model.store.StoreWithMenu
 import `in`.koreatech.koin.domain.repository.StoreRepository
+import `in`.koreatech.koin.domain.util.ext.sortedOpenStore
 import javax.inject.Inject
 
 class GetRecommendStoresUseCase @Inject constructor(
-    private val storeRepository: StoreRepository
+    private val storeRepository: StoreRepository,
 ) {
     suspend operator fun invoke(
-        store: StoreWithMenu
+        store: StoreWithMenu,
     ): List<Store> {
         return storeRepository.getStores()
             .filter {
-                val shopRandomCategoryId = store.shopCategories?.filter { it.id != StoreCategory.All.code }?.randomOrNull()?.id
+                val shopRandomCategoryId =
+                    store.shopCategories?.filter { it.id != StoreCategory.All.code }
+                        ?.randomOrNull()?.id
                 it.categoryIds.find {
                     it?.code == shopRandomCategoryId
                 }?.code == shopRandomCategoryId && !it.open.closed && it.uid != store.uid
             }
             .shuffled()
             .take(STORE_RECOMMEND_STORES)
+            .sortedOpenStore()
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetStoresUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetStoresUseCase.kt
@@ -3,21 +3,23 @@ package `in`.koreatech.koin.domain.usecase.store
 import `in`.koreatech.koin.domain.model.store.Store
 import `in`.koreatech.koin.domain.model.store.StoreCategory
 import `in`.koreatech.koin.domain.repository.StoreRepository
+import `in`.koreatech.koin.domain.util.ext.sortedOpenStore
 import `in`.koreatech.koin.domain.util.match
 import javax.inject.Inject
 
 class GetStoresUseCase @Inject constructor(
-    private val storeRepository: StoreRepository
+    private val storeRepository: StoreRepository,
 ) {
     suspend operator fun invoke(
         category: StoreCategory? = null,
-        search: String? = null
+        search: String? = null,
     ): List<Store> {
         return storeRepository.getStores()
             .filter {
-                if(category == null) return@filter true
+                if (category == null) return@filter true
                 category in it.categoryIds
             }
             .filter { if (search != null) it.name.match(search) else true }
+            .sortedOpenStore()
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StoreExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StoreExtensions.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.domain.util.ext
+
+import `in`.koreatech.koin.domain.model.store.Store
+
+fun List<Store>.sortedOpenStore() = this.sortedWith { store, otherStore ->
+    when {
+        !store.open.closed && store.open.openStore() -> -1
+        !otherStore.open.closed && otherStore.open.openStore() -> 1
+        else -> 0
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/TimeExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/TimeExtensions.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.domain.util.ext
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 
 val localTimeNow: LocalTime get() = LocalTime.now(ZoneId.of("Asia/Seoul"))
 val localDateTimeNow: LocalDateTime get() = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
@@ -16,6 +17,16 @@ val localDayOfWeekName get() = when(localDateTimeNow.dayOfWeek.value) {
     7 -> "SUNDAY"
     else -> {}
 }
+
+val LocalTime.HHMM get() = this.format(DateTimeFormatter.ofPattern("HH:mm"))
+
+// this >= time (17:00 >= 15:00)
+fun LocalTime.isEqualOrBigger(time: LocalTime): Boolean =
+    this.isAfter(time) || this.equals(time)
+
+// this <= time (17:00 <= 22:00)
+fun LocalTime.isEqualOrSmaller(time: LocalTime): Boolean =
+    this.isBefore(time) || this.equals(time)
 
 val Int.second get() = this * 1000L
 val Int.minute get() = this * 60 * 1000L

--- a/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreRecyclerAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreRecyclerAdapter.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.ui.store.adapter
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import android.widget.TextView
@@ -11,6 +12,12 @@ import androidx.recyclerview.widget.RecyclerView
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.databinding.StoreListItemBinding
 import `in`.koreatech.koin.domain.model.store.Store
+import `in`.koreatech.koin.domain.util.ext.HHMM
+import `in`.koreatech.koin.domain.util.ext.isEqualOrBigger
+import `in`.koreatech.koin.domain.util.ext.isEqualOrSmaller
+import `in`.koreatech.koin.domain.util.ext.localTimeNow
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 class StoreRecyclerAdapter : ListAdapter<Store, StoreRecyclerAdapter.ViewHolder>(
     diffCallback
@@ -39,7 +46,11 @@ class StoreRecyclerAdapter : ListAdapter<Store, StoreRecyclerAdapter.ViewHolder>
             binding.storeDeliveryTextview.setTextState(store.isDeliveryOk)
             binding.storeCardTextview.setTextState(store.isCardOk)
             binding.storeAccountTextview.setTextState(store.isBankOk)
-            binding.readyStoreFrameLayout.isVisible = store.open.closed
+            binding.readyStoreFrameLayout.isVisible = if (store.open.closed) {
+                true
+            } else {
+                !store.open.openStore()
+            }
 
             binding.root.setOnClickListener {
                 onItemClickListener?.onItemClick(store)


### PR DESCRIPTION
### 이슈 💡 
---
- #158 

### 문제 😟 
---
슬랙에서 나온 이슈로 해당 문제를 찾았습니다...(+ 저의 멍청이슈)
영업시간에 맞게 준비중 UI 적용이 안되어있는 문제 발생으로 시간에 대한 로직을 작성해서 해결하려고 했습니다.

### 해결방법 🎊 
---
간단하게 예제로 표현하겠습니다.

**예제 1)**
현재시간 = 01:00
상점 오픈시간 = 17:00
상점 닫는시간 = 23:00

- 오픈시간 < 닫는시간

"오픈시간 <= 현재시간 <= 닫는시간"  => 상점 영업중 (아니면 준비중)

**예제 2)**
현재시간 = 01:00
상점 오픈시간 = 17:00
상점 닫는시간 = 02:00

- 오픈시간 > 닫는시간

"현재시간 >= 오픈시간" 또는 "현재시간 <= 닫는시간" => 상점 영업중(아니면 준비중)

추가로,
00:00 ~ 00:00(24:00) 계속 상점 영업중으로 표시

### 질문 ❓ 
---
준비중이랑 영업중에 대한 상점 리스트가 무작위인데, 영업중을 맨 위로 올리는 정렬을 해주는 게 좋을 지 여쭤봅니다!! 어떻게 생각하시나용..? 저의 주관적인 생각으로 말씀을 올려본다면... 이 정도 상점 리스트는 영업중이라면, 리스트 맨 처음으로 옮겨도 괜찮을 것 같습니다..!


### 시연영상
---
https://github.com/BCSDLab/KOIN_ANDROID/assets/90740783/86c7cfc6-9ca4-4508-a184-bb29416b9668
