### PR TITLE
Feature/update dining response

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/DiningMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/DiningMapper.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.data.mapper
 
 import `in`.koreatech.koin.data.response.DiningResponse
 import `in`.koreatech.koin.domain.model.dining.Dining
-import `in`.koreatech.koin.domain.model.dining.DiningType
 
 fun DiningResponse.toDining() = Dining(
     this.id,
@@ -13,8 +12,13 @@ fun DiningResponse.toDining() = Dining(
     (this.priceCash ?: 0).toString(),
     (this.kcal ?: 0).toString(),
     this.menu,
+    this.imageUrl ?: "",
     this.createdAt,
     this.updatedAt,
+    this.isSoldOut,
+    // TODO: sold_out 품절 시각으로 변경시 대응
+//    this.soldOutAt ?: ""
+    this.isChanged,
     this.error ?: ""
 )
 

--- a/data/src/main/java/in/koreatech/koin/data/response/DiningResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/DiningResponse.kt
@@ -11,7 +11,12 @@ data class DiningResponse(
     @SerializedName("price_cash") val priceCash: Int?,
     @SerializedName("kcal") val kcal: Int?,
     @SerializedName("menu") val menu: List<String>,
+    @SerializedName("image_url") val imageUrl: String?,
     @SerializedName("created_at") val createdAt: String,
     @SerializedName("updated_at") val updatedAt: String,
+    @SerializedName("sold_out") val isSoldOut: Boolean,
+    // TODO: sold_out 품절 시각으로 변경시 대응
+//    @SerializedName("sold_out") val soldOutAt: String?,
+    @SerializedName("is_changed") val isChanged: Boolean,
     @SerializedName("error") val error: String?
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/Dining.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/Dining.kt
@@ -9,7 +9,12 @@ data class Dining(
     val priceCash: String,
     val kcal: String,
     val menu: List<String>,
+    val imageUrl: String,
     val createdAt: String,
     val updatedAt: String,
+    val isSoldOut: Boolean,
+    // TODO: sold_out 품절 시각으로 변경시 대응
+//    val soldOutAt: String,
+    val isChanged: Boolean,
     val error: String
 )


### PR DESCRIPTION
### 이슈
* close #200 
### 작업사항
서버에서 넘어오는 값에 따라 response 구조에 이미지 url, 품절여부, 식단 변경을 추가했습니다.
### 참고사항
4월 3일에 이루어진 [캠퍼스팀 주간공유](https://docs.google.com/document/d/1kMg98dCIIJ2XfvS_QO5ckEGjf4CQvNqNq6kR2-hzeHU/edit) 에서 품절 안내를 `Boolean`으로 하는대신 품절 시각을 `String`으로 넘기기로 했습니다.
아직 백엔드에서 반영되지 않았기 때문에 일단 boolean으로 했고, 반영 완료되면 주석처리된걸로 변경해주면 될 것 같습니다.