### PR TITLE
메인화면 식단 영역 리뉴얼

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/DiningMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/DiningMapper.kt
@@ -15,10 +15,8 @@ fun DiningResponse.toDining() = Dining(
     this.imageUrl ?: "",
     this.createdAt,
     this.updatedAt,
-    this.isSoldOut,
-    // TODO: sold_out 품절 시각으로 변경시 대응
-//    this.soldOutAt ?: ""
-    this.isChanged,
+    this.soldoutAt ?: "",
+    this.changedAt ?: "",
     this.error ?: ""
 )
 

--- a/data/src/main/java/in/koreatech/koin/data/response/DiningResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/DiningResponse.kt
@@ -14,9 +14,7 @@ data class DiningResponse(
     @SerializedName("image_url") val imageUrl: String?,
     @SerializedName("created_at") val createdAt: String,
     @SerializedName("updated_at") val updatedAt: String,
-    @SerializedName("sold_out") val isSoldOut: Boolean,
-    // TODO: sold_out 품절 시각으로 변경시 대응
-//    @SerializedName("sold_out") val soldOutAt: String?,
-    @SerializedName("is_changed") val isChanged: Boolean,
+    @SerializedName("soldout_at") val soldoutAt: String?,
+    @SerializedName("changed_at") val changedAt: String?,
     @SerializedName("error") val error: String?
 )

--- a/data/src/main/java/in/koreatech/koin/data/util/DiningUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/DiningUtil.kt
@@ -8,4 +8,5 @@ fun DiningType.localized(context: Context) = when(this) {
     DiningType.Breakfast -> context.getString(R.string.dining_breakfast)
     DiningType.Lunch -> context.getString(R.string.dining_lunch)
     DiningType.Dinner -> context.getString(R.string.dining_dinner)
+    DiningType.NextBreakfast -> context.getString(R.string.dining_next_breakfast)
 }

--- a/data/src/main/res/values/strings.xml
+++ b/data/src/main/res/values/strings.xml
@@ -61,4 +61,5 @@
     <string name="dining_breakfast">아침</string>
     <string name="dining_lunch">점심</string>
     <string name="dining_dinner">저녁</string>
+    <string name="dining_next_breakfast">내일 아침</string>
 </resources>

--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/Dining.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/Dining.kt
@@ -12,9 +12,7 @@ data class Dining(
     val imageUrl: String,
     val createdAt: String,
     val updatedAt: String,
-    val isSoldOut: Boolean,
-    // TODO: sold_out 품절 시각으로 변경시 대응
-//    val soldOutAt: String,
-    val isChanged: Boolean,
+    val soldoutAt: String,
+    val changedAt: String,
     val error: String
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
@@ -10,6 +10,6 @@ enum class DiningType(
 ) {
     Breakfast (BREAKFAST, "아침"),
     Lunch (LUNCH, "점심"),
-    Dinner (DINNER, "저녁");
-    object NextBreakfast : DiningType(3, "BREAKFAST", "내일 아침")
+    Dinner (DINNER, "저녁"),
+    NextBreakfast (BREAKFAST, "내일 아침");
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningType.kt
@@ -11,4 +11,5 @@ enum class DiningType(
     Breakfast (BREAKFAST, "아침"),
     Lunch (LUNCH, "점심"),
     Dinner (DINNER, "저녁");
+    object NextBreakfast : DiningType(3, "BREAKFAST", "내일 아침")
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
@@ -6,7 +6,7 @@ import `in`.koreatech.koin.domain.util.ext.arrange
 import `in`.koreatech.koin.domain.util.ext.typeFilter
 
 object DiningUtil {
-    private val diningEndTime = listOf("09:00", "13:30", "18:30")
+    private val diningEndTime = listOf("09:00", "13:30", "18:30", "00:00")
 
     fun typeFiltering(diningList: List<Dining>, type: DiningType): List<Dining> =
         diningList.typeFilter(type).arrange()
@@ -17,6 +17,8 @@ object DiningUtil {
         DiningType.Lunch
     } else if (TimeUtil.compareWithCurrentTime(diningEndTime[2]) >= 0) {
         DiningType.Dinner
+    } else if (TimeUtil.compareWithCurrentTime(diningEndTime[3]) >= 0) {
+        DiningType.NextBreakfast
     } else {
         DiningType.Breakfast
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
@@ -6,21 +6,26 @@ import `in`.koreatech.koin.domain.util.ext.arrange
 import `in`.koreatech.koin.domain.util.ext.typeFilter
 
 object DiningUtil {
-    private val diningEndTime = listOf("09:00", "13:30", "18:30", "00:00")
+    private val diningEndTime = listOf("09:00", "13:30", "18:30", "23:59")
 
     fun typeFiltering(diningList: List<Dining>, type: DiningType): List<Dining> =
         diningList.typeFilter(type).arrange()
 
-    fun getCurrentType() = if (TimeUtil.compareWithCurrentTime(diningEndTime[0]) >= 0) {
-        DiningType.Breakfast
-    } else if (TimeUtil.compareWithCurrentTime(diningEndTime[1]) >= 0) {
-        DiningType.Lunch
-    } else if (TimeUtil.compareWithCurrentTime(diningEndTime[2]) >= 0) {
-        DiningType.Dinner
-    } else if (TimeUtil.compareWithCurrentTime(diningEndTime[3]) >= 0) {
-        DiningType.NextBreakfast
-    } else {
-        DiningType.Breakfast
+    fun getCurrentType(): DiningType {
+        var currentType = DiningType.Breakfast
+        diningEndTime.forEachIndexed { index, time ->
+            if (TimeUtil.compareWithCurrentTime(time) >= 0) {
+                currentType = when (index) {
+                    0 -> DiningType.Breakfast
+                    1 -> DiningType.Lunch
+                    2 -> DiningType.Dinner
+                    3 -> DiningType.NextBreakfast
+                    else -> DiningType.Breakfast
+                }
+                return currentType
+            }
+        }
+        return currentType
     }
 
     fun isNextDay() = TimeUtil.compareWithCurrentTime(diningEndTime[2]) < 0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,10 @@
 # The setting is particularly useful for tweaking memory settings.
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx1536m
+org.gradle.jvmargs=-Xmx1536m \
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
 #Enable daemon
 org.gradle.daemon=true
@@ -20,7 +23,6 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 # Enable configure on demand.
 org.gradle.configureondemand=true
-
 
 
 # When configured, Gradle will run in incubating parallel mode.

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -38,50 +38,7 @@ class DiningActivity : KoinNavigationDrawerActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = DataBindingUtil.setContentView(this, R.layout.dining_activity_main)
-        init()
-        with(diningViewModel) {
-            updateDiningData()
-            selectedDate.observe(this@DiningActivity) {
-                binding.diningDateTextView.text = it
-            }
-            diningData.observe(this@DiningActivity) {
-                setSwipeRefreshingFalse()
-                updateRecyclerData()
-            }
-            isLoading.observe(this@DiningActivity) {
-                if (it) {
-                    showProgressDialog(R.string.loading)
-                    //NavigationDrawer Refactoring 할 시 변경
-                } else {
-                    hideProgressDialog()
-                    //NavigationDrawer Refactoring 할 시 변경
-                }
-            }
-            isDataLoaded.observe(this@DiningActivity) {
-                setSwipeRefreshingFalse()
-                if (!it) {
-                    updateRecyclerData()
-                    Toast.makeText(
-                        this@DiningActivity,
-                        R.string.error_network,
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
-            }
-            isDateError.observe(this@DiningActivity) {
-                if(it) {
-                    Toast.makeText(this@DiningActivity, R.string.dining_no_more_data_load, Toast.LENGTH_SHORT).show()
-                    dateErrorInit()
-                }
-            }
-            when (selectedType) {
-                is DiningType.Breakfast -> setTextSelected(binding.diningBreakfastButton)
-                is DiningType.Lunch -> setTextSelected(binding.diningLunchButton)
-                is DiningType.Dinner -> setTextSelected(binding.diningDinnerButton)
-                is DiningType.NextBreakfast -> setTextSelected(binding.diningBreakfastButton)
-            }
-        }
+        setContentView(binding.root)
 
         initCalendar()
         initViewPager()

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -38,7 +38,50 @@ class DiningActivity : KoinNavigationDrawerActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(binding.root)
+        binding = DataBindingUtil.setContentView(this, R.layout.dining_activity_main)
+        init()
+        with(diningViewModel) {
+            updateDiningData()
+            selectedDate.observe(this@DiningActivity) {
+                binding.diningDateTextView.text = it
+            }
+            diningData.observe(this@DiningActivity) {
+                setSwipeRefreshingFalse()
+                updateRecyclerData()
+            }
+            isLoading.observe(this@DiningActivity) {
+                if (it) {
+                    showProgressDialog(R.string.loading)
+                    //NavigationDrawer Refactoring 할 시 변경
+                } else {
+                    hideProgressDialog()
+                    //NavigationDrawer Refactoring 할 시 변경
+                }
+            }
+            isDataLoaded.observe(this@DiningActivity) {
+                setSwipeRefreshingFalse()
+                if (!it) {
+                    updateRecyclerData()
+                    Toast.makeText(
+                        this@DiningActivity,
+                        R.string.error_network,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
+            isDateError.observe(this@DiningActivity) {
+                if(it) {
+                    Toast.makeText(this@DiningActivity, R.string.dining_no_more_data_load, Toast.LENGTH_SHORT).show()
+                    dateErrorInit()
+                }
+            }
+            when (selectedType) {
+                is DiningType.Breakfast -> setTextSelected(binding.diningBreakfastButton)
+                is DiningType.Lunch -> setTextSelected(binding.diningLunchButton)
+                is DiningType.Dinner -> setTextSelected(binding.diningDinnerButton)
+                is DiningType.NextBreakfast -> setTextSelected(binding.diningBreakfastButton)
+            }
+        }
 
         initCalendar()
         initViewPager()

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -80,6 +80,7 @@ class DiningActivity : KoinNavigationDrawerActivity() {
                 DiningType.Breakfast -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(0))
                 DiningType.Lunch -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(1))
                 DiningType.Dinner -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(2))
+                DiningType.NextBreakfast -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(0))
             }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -62,7 +62,7 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                     }
                 }
 
-                if(dining.isSoldOut) {
+                if(dining.soldoutAt.isNotEmpty()) {
                     groupSoldOut.visibility = View.VISIBLE
                     textViewDiningSoldOut.visibility = View.VISIBLE
                 } else {
@@ -70,7 +70,7 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                     textViewDiningSoldOut.visibility = View.INVISIBLE
                 }
 
-                if(dining.isChanged) {
+                if(dining.changedAt.isNotEmpty()) {
                     textViewDiningChanged.visibility = View.VISIBLE
                 } else {
                     textViewDiningChanged.visibility = View.INVISIBLE

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -134,7 +134,7 @@ class MainActivity : KoinNavigationDrawerActivity() {
         }
 
         observeLiveData(selectedType) {
-            binding.textViewCardDiningTime.text = it.localized(this@MainActivity)
+            binding.textViewDiningTime.text = it.localized(this@MainActivity)
         }
 
         observeLiveData(busTimer) {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -174,14 +174,14 @@ class MainActivity : KoinNavigationDrawerActivity() {
 
         listOf(
             binding.textViewCardDiningMenu0,
-            binding.textViewCardDiningMenu1,
             binding.textViewCardDiningMenu2,
-            binding.textViewCardDiningMenu3,
             binding.textViewCardDiningMenu4,
-            binding.textViewCardDiningMenu5,
             binding.textViewCardDiningMenu6,
-            binding.textViewCardDiningMenu7,
             binding.textViewCardDiningMenu8,
+            binding.textViewCardDiningMenu1,
+            binding.textViewCardDiningMenu3,
+            binding.textViewCardDiningMenu5,
+            binding.textViewCardDiningMenu7,
             binding.textViewCardDiningMenu9
         ).zip(diningArranged[position].menu).forEach { (textView, menu) ->
             textView.text = menu

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -24,6 +24,7 @@ import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
 import androidx.activity.viewModels
+import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -184,6 +185,26 @@ class MainActivity : KoinNavigationDrawerActivity() {
             binding.textViewCardDiningMenu9
         ).zip(diningArranged[position].menu).forEach { (textView, menu) ->
             textView.text = menu
+        }
+
+        val isSoldOut = diningArranged[position].soldoutAt.isNotEmpty()
+        val isChanged = diningArranged[position].changedAt.isNotEmpty()
+        with (binding.textViewDiningStatus) {
+            when {
+                isSoldOut -> {
+                    text = context.getString(R.string.dining_soldout)
+                    setTextColor(ContextCompat.getColor(context, R.color.dining_soldout_text))
+                    background = ContextCompat.getDrawable(context, R.drawable.dining_soldout_fill_radius_4)
+                }
+                isChanged -> {
+                    text = context.getString(R.string.dining_changed)
+                    setTextColor(ContextCompat.getColor(context, R.color.dining_changed_text))
+                    background = ContextCompat.getDrawable(context, R.drawable.dining_changed_fill_radius_4)
+                }
+                else -> {
+                    visibility = View.INVISIBLE
+                }
+            }
         }
     }
 }

--- a/koin/src/main/res/drawable/dining_changed_fill_radius_4.xml
+++ b/koin/src/main/res/drawable/dining_changed_fill_radius_4.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/dining_changed_background"/>
+    <corners android:radius="4dp"/>
+</shape>

--- a/koin/src/main/res/drawable/dining_soldout_fill_radius_4.xml
+++ b/koin/src/main/res/drawable/dining_soldout_fill_radius_4.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/dining_soldout_background"/>
+    <corners android:radius="4dp"/>
+</shape>

--- a/koin/src/main/res/layout/activity_main.xml
+++ b/koin/src/main/res/layout/activity_main.xml
@@ -124,29 +124,16 @@
                                 android:layout_height="wrap_content">
 
                                 <TextView
-                                    android:id="@+id/text_view_dining_tomorrow"
+                                    android:id="@+id/text_view_dining_time"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
                                     android:layout_marginStart="20dp"
                                     android:layout_marginTop="32dp"
-                                    android:text="내일"
                                     android:textColor="@color/colorPrimary"
                                     android:textSize="15sp"
                                     android:textStyle="bold"
                                     app:layout_constraintStart_toStartOf="parent"
                                     app:layout_constraintTop_toTopOf="parent"
-                                    tools:visibility="visible" />
-
-                                <TextView
-                                    android:id="@+id/text_view_dining_time"
-                                    android:layout_width="wrap_content"
-                                    android:layout_height="wrap_content"
-                                    android:layout_marginStart="4dp"
-                                    android:textColor="@color/colorPrimary"
-                                    android:textSize="15sp"
-                                    android:textStyle="bold"
-                                    app:layout_constraintStart_toEndOf="@id/text_view_dining_tomorrow"
-                                    app:layout_constraintTop_toTopOf="@id/text_view_dining_tomorrow"
                                     tools:text="아침" />
 
                                 <TextView

--- a/koin/src/main/res/layout/activity_main.xml
+++ b/koin/src/main/res/layout/activity_main.xml
@@ -201,7 +201,7 @@
                                         app:layout_constraintStart_toStartOf="parent"
                                         app:layout_constraintTop_toTopOf="parent">
 
-                                        <TableRow android:paddingBottom="8dp">
+                                        <TableRow android:paddingBottom="4dp">
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_0"
@@ -229,7 +229,7 @@
 
                                         </TableRow>
 
-                                        <TableRow android:paddingBottom="8dp">
+                                        <TableRow android:paddingBottom="4dp">
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_2"
@@ -257,7 +257,7 @@
 
                                         </TableRow>
 
-                                        <TableRow android:paddingBottom="8dp">
+                                        <TableRow android:paddingBottom="4dp">
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_4"
@@ -285,7 +285,7 @@
 
                                         </TableRow>
 
-                                        <TableRow android:paddingBottom="8dp">
+                                        <TableRow android:paddingBottom="4dp">
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_6"
@@ -316,7 +316,7 @@
                                         <TableRow
                                             android:layout_width="match_parent"
                                             android:layout_height="wrap_content"
-                                            android:paddingBottom="8dp">
+                                            android:paddingBottom="4dp">
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_8"

--- a/koin/src/main/res/layout/activity_main.xml
+++ b/koin/src/main/res/layout/activity_main.xml
@@ -9,13 +9,16 @@
         android:layout_height="match_parent"
         android:fitsSystemWindows="true"
         tools:ignore="MissingPrefix">
+
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical">
+
                 <com.google.android.material.card.MaterialCardView
                     android:id="@+id/toolbar"
                     style="@style/AppTheme.Toolbar.Main"
@@ -24,14 +27,17 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
+
                     <FrameLayout
                         android:id="@+id/toolbar_layout"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:orientation="vertical">
+
                         <androidx.constraintlayout.widget.ConstraintLayout
                             android:layout_width="match_parent"
                             android:layout_height="@dimen/toolbar_main_height">
+
                             <ImageView
                                 android:id="@+id/imageView3"
                                 android:layout_width="wrap_content"
@@ -41,6 +47,7 @@
                                 app:layout_constraintBottom_toBottomOf="parent"
                                 app:layout_constraintStart_toStartOf="parent"
                                 app:layout_constraintTop_toTopOf="parent" />
+
                             <androidx.appcompat.widget.AppCompatImageButton
                                 android:id="@+id/button_category"
                                 android:layout_width="24dp"
@@ -54,20 +61,24 @@
                         </androidx.constraintlayout.widget.ConstraintLayout>
                     </FrameLayout>
                 </com.google.android.material.card.MaterialCardView>
+
                 <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
                     android:id="@+id/main_swipe_refresh_layout"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:layout_marginTop="-24dp">
+
                     <androidx.core.widget.NestedScrollView
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:fillViewport="true">
+
                         <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:layout_marginTop="24dp"
                             android:orientation="vertical">
+
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -77,16 +88,18 @@
                                 android:textColor="@color/colorPrimary"
                                 android:textSize="15sp"
                                 android:textStyle="bold" />
+
                             <androidx.viewpager2.widget.ViewPager2
                                 android:id="@+id/bus_view_pager"
                                 android:layout_width="match_parent"
                                 android:layout_height="151dp"
                                 android:layout_marginTop="4dp"
                                 android:clipToPadding="false"
-                                tools:paddingStart="40dp"
-                                tools:paddingTop="8dp"
+                                tools:paddingBottom="8dp"
                                 tools:paddingEnd="40dp"
-                                tools:paddingBottom="8dp" />
+                                tools:paddingStart="40dp"
+                                tools:paddingTop="8dp" />
+
                             <TextView
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
@@ -96,6 +109,7 @@
                                 android:textColor="@color/colorPrimary"
                                 android:textSize="15sp"
                                 android:textStyle="bold" />
+
                             <androidx.recyclerview.widget.RecyclerView
                                 android:id="@+id/recycler_view_store_category"
                                 android:layout_width="match_parent"
@@ -104,24 +118,59 @@
                                 android:paddingStart="10dp"
                                 android:paddingTop="11dp"
                                 android:paddingEnd="10dp" />
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:layout_marginStart="20dp"
-                                android:layout_marginTop="32dp"
-                                android:text="식단"
-                                android:textColor="@color/colorPrimary"
-                                android:textSize="15sp"
-                                android:textStyle="bold" />
 
+                            <androidx.constraintlayout.widget.ConstraintLayout
+                                android:layout_width="match_parent"
+                                android:layout_height="wrap_content">
+
+                                <TextView
+                                    android:id="@+id/text_view_dining_tomorrow"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="20dp"
+                                    android:layout_marginTop="32dp"
+                                    android:text="내일"
+                                    android:textColor="@color/colorPrimary"
+                                    android:textSize="15sp"
+                                    android:textStyle="bold"
+                                    app:layout_constraintStart_toStartOf="parent"
+                                    app:layout_constraintTop_toTopOf="parent"
+                                    tools:visibility="visible" />
+
+                                <TextView
+                                    android:id="@+id/text_view_dining_time"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="4dp"
+                                    android:textColor="@color/colorPrimary"
+                                    android:textSize="15sp"
+                                    android:textStyle="bold"
+                                    app:layout_constraintStart_toEndOf="@id/text_view_dining_tomorrow"
+                                    app:layout_constraintTop_toTopOf="@id/text_view_dining_tomorrow"
+                                    tools:text="아침" />
+
+                                <TextView
+                                    android:id="@+id/text_view_dining_title"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_marginStart="4dp"
+                                    android:text="식단"
+                                    android:textColor="@color/colorPrimary"
+                                    android:textSize="15sp"
+                                    android:textStyle="bold"
+                                    app:layout_constraintStart_toEndOf="@id/text_view_dining_time"
+                                    app:layout_constraintTop_toTopOf="@id/text_view_dining_time" />
+
+
+                            </androidx.constraintlayout.widget.ConstraintLayout>
 
                             <com.google.android.material.card.MaterialCardView
                                 android:id="@+id/dining_container"
                                 android:layout_width="match_parent"
                                 android:layout_height="wrap_content"
+                                android:layout_margin="16dp"
                                 android:elevation="@dimen/normal_card_elevation"
-                                app:cardCornerRadius="0dp"
-                                android:layout_margin="16dp">
+                                app:cardCornerRadius="0dp">
 
                                 <androidx.constraintlayout.widget.ConstraintLayout
                                     android:layout_width="match_parent"
@@ -171,9 +220,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴1"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴1" />
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_1"
@@ -183,9 +232,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴2"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴2" />
 
                                         </TableRow>
 
@@ -199,9 +248,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴3"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴3" />
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_3"
@@ -211,9 +260,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴4"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴4" />
 
                                         </TableRow>
 
@@ -227,9 +276,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴5"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴5" />
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_5"
@@ -239,9 +288,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴6"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴6" />
 
                                         </TableRow>
 
@@ -255,9 +304,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴7"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴7" />
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_7"
@@ -267,9 +316,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴8"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴8" />
 
                                         </TableRow>
 
@@ -286,9 +335,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="메뉴9"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="메뉴9" />
 
                                             <TextView
                                                 android:id="@+id/text_view_card_dining_menu_9"
@@ -298,9 +347,9 @@
                                                 android:layout_weight="1"
                                                 android:ellipsize="end"
                                                 android:maxLines="1"
-                                                tools:text="까르보나라민트초코파맛첵스파게티"
                                                 android:textColor="@color/black"
-                                                android:textSize="12sp" />
+                                                android:textSize="12sp"
+                                                tools:text="까르보나라민트초코파맛첵스파게티" />
 
                                         </TableRow>
 
@@ -325,6 +374,7 @@
                 </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
             </LinearLayout>
         </androidx.coordinatorlayout.widget.CoordinatorLayout>
+
         <include layout="@layout/base_navigation_drawer_right" />
     </androidx.drawerlayout.widget.DrawerLayout>
 </layout>

--- a/koin/src/main/res/layout/activity_main.xml
+++ b/koin/src/main/res/layout/activity_main.xml
@@ -182,21 +182,25 @@
                                         android:layout_height="52dp"
                                         android:paddingStart="16dp"
                                         android:paddingEnd="48dp"
+                                        app:layout_constraintEnd_toStartOf="@id/text_view_dining_status"
                                         app:layout_constraintStart_toStartOf="parent"
-                                        app:layout_constraintEnd_toStartOf="@id/text_view_card_dining_time"
                                         app:layout_constraintTop_toTopOf="parent" />
 
                                     <TextView
-                                        android:id="@+id/text_view_card_dining_time"
+                                        android:id="@+id/text_view_dining_status"
                                         android:layout_width="wrap_content"
                                         android:layout_height="wrap_content"
-                                        android:layout_marginTop="18dp"
+                                        android:layout_marginTop="17dp"
                                         android:layout_marginEnd="16dp"
-                                        android:text="아침"
-                                        android:textColor="@color/black"
-                                        android:textSize="13sp"
+                                        android:includeFontPadding="false"
+                                        android:paddingHorizontal="8dp"
+                                        android:paddingVertical="4dp"
+                                        android:textSize="12sp"
                                         app:layout_constraintEnd_toEndOf="parent"
-                                        app:layout_constraintTop_toTopOf="parent" />
+                                        app:layout_constraintTop_toTopOf="parent"
+                                        tools:background="@drawable/dining_soldout_fill_radius_4"
+                                        tools:text="@string/dining_soldout"
+                                        tools:textColor="@color/dining_soldout_text" />
 
                                     <TableLayout
                                         android:layout_width="0dp"

--- a/koin/src/main/res/layout/main_card_dining.xml
+++ b/koin/src/main/res/layout/main_card_dining.xml
@@ -20,7 +20,7 @@
             android:paddingStart="16dp"
             android:paddingEnd="48dp"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/text_view_card_dining_time"
+            app:layout_constraintEnd_toStartOf="@id/text_view_dining_time"
             app:layout_constraintTop_toTopOf="parent" >
 
             <LinearLayout
@@ -111,7 +111,7 @@
         </HorizontalScrollView>
 
         <TextView
-            android:id="@+id/text_view_card_dining_time"
+            android:id="@+id/text_view_dining_time"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="18dp"

--- a/koin/src/main/res/values/colors.xml
+++ b/koin/src/main/res/values/colors.xml
@@ -1,3 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- dining sold out -->
+    <color name="dining_soldout_text">#FFAD0D</color>
+    <color name="dining_soldout_background">#FFF7E1</color>
+    <!-- dining changed -->
+    <color name="dining_changed_text">#4B4B4B</color>
+    <color name="dining_changed_background">#EEEEEE</color>
 </resources>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -232,6 +232,8 @@
     <string name="dining_western">양식</string>
     <string name="dining_nungsu">능수관</string>
     <string name="dining_non_upload">학교에서 식단이 업로드 되지 않았습니다.</string>
+    <string name="dining_soldout">품절</string>
+    <string name="dining_changed">변경됨</string>
     <string name="bus_app_bar_title">버스 / 교통</string>
     <string name="bus_tab_info">운행정보</string>
     <string name="bus_tab_search_info">운행 정보 검색</string>


### PR DESCRIPTION
### 이슈
* close #212 
### 작업사항
* 식단 품절, 변경됨 여부에 따른 UI 반영
* 식단 상세 칩이 들어가는 대신 시간 텍스트(아침, 점심, 저녁) 제목 옆으로 배치
* 18:30~00:00 일때 "내일 아침"으로 표시
* 식단 메뉴 배열 수평 -> 수직
### 참고사항
서버에서 넘어오는 품절, 변경됨 상태값이 string으로 변경됨에 따라 반영해주었습니다. 식단 상세에서 이미 이루어졌다면 해당 커밋 지우도록 하겠습니다
### 구현 화면
(오전 5시 47분 기준)
<img width="362" alt="image" src="https://github.com/BCSDLab/KOIN_ANDROID/assets/74162198/8d29bf42-2e16-466b-912a-8fa5c04cfa11">
<img width="363" alt="image" src="https://github.com/BCSDLab/KOIN_ANDROID/assets/74162198/ee8984e0-e3d3-4b68-acd0-966494702414"> <img width="361" alt="image" src="https://github.com/BCSDLab/KOIN_ANDROID/assets/74162198/144ef560-56e3-41c2-b6fd-444b6a7a46b2">