### PR TITLE
[Fix] 식단 상세 페이지 QA

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -80,7 +80,10 @@ class DiningActivity : KoinNavigationDrawerActivity() {
                 DiningType.Breakfast -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(0))
                 DiningType.Lunch -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(1))
                 DiningType.Dinner -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(2))
-                DiningType.NextBreakfast -> tabsDiningTime.selectTab(tabsDiningTime.getTabAt(0))
+                DiningType.NextBreakfast -> {
+                    tabsDiningTime.selectTab(tabsDiningTime.getTabAt(0))
+                    diningDateAdapter.setSelectedPosition(dates.size / 2 + 1)
+                }
             }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -93,10 +93,10 @@ class DiningActivity : KoinNavigationDrawerActivity() {
             recyclerViewCalendar.adapter = diningDateAdapter
             val current = TimeUtil.getCurrentTime()
             dates.add(current)
-            repeat(7) {
+            repeat(3) {
                 dates.add(0, TimeUtil.getPreviousDayDate(dates.first()))
             }
-            repeat(7) {
+            repeat(3) {
                 dates.add(TimeUtil.getNextDayDate(dates.last()))
             }
             diningDateAdapter.submitList(dates)

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -27,6 +27,26 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
     }
 
     class DiningViewHolder(private val binding: ItemDiningBinding) : RecyclerView.ViewHolder(binding.root) {
+
+        private fun setEmptyDataVisibility(dining: Dining) {
+            with(binding) {
+                if(dining.kcal.isEmpty()) {
+                    textViewKcal.visibility = View.GONE
+                    dividerDot.visibility = View.GONE
+                }
+                if(dining.priceCash.isEmpty()) {
+                    textViewCashPrice.visibility = View.GONE
+                    dividerSlash.visibility = View.GONE
+                }
+                if(dining.priceCard.isEmpty()) {
+                    textViewCardPrice.visibility = View.GONE
+                    dividerSlash.visibility = View.GONE
+                }
+                if(dining.priceCard.isEmpty() && dining.priceCash.isEmpty()) {
+                    dividerDot.visibility = View.GONE
+                }
+            }
+        }
         
         fun bind(dining: Dining) {
             with(binding) {
@@ -39,6 +59,8 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                 textViewCardPrice.text =
                     context.getString(R.string.price, dining.priceCard)
                 textViewDiningMenuItems.text = dining.menu.joinToString("\n")
+                
+                setEmptyDataVisibility(dining)
 
                 if(dining.imageUrl.isNotEmpty()) {
                     Glide.with(context)

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -45,6 +45,9 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                         .load(dining.imageUrl)
                         .into(imageViewDining)
 
+                    textViewNoPhoto.visibility = View.INVISIBLE
+                    imageViewNoPhoto.visibility = View.INVISIBLE
+
                     val dialog = Dialog(context).apply {
                         setContentView(R.layout.dialog_dining_image)
                         window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -65,18 +65,19 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                     }
                 }
 
-                if(dining.soldoutAt.isNotEmpty()) {
-                    groupSoldOut.visibility = View.VISIBLE
-                    textViewDiningSoldOut.visibility = View.VISIBLE
-                } else {
-                    groupSoldOut.visibility = View.INVISIBLE
-                    textViewDiningSoldOut.visibility = View.INVISIBLE
-                }
-
                 if(dining.changedAt.isNotEmpty()) {
                     textViewDiningChanged.visibility = View.VISIBLE
                 } else {
                     textViewDiningChanged.visibility = View.INVISIBLE
+                }
+
+                if(dining.soldoutAt.isNotEmpty()) {
+                    groupSoldOut.visibility = View.VISIBLE
+                    textViewDiningSoldOut.visibility = View.VISIBLE
+                    textViewDiningChanged.visibility = View.INVISIBLE
+                } else {
+                    groupSoldOut.visibility = View.INVISIBLE
+                    textViewDiningSoldOut.visibility = View.INVISIBLE
                 }
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -45,6 +45,7 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                         .load(dining.imageUrl)
                         .into(imageViewDining)
 
+                    cardViewDining.strokeWidth = 0
                     textViewNoPhoto.visibility = View.INVISIBLE
                     imageViewNoPhoto.visibility = View.INVISIBLE
 

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningDateAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningDateAdapter.kt
@@ -48,7 +48,7 @@ class DiningDateAdapter(
                 textViewDayOfTheWeek.text = DateFormatUtil.getDayOfWeek(date)
                 textViewDay.text = date.date.toString()
 
-                if (position < selectedPosition) {
+                if (position < itemCount / 2) {
                     textViewDay.setTextColor(
                         ContextCompat.getColor(
                             context,
@@ -97,7 +97,7 @@ class DiningDateAdapter(
                         )
                     else
                         notifyItemRangeChanged(position, selectedPosition - position + 1)
-                    selectedPosition = position
+                    setSelectedPosition(position)
                 }
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/viewmodel/DiningViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/viewmodel/DiningViewModel.kt
@@ -28,7 +28,7 @@ class DiningViewModel @Inject constructor(
     val dining: StateFlow<List<Dining>> get() = _dining
 
     fun setSelectedDate(date: Date) {
-        _selectedDate.value = TimeUtil.dateFormatToYYYYMMDD(date)
+        _selectedDate.value = TimeUtil.dateFormatToYYMMDD(date)
     }
 
     fun getDining(

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/viewmodel/DiningViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/viewmodel/DiningViewModel.kt
@@ -27,10 +27,6 @@ class DiningViewModel @Inject constructor(
         MutableStateFlow<List<Dining>>(emptyList())
     val dining: StateFlow<List<Dining>> get() = _dining
 
-    init {
-        setSelectedDate(DiningUtil.getCurrentDate())
-    }
-
     fun setSelectedDate(date: Date) {
         _selectedDate.value = TimeUtil.dateFormatToYYYYMMDD(date)
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -87,9 +87,9 @@ class MainActivity : KoinNavigationDrawerActivity() {
             offscreenPageLimit = 3
             currentItem = Int.MAX_VALUE / 2
 
-            val nextItemPx = resources.getDimension(R.dimen.view_pager_next_item_visible_dp)
-            val currentItemMarginPx = resources.getDimension(R.dimen.view_pager_item_margin)
-            setPageTransformer(ScaledViewPager2Transformation(currentItemMarginPx, nextItemPx))
+            // val nextItemPx = resources.getDimension(R.dimen.view_pager_next_item_visible_dp)
+            // val currentItemMarginPx = resources.getDimension(R.dimen.view_pager_item_margin)
+            // setPageTransformer(ScaledViewPager2Transformation(currentItemMarginPx, nextItemPx))
             addItemDecoration(
                 HorizontalMarginItemDecoration(
                     this@MainActivity,

--- a/koin/src/main/res/layout/bus_timetable_express_footer.xml
+++ b/koin/src/main/res/layout/bus_timetable_express_footer.xml
@@ -18,8 +18,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/last_update"
+            android:layout_marginEnd="4dp"
             app:layout_constraintEnd_toStartOf="@id/text_view_updated_at"
-            app:layout_constraintTop_toTopOf="@id/text_view_updated_at"
             app:layout_constraintBottom_toBottomOf="@id/text_view_updated_at" />
 
         <TextView

--- a/koin/src/main/res/layout/bus_timetable_shuttle_footer.xml
+++ b/koin/src/main/res/layout/bus_timetable_shuttle_footer.xml
@@ -18,8 +18,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/last_update"
+            android:layout_marginEnd="4dp"
             app:layout_constraintEnd_toStartOf="@id/text_view_updated_at"
-            app:layout_constraintTop_toTopOf="@id/text_view_updated_at"
             app:layout_constraintBottom_toBottomOf="@id/text_view_updated_at" />
 
         <TextView

--- a/koin/src/main/res/layout/dialog_dining_image.xml
+++ b/koin/src/main/res/layout/dialog_dining_image.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_width="324dp"
+    android:layout_height="224dp"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
@@ -14,11 +14,11 @@
 
     <ImageView
         android:id="@+id/image_view_dining"
-        android:layout_width="342dp"
-        android:layout_height="224dp"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:layout_marginTop="13dp"
-        android:scaleType="centerCrop"
-        android:src="@drawable/no_photo"
+        android:scaleType="fitCenter"
+        android:adjustViewBounds="true"
         app:layout_constraintTop_toBottomOf="@id/image_view_close"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/koin/src/main/res/layout/item_dining.xml
+++ b/koin/src/main/res/layout/item_dining.xml
@@ -118,6 +118,16 @@
 
                 <ImageView
                     android:id="@+id/image_view_dining"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintBottom_toTopOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    />
+
+                <ImageView
+                    android:id="@+id/image_view_no_photo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     app:layout_constraintVertical_chainStyle="packed"
@@ -135,7 +145,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/image_view_dining"
+                    app:layout_constraintTop_toBottomOf="@id/image_view_no_photo"
                     android:text="@string/no_photo" />
 
                 <androidx.constraintlayout.widget.Group

--- a/koin/src/main/res/layout/item_dining.xml
+++ b/koin/src/main/res/layout/item_dining.xml
@@ -104,7 +104,6 @@
             app:cardCornerRadius="10dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="24dp"
-            android:outlineProvider="none"
             app:strokeWidth="1dp"
             app:strokeColor="#CACACA"
             app:rippleColor="@android:color/transparent"

--- a/koin/src/main/res/layout/item_dining.xml
+++ b/koin/src/main/res/layout/item_dining.xml
@@ -5,111 +5,107 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" >
+        android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/text_view_dining_corner"
+        <LinearLayout
+            android:id="@+id/linear_layout_dining_information"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="18sp"
-            android:textStyle="bold"
-            android:layout_marginStart="24dp"
-            android:layout_marginTop="16dp"
-            android:textColor="@color/black"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            tools:text="A코너" />
+            android:paddingTop="16dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal">
 
-        <TextView
-            android:id="@+id/text_view_kcal"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="6dp"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_dining_corner"
-            app:layout_constraintStart_toEndOf="@id/text_view_dining_corner"
-            tools:text="786kcal" />
+            <TextView
+                android:id="@+id/text_view_dining_corner"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="24dp"
+                android:textColor="@color/black"
+                android:textSize="18sp"
+                android:textStyle="bold"
+                tools:text="A코너" />
 
-        <TextView
-            android:id="@+id/divider_dot"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="•"
-            android:layout_marginStart="4dp"
-            app:layout_constraintStart_toEndOf="@id/text_view_kcal"
-            app:layout_constraintTop_toTopOf="@id/text_view_kcal"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_kcal" />
+            <TextView
+                android:id="@+id/text_view_kcal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                tools:text="786kcal" />
 
-        <TextView
-            android:id="@+id/text_view_card_price"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_dining_corner"
-            app:layout_constraintStart_toEndOf="@id/divider_dot"
-            tools:text="1000원" />
+            <TextView
+                android:id="@+id/divider_dot"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                android:text="•" />
 
-        <TextView
-            android:id="@+id/divider_slash"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="/"
-            app:layout_constraintTop_toTopOf="@id/text_view_card_price"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_card_price"
-            app:layout_constraintStart_toEndOf="@id/text_view_card_price" />
+            <TextView
+                android:id="@+id/text_view_card_price"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp"
+                tools:text="1000원" />
 
-        <TextView
-            android:id="@+id/text_view_cash_price"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_dining_corner"
-            app:layout_constraintStart_toEndOf="@id/divider_slash"
-            tools:text="1000원" />
+            <TextView
+                android:id="@+id/divider_slash"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="/" />
+
+            <TextView
+                android:id="@+id/text_view_cash_price"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="1000원" />
+
+        </LinearLayout>
 
         <TextView
             android:id="@+id/text_view_dining_sold_out"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@drawable/background_dining_sold_out_text"
+            app:layout_constraintBottom_toBottomOf="@id/linear_layout_dining_information"
+            app:layout_constraintEnd_toEndOf="@id/card_view_dining"
             android:gravity="center"
             android:minWidth="50dp"
             android:minHeight="26dp"
-            android:textStyle="bold"
             android:text="@string/sold_out"
             android:textColor="#FFAD0D"
-            android:visibility="invisible"
-            android:background="@drawable/background_dining_sold_out_text"
-            app:layout_constraintEnd_toEndOf="@id/card_view_dining"
-            app:layout_constraintTop_toTopOf="@id/text_view_dining_corner"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_dining_corner" />
+            android:textStyle="bold"
+            android:visibility="invisible" />
 
         <TextView
             android:id="@+id/text_view_dining_changed"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:background="@drawable/background_dining_changed_text"
+            app:layout_constraintBottom_toBottomOf="@id/linear_layout_dining_information"
+            app:layout_constraintEnd_toEndOf="@id/card_view_dining"
+            android:layout_gravity="end"
+            android:gravity="center"
             android:minWidth="58dp"
             android:minHeight="26dp"
-            android:textStyle="bold"
-            android:gravity="center"
             android:text="@string/changed"
-            android:visibility="invisible"
             android:textColor="#4B4B4B"
-            android:background="@drawable/background_dining_changed_text"
-            app:layout_constraintEnd_toEndOf="@id/card_view_dining"
-            app:layout_constraintTop_toTopOf="@id/text_view_dining_corner"
-            app:layout_constraintBottom_toBottomOf="@id/text_view_dining_corner" />
+            android:textStyle="bold"
+            android:visibility="invisible" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/card_view_dining"
             android:layout_width="202dp"
             android:layout_height="132dp"
-            app:cardCornerRadius="10dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="24dp"
-            app:strokeWidth="1dp"
-            app:strokeColor="#CACACA"
+            app:cardCornerRadius="10dp"
             app:cardElevation="0dp"
-            app:rippleColor="@android:color/transparent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/text_view_dining_corner">
+            app:layout_constraintTop_toBottomOf="@id/linear_layout_dining_information"
+            app:rippleColor="@android:color/transparent"
+            app:strokeColor="#CACACA"
+            app:strokeWidth="1dp">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
@@ -121,38 +117,37 @@
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     android:scaleType="centerCrop"
-                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toTopOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
                 <ImageView
                     android:id="@+id/image_view_no_photo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    app:layout_constraintVertical_chainStyle="packed"
-                    app:layout_constraintTop_toTopOf="parent"
+                    android:src="@drawable/no_photo"
                     app:layout_constraintBottom_toTopOf="@id/text_view_no_photo"
-                    app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
-                    android:src="@drawable/no_photo" />
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_chainStyle="packed" />
 
                 <TextView
                     android:id="@+id/text_view_no_photo"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="8dp"
+                    android:text="@string/no_photo"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/image_view_no_photo"
-                    android:text="@string/no_photo" />
+                    app:layout_constraintTop_toBottomOf="@id/image_view_no_photo" />
 
                 <androidx.constraintlayout.widget.Group
+                    android:id="@+id/group_sold_out"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:id="@+id/group_sold_out"
                     android:visibility="invisible"
                     app:constraint_referenced_ids="view_sold_out, image_view_sold_out, text_view_sold_out" />
 
@@ -160,19 +155,19 @@
                     android:id="@+id/view_sold_out"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:background="@color/black"
-                    android:alpha="0.5" />
+                    android:alpha="0.5"
+                    android:background="@color/black" />
 
                 <ImageView
                     android:id="@+id/image_view_sold_out"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:src="@drawable/no_meals"
-                    app:layout_constraintVertical_chainStyle="packed"
-                    app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toTopOf="@id/text_view_sold_out"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintVertical_chainStyle="packed" />
 
                 <TextView
                     android:id="@+id/text_view_sold_out"
@@ -193,11 +188,11 @@
             android:id="@+id/text_view_dining_menu_items"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:minHeight="132dp"
-            android:layout_marginEnd="8dp"
-            android:textSize="12sp"
-            android:textColor="@color/black"
             android:layout_marginStart="24dp"
+            android:layout_marginEnd="8dp"
+            android:minHeight="132dp"
+            android:textColor="@color/black"
+            android:textSize="12sp"
             app:layout_constraintEnd_toStartOf="@id/card_view_dining"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="@+id/card_view_dining"
@@ -207,8 +202,8 @@
         <View
             android:layout_width="match_parent"
             android:layout_height="8dp"
-            android:background="@color/background_dark"
             android:layout_marginTop="16dp"
+            android:background="@color/background_dark"
             app:layout_constraintTop_toBottomOf="@id/text_view_dining_menu_items" />
 
 

--- a/koin/src/main/res/layout/item_dining.xml
+++ b/koin/src/main/res/layout/item_dining.xml
@@ -106,6 +106,7 @@
             android:layout_marginEnd="24dp"
             app:strokeWidth="1dp"
             app:strokeColor="#CACACA"
+            app:cardElevation="0dp"
             app:rippleColor="@android:color/transparent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@id/text_view_dining_corner">
@@ -119,6 +120,7 @@
                     android:id="@+id/image_view_dining"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
                     app:layout_constraintTop_toTopOf="parent"
                     app:layout_constraintBottom_toTopOf="parent"
                     app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### 개요
식단 상세 페이지 및 버스 QA 반영

### 상세 작업 내용
- close #223 
    - 애니메이션이 원활히 작동하지 않아 애니메이션이 아니라 버벅거리는 것처럼 보이던 현상
    - 애니메이션 수정이 아닌 제거로 결정
    
- close #224 
    - 높이가 맞지 않아 UI적으로 좋지 않아 보였음
    
- close #225 
    - 기존 정보 없을 시 0kcal 또는 0원으로 표시
    - 0이 아닌 아예 표시하지 않기로 결정
    
- close #226 
    - 오늘 기준 전후 3일씩만 표시
    - 어제 날짜까진 텍스트 Gray, 오늘 날짜 이후는 텍스트 Black

- 기타
    - 식단 상세 페이지 첫 진입 시 클릭된 날짜와 보여지는 식단 날짜가 다르던 버그 수정
    - "사진 없음" 잘못된 사용 수정
    - 품절 시 품절 오버레이 radius 수정
    - 품절의 우선순위를 변경됨보다 상위로 수정
    - 식단 이미지 Scale 수정
    - Production 환경에서 작동하지 않는 api request 수정
    