### PR TITLE
영양사 페이지 진입점에 웹뷰 추가

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -18,7 +18,7 @@ class WebViewActivity : ActivityBase(R.layout.activity_webview) {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val title = intent.getStringExtra("title")
+        val title = intent.getStringExtra("title") ?: ""
         val url = intent.getStringExtra("url")
         init(title, url)
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.ui.navigation
 
 import android.content.Intent
 import android.graphics.Typeface
-import android.net.Uri
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -174,7 +173,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
             if (menuState == MenuState.Main) {
                 if (System.currentTimeMillis() > pressTime + 2000) {
                     pressTime = System.currentTimeMillis()
-                    ToastUtil.getInstance().makeShort("뒤로가기 버튼을 한 번 더 누르면 종료됩니다.")
+                    ToastUtil.getInstance().makeShort(getString(R.string.press_again_to_exit))
                 } else {
                     finishAffinity()
                 }
@@ -188,7 +187,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         observeLiveData(userState) { user ->
             val nameTextview = findViewById<TextView>(R.id.base_naviagtion_drawer_nickname_textview)
             when (user) {
-                User.Anonymous -> nameTextview.text = "익명"
+                User.Anonymous -> nameTextview.text = getString(R.string.user_anon)
                 is User.Student -> nameTextview.text = user.name
             }
         }
@@ -267,7 +266,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
             }
 
             else -> {
-                ToastUtil.getInstance().makeShort("서비스예정입니다")
+                ToastUtil.getInstance().makeShort(getString(R.string.to_be_opened))
             }
         }
     }
@@ -370,10 +369,10 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
     fun showLoginRequestDialog() {
         val builder = AlertDialog.Builder(this)
-        builder.setTitle("회원 전용 서비스")
-            .setMessage("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?")
+        builder.setTitle(getString(R.string.user_only))
+            .setMessage(getString(R.string.login_request))
             .setCancelable(false)
-            .setPositiveButton("확인") { dialog, _ ->
+            .setPositiveButton(getString(R.string.navigation_ok)) { dialog, _ ->
                 val intent = Intent(
                     this,
                     LoginActivity::class.java
@@ -382,7 +381,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 startActivity(intent)
                 overridePendingTransition(android.R.anim.slide_in_left, android.R.anim.fade_out)
             }
-            .setNegativeButton("취소") { dialog, _ ->
+            .setNegativeButton(getString(R.string.navigation_cancel)) { dialog, _ ->
                 dialog.cancel()
             }
         val dialog = builder.create() // 알림창 객체 생성

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -1,21 +1,5 @@
 package `in`.koreatech.koin.ui.navigation
 
-import `in`.koreatech.koin.R
-import `in`.koreatech.koin.core.activity.ActivityBase
-import `in`.koreatech.koin.core.activity.WebViewActivity
-import `in`.koreatech.koin.core.toast.ToastUtil
-import `in`.koreatech.koin.ui.bus.BusActivity
-import `in`.koreatech.koin.ui.dining.DiningActivity
-import `in`.koreatech.koin.ui.land.LandActivity
-import `in`.koreatech.koin.ui.login.LoginActivity
-import `in`.koreatech.koin.ui.main.activity.MainActivity
-import `in`.koreatech.koin.ui.navigation.state.MenuState
-import `in`.koreatech.koin.ui.navigation.viewmodel.KoinNavigationDrawerViewModel
-import `in`.koreatech.koin.ui.store.activity.StoreActivity
-import `in`.koreatech.koin.ui.timetable.TimetableActivity
-import `in`.koreatech.koin.ui.timetable.TimetableAnonymousActivity
-import `in`.koreatech.koin.ui.userinfo.UserInfoActivity
-import `in`.koreatech.koin.util.ext.*
 import android.content.Intent
 import android.graphics.Typeface
 import android.net.Uri
@@ -33,13 +17,36 @@ import androidx.drawerlayout.widget.DrawerLayout
 import com.google.android.material.navigation.NavigationView
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.BuildConfig
+import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.activity.ActivityBase
+import `in`.koreatech.koin.core.activity.WebViewActivity
+import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.data.constant.URLConstant
 import `in`.koreatech.koin.domain.model.user.User
+import `in`.koreatech.koin.ui.bus.BusActivity
+import `in`.koreatech.koin.ui.dining.DiningActivity
+import `in`.koreatech.koin.ui.land.LandActivity
+import `in`.koreatech.koin.ui.login.LoginActivity
+import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.navigation.contract.GotoAskFormContract
+import `in`.koreatech.koin.ui.navigation.state.MenuState
+import `in`.koreatech.koin.ui.navigation.viewmodel.KoinNavigationDrawerViewModel
+import `in`.koreatech.koin.ui.store.activity.StoreActivity
+import `in`.koreatech.koin.ui.timetable.TimetableActivity
+import `in`.koreatech.koin.ui.timetable.TimetableAnonymousActivity
+import `in`.koreatech.koin.ui.userinfo.UserInfoActivity
+import `in`.koreatech.koin.util.ext.addDrawerListener
+import `in`.koreatech.koin.util.ext.blueStatusBar
+import `in`.koreatech.koin.util.ext.closeDrawer
+import `in`.koreatech.koin.util.ext.isDrawerOpened
+import `in`.koreatech.koin.util.ext.observeLiveData
+import `in`.koreatech.koin.util.ext.toggleDrawer
+import `in`.koreatech.koin.util.ext.whiteStatusBar
+import `in`.koreatech.koin.util.ext.windowWidth
 
 @AndroidEntryPoint
 abstract class KoinNavigationDrawerActivity : ActivityBase(),
-        NavigationView.OnNavigationItemSelectedListener {
+    NavigationView.OnNavigationItemSelectedListener {
     protected abstract val menuState: MenuState
 
     val drawerLayoutId get() = R.id.drawer_layout
@@ -59,21 +66,21 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
     private val menus by lazy {
         listOf(
-                R.id.navi_item_store,
-                R.id.navi_item_bus, R.id.navi_item_dining,
-                R.id.navi_item_timetable, R.id.navi_item_land,
-                R.id.navi_item_owner
+            R.id.navi_item_store,
+            R.id.navi_item_bus, R.id.navi_item_dining,
+            R.id.navi_item_timetable, R.id.navi_item_land,
+            R.id.navi_item_owner
         ).map {
             findViewById<View>(it)
         }.zip(
-                listOf(
-                        MenuState.Store,
-                        MenuState.Bus,
-                        MenuState.Dining,
-                        MenuState.Timetable,
-                        MenuState.Land,
-                        MenuState.Owner
-                )
+            listOf(
+                MenuState.Store,
+                MenuState.Bus,
+                MenuState.Dining,
+                MenuState.Timetable,
+                MenuState.Land,
+                MenuState.Owner
+            )
         ) { view, state ->
             state to view
         }.toMap()
@@ -81,21 +88,21 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
     private val menuTextViews by lazy {
         listOf(
-                R.id.navi_item_store_textview,
-                R.id.navi_item_bus_textview, R.id.navi_item_dining_textview,
-                R.id.navi_item_timetable_textview, R.id.navi_item_land_textview
+            R.id.navi_item_store_textview,
+            R.id.navi_item_bus_textview, R.id.navi_item_dining_textview,
+            R.id.navi_item_timetable_textview, R.id.navi_item_land_textview
         ).map {
             findViewById<TextView>(it).apply {
                 changeMenuFont(this)
             }
         }.zip(
-                listOf(
-                        MenuState.Store,
-                        MenuState.Bus,
-                        MenuState.Dining,
-                        MenuState.Timetable,
-                        MenuState.Land
-                )
+            listOf(
+                MenuState.Store,
+                MenuState.Bus,
+                MenuState.Dining,
+                MenuState.Timetable,
+                MenuState.Land
+            )
         ) { view, state ->
             state to view
         }.toMap()
@@ -112,10 +119,15 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         menus.forEach { (state, view) ->
             view.setOnClickListener {
                 when (state) {
-                    MenuState.Owner -> startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(
-                            if (BuildConfig.IS_DEBUG) URLConstant.OWNER_URL_STAGE
-                            else URLConstant.OWNER_URL_PRODUCTION
-                    )))
+                    MenuState.Owner -> {
+                        Intent(this, WebViewActivity::class.java).apply {
+                            putExtra(
+                                "url",
+                                if (BuildConfig.IS_DEBUG) URLConstant.OWNER_URL_STAGE
+                                else URLConstant.OWNER_URL_PRODUCTION
+                            )
+                        }.run(::startActivity)
+                    }
 
                     else -> {
                         koinNavigationDrawerViewModel.selectMenu(state)
@@ -152,7 +164,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         super.onAttachedToWindow()
 
         leftNavigationView.layoutParams =
-                leftNavigationView.layoutParams.apply { width = windowWidth }
+            leftNavigationView.layoutParams.apply { width = windowWidth }
     }
 
     override fun onBackPressed() {
@@ -359,20 +371,20 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
     fun showLoginRequestDialog() {
         val builder = AlertDialog.Builder(this)
         builder.setTitle("회원 전용 서비스")
-                .setMessage("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?")
-                .setCancelable(false)
-                .setPositiveButton("확인") { dialog, _ ->
-                    val intent = Intent(
-                            this,
-                            LoginActivity::class.java
-                    )
-                    intent.putExtra("FIRST_LOGIN", false)
-                    startActivity(intent)
-                    overridePendingTransition(android.R.anim.slide_in_left, android.R.anim.fade_out)
-                }
-                .setNegativeButton("취소") { dialog, _ ->
-                    dialog.cancel()
-                }
+            .setMessage("로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?")
+            .setCancelable(false)
+            .setPositiveButton("확인") { dialog, _ ->
+                val intent = Intent(
+                    this,
+                    LoginActivity::class.java
+                )
+                intent.putExtra("FIRST_LOGIN", false)
+                startActivity(intent)
+                overridePendingTransition(android.R.anim.slide_in_left, android.R.anim.fade_out)
+            }
+            .setNegativeButton("취소") { dialog, _ ->
+                dialog.cancel()
+            }
         val dialog = builder.create() // 알림창 객체 생성
         dialog.show() // 알림창 띄우기
     }
@@ -398,8 +410,8 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         get() {
             val s = text.toString()
             val styledText = HtmlCompat.fromHtml(
-                    "<font color='#f7941e'>$s</font>",
-                    HtmlCompat.FROM_HTML_MODE_LEGACY
+                "<font color='#f7941e'>$s</font>",
+                HtmlCompat.FROM_HTML_MODE_LEGACY
             )
             setText(styledText, TextView.BufferType.SPANNABLE) //#f7941e
             return this

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -36,6 +36,13 @@
     <string name="navigation_item_open_source">오픈소스</string>
     <string name="navigation_item_login">로그인</string>
     <string name="navigation_item_logout">로그아웃</string>
+    <string name="navigation_cancel">취소</string>
+    <string name="login_request">로그인이 필요한 서비스입니다.\n로그인 하시겠습니까?</string>
+    <string name="navigation_ok">확인</string>
+    <string name="user_only">회원 전용 서비스</string>
+    <string name="to_be_opened">서비스예정입니다</string>
+    <string name="press_again_to_exit">뒤로가기 버튼을 한 번 더 누르면 종료됩니다.</string>
+    <string name="user_anon">익명</string>
 
 
     <!-- Server Messages -->


### PR DESCRIPTION
### 이슈
* close #187
### 작업사항
- [x] 사이드바 > 코인 for business 클릭시 웹뷰로 이동
- [ ] 영양사 페이지 url 추가 
### 참고사항
회의 당시에는 영양사 페이지랑 사장님 페이지랑 진입점이 동일할 수도 있다고 해서 일단 진입점을 코인 for business로 잡았어요
하지만 영양사 페이지 url 추가하면서 진입점이 수정될 가능성이 있습니다! url 나오는대로 변경해서 커밋 올리겠습니다
### 구현 화면
<img width="300" alt="image" src="https://github.com/BCSDLab/KOIN_ANDROID/assets/74162198/fb95c401-680f-4f6d-b112-8c525962bbf9">
