### PR TITLE
[Feature] GA4 클릭/스크롤 이벤트 추가

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
@@ -10,6 +10,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.progressdialog.CustomProgressDialog
 import `in`.koreatech.koin.core.progressdialog.IProgressDialog
@@ -56,39 +57,6 @@ abstract class ActivityBase : AppCompatActivity, IProgressDialog {
         super.onResume()
         Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
             param(PAGE_TITLE, screenTitle)
-        }
-    }
-
-    /**
-     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
-     * @param label: 이벤트 소분류
-     * @param value: 이벤트 값
-     */
-    protected fun logClickEvent(action: String, label: String, value: String) {
-        logEvent(action, AnalyticsConstant.Category.CLICK, label, value)
-    }
-
-    /**
-     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
-     * @param label: 이벤트 소분류
-     * @param value: 이벤트 값
-     */
-    protected fun logScrollEvent(action: String, label: String, value: String) {
-        logEvent(action, AnalyticsConstant.Category.SCROLL, label, value)
-    }
-
-    /**
-     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
-     * @param category: 이벤트 종류(click, scroll, ...)
-     * @param label: 이벤트 소분류
-     * @param value: 이벤트 값
-     * @sample logEvent("BUSINESS", "click", "main_store_categories", "전체보기")
-     */
-    private fun logEvent(action: String, category: String, label: String, value: String) {
-        Firebase.analytics.logEvent(action) {
-            param("event_category", category)
-            param("event_label", label)
-            param("value", value)
         }
     }
 

--- a/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
@@ -10,8 +10,6 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase
-import `in`.koreatech.koin.core.analytics.EventLogger
-import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.progressdialog.CustomProgressDialog
 import `in`.koreatech.koin.core.progressdialog.IProgressDialog
 

--- a/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
@@ -10,6 +10,7 @@ import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.progressdialog.CustomProgressDialog
 import `in`.koreatech.koin.core.progressdialog.IProgressDialog
 
@@ -55,6 +56,39 @@ abstract class ActivityBase : AppCompatActivity, IProgressDialog {
         super.onResume()
         Firebase.analytics.logEvent(FirebaseAnalytics.Event.SCREEN_VIEW) {
             param(PAGE_TITLE, screenTitle)
+        }
+    }
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     */
+    protected fun logClickEvent(action: String, label: String, value: String) {
+        logEvent(action, AnalyticsConstant.Category.CLICK, label, value)
+    }
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     */
+    protected fun logScrollEvent(action: String, label: String, value: String) {
+        logEvent(action, AnalyticsConstant.Category.SCROLL, label, value)
+    }
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param category: 이벤트 종류(click, scroll, ...)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     * @sample logEvent("BUSINESS", "click", "main_store_categories", "전체보기")
+     */
+    private fun logEvent(action: String, category: String, label: String, value: String) {
+        Firebase.analytics.logEvent(action) {
+            param("event_category", category)
+            param("event_label", label)
+            param("value", value)
         }
     }
 

--- a/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.core.analytics
 
-import android.os.Build
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase

--- a/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -1,0 +1,42 @@
+package `in`.koreatech.koin.core.analytics
+
+import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.analytics.ktx.logEvent
+import com.google.firebase.ktx.Firebase
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
+
+object EventLogger {
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     */
+    fun logClickEvent(action: String, label: String, value: String) {
+        logEvent(action, AnalyticsConstant.Category.CLICK, label, value)
+    }
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     */
+    fun logScrollEvent(action: String, label: String, value: String) {
+        logEvent(action, AnalyticsConstant.Category.SCROLL, label, value)
+    }
+
+    /**
+     * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param category: 이벤트 종류(click, scroll, ...)
+     * @param label: 이벤트 소분류
+     * @param value: 이벤트 값
+     * @sample logEvent("BUSINESS", "click", "main_store_categories", "전체보기")
+     */
+    private fun logEvent(action: String, category: String, label: String, value: String) {
+        Firebase.analytics.logEvent(action) {
+            param("event_category", category)
+            param("event_label", label)
+            param("value", value)
+        }
+    }
+}

--- a/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -8,6 +8,10 @@ import `in`.koreatech.koin.core.constant.AnalyticsConstant
 
 object EventLogger {
 
+    private const val EVENT_CATEGORY = "event_category"
+    private const val EVENT_LABEL = "event_label"
+    private const val VALUE = "value"
+
     /**
      * @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
      * @param label: 이벤트 소분류
@@ -34,11 +38,11 @@ object EventLogger {
      * @sample logEvent("BUSINESS", "click", "main_shop_categories", "전체보기")
      */
     private fun logEvent(action: String, category: String, label: String, value: String) {
-        if(BuildConfig.IS_DEBUG) return
+        if (BuildConfig.IS_DEBUG) return
         Firebase.analytics.logEvent(action) {
-            param("event_category", category)
-            param("event_label", label)
-            param("value", value)
+            param(EVENT_CATEGORY, category)
+            param(EVENT_LABEL, label)
+            param(VALUE, value)
         }
     }
 }

--- a/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -1,8 +1,10 @@
 package `in`.koreatech.koin.core.analytics
 
+import android.os.Build
 import com.google.firebase.analytics.ktx.analytics
 import com.google.firebase.analytics.ktx.logEvent
 import com.google.firebase.ktx.Firebase
+import `in`.koreatech.koin.core.BuildConfig
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 
 object EventLogger {
@@ -30,9 +32,10 @@ object EventLogger {
      * @param category: 이벤트 종류(click, scroll, ...)
      * @param label: 이벤트 소분류
      * @param value: 이벤트 값
-     * @sample logEvent("BUSINESS", "click", "main_store_categories", "전체보기")
+     * @sample logEvent("BUSINESS", "click", "main_shop_categories", "전체보기")
      */
     private fun logEvent(action: String, category: String, label: String, value: String) {
+        if(BuildConfig.IS_DEBUG) return
         Firebase.analytics.logEvent(action) {
             param("event_category", category)
             param("event_label", label)

--- a/core/src/main/java/in/koreatech/koin/core/appbar/AppBarBase.java
+++ b/core/src/main/java/in/koreatech/koin/core/appbar/AppBarBase.java
@@ -52,7 +52,7 @@ public class AppBarBase extends AppBarLayout {
         this.onClickListener = onClickListener;
         background.setOnClickListener(onClickListener);
         leftButton.setOnClickListener(onClickListener);
-        rightButton.setOnClickListener(v -> {
+        rightButton.setOnClickListener( v -> {
             onClickListener.onClick(v);
             EventLogger.INSTANCE.logClickEvent(
                     AnalyticsConstant.Domain.USER,
@@ -116,7 +116,7 @@ public class AppBarBase extends AppBarLayout {
         leftButton.setBackground(leftButtonBackground);
         leftButton.setText(leftButtonString);
         leftButton.setVisibility(leftButtonVisibility);
-        if(leftButtonHeight!= -1 || leftButtonWidth != -1){
+        if (leftButtonHeight != -1 || leftButtonWidth != -1) {
             leftButton.setHeight(leftButtonHeight);
             leftButton.setWidth(leftButtonWidth);
         }
@@ -125,7 +125,7 @@ public class AppBarBase extends AppBarLayout {
         rightButton.setBackground(rightButtonBackground);
         rightButton.setText(rightButtonString);
         rightButton.setVisibility(rightButtonVisibility);
-        if(leftButtonHeight!= -1 || leftButtonWidth != -1){
+        if (leftButtonHeight != -1 || leftButtonWidth != -1) {
             rightButton.setHeight(rightButtonHeight);
             rightButton.setWidth(rightButtonWidth);
         }

--- a/core/src/main/java/in/koreatech/koin/core/appbar/AppBarBase.java
+++ b/core/src/main/java/in/koreatech/koin/core/appbar/AppBarBase.java
@@ -17,6 +17,8 @@ import android.util.AttributeSet;
 
 
 import in.koreatech.koin.core.R;
+import in.koreatech.koin.core.analytics.EventLogger;
+import in.koreatech.koin.core.constant.AnalyticsConstant;
 
 
 public class AppBarBase extends AppBarLayout {
@@ -50,7 +52,14 @@ public class AppBarBase extends AppBarLayout {
         this.onClickListener = onClickListener;
         background.setOnClickListener(onClickListener);
         leftButton.setOnClickListener(onClickListener);
-        rightButton.setOnClickListener(onClickListener);
+        rightButton.setOnClickListener(v -> {
+            onClickListener.onClick(v);
+            EventLogger.INSTANCE.logClickEvent(
+                    AnalyticsConstant.Domain.USER,
+                    AnalyticsConstant.Label.HAMBURGER,
+                    getContext().getString(R.string.hamburger)
+            );
+        });
         title.setOnClickListener(onClickListener);
     }
 

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -23,6 +23,8 @@ object AnalyticsConstant {
         const val HAMBURGER_MY_INFO_WITH_LOGIN = "${HAMBURGER}_my_info_with_login"
         const val HAMBURGER_BUS = "${HAMBURGER}_bus"
         const val USER_ONLY_OK = "user_only_ok"
+        const val MAIN_MENU_MOVEDETAILVIEW = "main_menu_moveDetailView"
+        const val MAIN_MENU_CORNER = "main_menu_corner"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -28,6 +28,7 @@ object AnalyticsConstant {
         const val MENU_TIME = "menu_time"
         const val MAIN_BUS = "main_bus"
         const val MAIN_BUS_CHANGETOFROM = "main_bus_changeToFrom"
+        const val MAIN_BUS_SCROLL = "main_bus_scroll"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -1,0 +1,19 @@
+package `in`.koreatech.koin.core.constant
+
+object AnalyticsConstant {
+
+    object Domain {
+        const val BUSINESS = "BUSINESS"
+        const val CAMPUS = "CAMPUS"
+        const val USER = "USER"
+    }
+
+    object Category {
+        const val CLICK = "click"
+        const val SCROLL = "scroll"
+    }
+
+    object Label {
+
+    }
+}

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -37,6 +37,7 @@ object AnalyticsConstant {
         const val BUS_TIMETABLE_TIME = "bus_timetable_time"
         const val BUS_TIMETABLE_EXPRESS = "bus_timetable_express"
         const val MENU_IMAGE = "menu_image"
+        const val LOGIN = "login"
         const val START_SIGN_UP = "start_sign_up"
         const val COMPLETE_SIGN_UP = "complete_sign_up"
     }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -31,6 +31,10 @@ object AnalyticsConstant {
         const val MAIN_BUS_SCROLL = "main_bus_scroll"
         const val BUS_DEPARTURE = "bus_departure"
         const val BUS_ARRIVAL = "bus_arrival"
+        const val BUS_TIMETABLE = "bus_timetable"
+        const val BUS_TIMETABLE_AREA = "bus_timetable_area"
+        const val BUS_TIMETABLE_TIME = "bus_timetable_time"
+        const val BUS_TIMETABLE_EXPRESS = "bus_timetable_express"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -40,6 +40,9 @@ object AnalyticsConstant {
         const val LOGIN = "login"
         const val START_SIGN_UP = "start_sign_up"
         const val COMPLETE_SIGN_UP = "complete_sign_up"
+        const val STORE_PICTURE = "store_picture"
+        const val STORE_CALL = "store_call"
+        const val STORE_CLICK = "store_click"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -16,6 +16,7 @@ object AnalyticsConstant {
     object Label {
         const val MAIN_STORE_CATEGORIES = "main_store_categories"
         const val STORE_CATEGORIES = "store_categories"
+        const val STORE_CATEGORIES_SEARCH = "store_categories_search"
         const val HAMBURGER = "hamburger"
         const val HAMBURGER_STORE = "${HAMBURGER}_store"
         const val HAMBURGER_DINING = "${HAMBURGER}_dining"

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -29,6 +29,8 @@ object AnalyticsConstant {
         const val MAIN_BUS = "main_bus"
         const val MAIN_BUS_CHANGETOFROM = "main_bus_changeToFrom"
         const val MAIN_BUS_SCROLL = "main_bus_scroll"
+        const val BUS_DEPARTURE = "bus_departure"
+        const val BUS_ARRIVAL = "bus_arrival"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -15,6 +15,7 @@ object AnalyticsConstant {
 
     object Label {
         const val MAIN_STORE_CATEGORIES = "main_store_categories"
+        const val STORE_CATEGORIES = "store_categories"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -16,6 +16,13 @@ object AnalyticsConstant {
     object Label {
         const val MAIN_STORE_CATEGORIES = "main_store_categories"
         const val STORE_CATEGORIES = "store_categories"
+        const val HAMBURGER = "hamburger"
+        const val HAMBURGER_STORE = "${HAMBURGER}_store"
+        const val HAMBURGER_DINING = "${HAMBURGER}_dining"
+        const val HAMBURGER_MY_INFO_WITHOUT_LOGIN = "${HAMBURGER}_my_info_without_login"
+        const val HAMBURGER_MY_INFO_WITH_LOGIN = "${HAMBURGER}_my_info_with_login"
+        const val HAMBURGER_BUS = "${HAMBURGER}_bus"
+        const val USER_ONLY_OK = "user_only_ok"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -25,6 +25,7 @@ object AnalyticsConstant {
         const val USER_ONLY_OK = "user_only_ok"
         const val MAIN_MENU_MOVEDETAILVIEW = "main_menu_moveDetailView"
         const val MAIN_MENU_CORNER = "main_menu_corner"
+        const val MENU_TIME = "menu_time"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -37,6 +37,8 @@ object AnalyticsConstant {
         const val BUS_TIMETABLE_TIME = "bus_timetable_time"
         const val BUS_TIMETABLE_EXPRESS = "bus_timetable_express"
         const val MENU_IMAGE = "menu_image"
+        const val START_SIGN_UP = "start_sign_up"
+        const val COMPLETE_SIGN_UP = "complete_sign_up"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -14,11 +14,11 @@ object AnalyticsConstant {
     }
 
     object Label {
-        const val MAIN_STORE_CATEGORIES = "main_store_categories"
-        const val STORE_CATEGORIES = "store_categories"
-        const val STORE_CATEGORIES_SEARCH = "store_categories_search"
+        const val MAIN_SHOP_CATEGORIES = "main_shop_categories"
+        const val SHOP_CATEGORIES = "shop_categories"
+        const val SHOP_CATEGORIES_SEARCH = "shop_categories_search"
         const val HAMBURGER = "hamburger"
-        const val HAMBURGER_STORE = "${HAMBURGER}_store"
+        const val HAMBURGER_SHOP = "${HAMBURGER}_shop"
         const val HAMBURGER_DINING = "${HAMBURGER}_dining"
         const val HAMBURGER_MY_INFO_WITHOUT_LOGIN = "${HAMBURGER}_my_info_without_login"
         const val HAMBURGER_MY_INFO_WITH_LOGIN = "${HAMBURGER}_my_info_with_login"
@@ -40,9 +40,9 @@ object AnalyticsConstant {
         const val LOGIN = "login"
         const val START_SIGN_UP = "start_sign_up"
         const val COMPLETE_SIGN_UP = "complete_sign_up"
-        const val STORE_PICTURE = "store_picture"
-        const val STORE_CALL = "store_call"
-        const val STORE_CLICK = "store_click"
+        const val SHOP_PICTURE = "shop_picture"
+        const val SHOP_CALL = "shop_call"
+        const val SHOP_CLICK = "shop_click"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -35,6 +35,7 @@ object AnalyticsConstant {
         const val BUS_TIMETABLE_AREA = "bus_timetable_area"
         const val BUS_TIMETABLE_TIME = "bus_timetable_time"
         const val BUS_TIMETABLE_EXPRESS = "bus_timetable_express"
+        const val MENU_IMAGE = "menu_image"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -14,6 +14,7 @@ object AnalyticsConstant {
     }
 
     object Label {
-
+        const val MAIN_STORE_CATEGORIES = "main_store_categories"
     }
+
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -26,6 +26,8 @@ object AnalyticsConstant {
         const val MAIN_MENU_MOVEDETAILVIEW = "main_menu_moveDetailView"
         const val MAIN_MENU_CORNER = "main_menu_corner"
         const val MENU_TIME = "menu_time"
+        const val MAIN_BUS = "main_bus"
+        const val MAIN_BUS_CHANGETOFROM = "main_bus_changeToFrom"
     }
 
 }

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -76,4 +76,5 @@
     <string name="navigation_drawer_right_button_ask">문의하기</string>
     <string name="navigation_drawer_right_hello_message">님, 안녕하세요!</string>
     <string name="navigation_drawer_right_myinfo">내 정보</string>
+    <string name="hamburger">햄버거</string>
 </resources>

--- a/data/src/main/res/values/strings.xml
+++ b/data/src/main/res/values/strings.xml
@@ -41,6 +41,7 @@
     <string name="bus_name_commuting">통학버스</string>
     <string name="bus_name_express">대성고속</string>
     <string name="bus_name_shuttle">셔틀버스</string>
+    <string name="bus_name_school_shuttle">학교셔틀</string>
     <string name="city_bus_number_format">%1$d번 버스</string>
     <!-- dept -->
     <string name="dept_mechanical_engineering">기계공학부</string>

--- a/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
@@ -47,7 +47,7 @@ object DiningUtil {
             DiningType.Lunch.typeEnglish -> DiningType.Lunch.typeKorean
             DiningType.Dinner.typeEnglish -> DiningType.Dinner.typeKorean
             DiningType.NextBreakfast.typeEnglish -> DiningType.NextBreakfast.typeKorean
-            else -> ""
+            else -> "Unknown type"
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/DiningUtil.kt
@@ -40,4 +40,14 @@ object DiningUtil {
         }
         return null
     }
+
+    fun getKoreanName(type: String): String {
+        return when (type) {
+            DiningType.Breakfast.typeEnglish -> DiningType.Breakfast.typeKorean
+            DiningType.Lunch.typeEnglish -> DiningType.Lunch.typeKorean
+            DiningType.Dinner.typeEnglish -> DiningType.Dinner.typeKorean
+            DiningType.NextBreakfast.typeEnglish -> DiningType.NextBreakfast.typeKorean
+            else -> ""
+        }
+    }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
@@ -24,6 +24,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.util.dataBinding
 
 @AndroidEntryPoint
@@ -41,14 +43,40 @@ class BusMainFragment : Fragment(R.layout.bus_main_fragment) {
         initViewModel()
     }
 
+    private var isUserSelection = false
     private fun initView() = with(binding) {
         busDepartureSpinner.setSelection(BusNode.Koreatech.spinnerSelection)
         busArrivalSpinner.setSelection(BusNode.Terminal.spinnerSelection)
+        busDepartureSpinner.setOnTouchListener { _, _ ->
+            isUserSelection = true
+            busDepartureSpinner.performClick()
+        }
         busDepartureSpinner.setOnItemSelectedListener { _, _, position, _ ->
             viewModel.setDeparture(position.busNodeSelection)
+            if(isUserSelection) {
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.CAMPUS,
+                    AnalyticsConstant.Label.BUS_DEPARTURE,
+                    resources.getStringArray(R.array.bus_place)[position]
+                )
+                isUserSelection = false
+            }
+        }
+
+        busArrivalSpinner.setOnTouchListener { _, _ ->
+            isUserSelection = true
+            busArrivalSpinner.performClick()
         }
         busArrivalSpinner.setOnItemSelectedListener { _, _, position, _ ->
             viewModel.setArrival(position.busNodeSelection)
+            if(isUserSelection) {
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.CAMPUS,
+                    AnalyticsConstant.Label.BUS_ARRIVAL,
+                    resources.getStringArray(R.array.bus_place)[position]
+                )
+                isUserSelection = false
+            }
         }
         recyclerView.apply {
             layoutManager = LinearLayoutManager(requireContext())

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusMainFragment.kt
@@ -43,39 +43,38 @@ class BusMainFragment : Fragment(R.layout.bus_main_fragment) {
         initViewModel()
     }
 
-    private var isUserSelection = false
     private fun initView() = with(binding) {
         busDepartureSpinner.setSelection(BusNode.Koreatech.spinnerSelection)
         busArrivalSpinner.setSelection(BusNode.Terminal.spinnerSelection)
         busDepartureSpinner.setOnTouchListener { _, _ ->
-            isUserSelection = true
+            viewModel.isUserSelection = true
             busDepartureSpinner.performClick()
         }
         busDepartureSpinner.setOnItemSelectedListener { _, _, position, _ ->
             viewModel.setDeparture(position.busNodeSelection)
-            if(isUserSelection) {
+            if(viewModel.isUserSelection) {
                 EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.CAMPUS,
                     AnalyticsConstant.Label.BUS_DEPARTURE,
                     resources.getStringArray(R.array.bus_place)[position]
                 )
-                isUserSelection = false
+                viewModel.isUserSelection = false
             }
         }
 
         busArrivalSpinner.setOnTouchListener { _, _ ->
-            isUserSelection = true
+            viewModel.isUserSelection = true
             busArrivalSpinner.performClick()
         }
         busArrivalSpinner.setOnItemSelectedListener { _, _, position, _ ->
             viewModel.setArrival(position.busNodeSelection)
-            if(isUserSelection) {
+            if(viewModel.isUserSelection) {
                 EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.CAMPUS,
                     AnalyticsConstant.Label.BUS_ARRIVAL,
                     resources.getStringArray(R.array.bus_place)[position]
                 )
-                isUserSelection = false
+                viewModel.isUserSelection = false
             }
         }
         recyclerView.apply {

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusTimetableFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/BusTimetableFragment.kt
@@ -12,6 +12,8 @@ import android.view.View
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 
 @AndroidEntryPoint
 class BusTimetableFragment : DataBindingFragment<BusTimetableFragmentBinding>() {
@@ -39,12 +41,27 @@ class BusTimetableFragment : DataBindingFragment<BusTimetableFragmentBinding>() 
 
         binding.busTimetableBustypeShuttle.setOnClickListener {
             busTimetableViewModel.setBusType(BusType.Shuttle)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE,
+                getString(R.string.bus_name_school_shuttle)
+            )
         }
         binding.busTimetableBustypeDaesung.setOnClickListener {
             busTimetableViewModel.setBusType(BusType.Express)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE,
+                getString(R.string.bus_name_express)
+            )
         }
         binding.busTimetableBustypeCity.setOnClickListener {
             busTimetableViewModel.setBusType(BusType.City)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE,
+                getString(R.string.bus_name_city)
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ExpressBusTimetableFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ExpressBusTimetableFragment.kt
@@ -1,21 +1,5 @@
 package `in`.koreatech.koin.ui.bus.fragment
 
-import `in`.koreatech.koin.R
-import `in`.koreatech.koin.core.fragment.DataBindingFragment
-import `in`.koreatech.koin.core.progressdialog.IProgressDialog
-import `in`.koreatech.koin.databinding.LayoutExpressBusTimetableBinding
-import `in`.koreatech.koin.databinding.LayoutShuttleBusTimetableBinding
-import `in`.koreatech.koin.ui.bus.adpater.timetable.ExpressBusTimetableAdapter
-import `in`.koreatech.koin.ui.bus.adpater.timetable.ShuttleBusTimetableAdapter
-import `in`.koreatech.koin.ui.bus.state.toExpressBusTimetableUiItem
-import `in`.koreatech.koin.ui.bus.state.toShuttleBusTimetableUiItem
-import `in`.koreatech.koin.ui.bus.viewmodel.ExpressBusTimetableViewModel
-import `in`.koreatech.koin.ui.bus.viewmodel.ShuttleBusTimetableViewModel
-import `in`.koreatech.koin.util.SnackbarUtil
-import `in`.koreatech.koin.util.ext.observeLiveData
-import `in`.koreatech.koin.util.ext.setOnItemSelectedListener
-import `in`.koreatech.koin.util.ext.withLoading
-import `in`.koreatech.koin.util.ext.withToastError
 import android.os.Bundle
 import android.view.View
 import android.widget.ArrayAdapter
@@ -23,8 +7,19 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
+import `in`.koreatech.koin.core.fragment.DataBindingFragment
+import `in`.koreatech.koin.core.progressdialog.IProgressDialog
+import `in`.koreatech.koin.databinding.LayoutExpressBusTimetableBinding
+import `in`.koreatech.koin.ui.bus.adpater.timetable.ExpressBusTimetableAdapter
+import `in`.koreatech.koin.ui.bus.state.toExpressBusTimetableUiItem
+import `in`.koreatech.koin.ui.bus.viewmodel.ExpressBusTimetableViewModel
+import `in`.koreatech.koin.util.ext.observeLiveData
+import `in`.koreatech.koin.util.ext.setOnItemSelectedListener
+import `in`.koreatech.koin.util.ext.withLoading
+import `in`.koreatech.koin.util.ext.withToastError
 
 @AndroidEntryPoint
 class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetableBinding>() {
@@ -32,6 +27,7 @@ class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetabl
 
     private val expressBusTimetableViewModel by viewModels<ExpressBusTimetableViewModel>()
     private val expressBusTimetableAdapter = ExpressBusTimetableAdapter()
+    private var isInitialization = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -49,6 +45,10 @@ class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetabl
 
         busTimetableCoursesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             expressBusTimetableViewModel.setCoursePosition(position)
+            if (isInitialization) {
+                isInitialization = false
+                return@setOnItemSelectedListener
+            }
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.CAMPUS,
                 AnalyticsConstant.Label.BUS_TIMETABLE_EXPRESS,
@@ -63,7 +63,7 @@ class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetabl
         withToastError(this@ExpressBusTimetableFragment, binding.root)
 
         observeLiveData(busCoursesString) { courses ->
-            if(courses.isNullOrEmpty()) {
+            if (courses.isNullOrEmpty()) {
                 binding.busTimetableCoursesSpinner.isVisible = false
             } else {
                 binding.busTimetableCoursesSpinner.isVisible = true

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ExpressBusTimetableFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ExpressBusTimetableFragment.kt
@@ -23,6 +23,8 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 
 @AndroidEntryPoint
 class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetableBinding>() {
@@ -47,6 +49,11 @@ class ExpressBusTimetableFragment : DataBindingFragment<LayoutExpressBusTimetabl
 
         busTimetableCoursesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             expressBusTimetableViewModel.setCoursePosition(position)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE_EXPRESS,
+                busTimetableCoursesSpinner.selectedItem.toString()
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ShuttleBusTimetableFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ShuttleBusTimetableFragment.kt
@@ -27,6 +27,8 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
 
     private val shuttleBusTimetableViewModel by viewModels<ShuttleBusTimetableViewModel>()
     private val shuttleBusTimetableAdapter = ShuttleBusTimetableAdapter()
+    private var isCourseInitialization = true
+    private var isRouteInitialization = true
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -44,6 +46,10 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
 
         busTimetableCoursesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             shuttleBusTimetableViewModel.setCoursePosition(position)
+            if (isCourseInitialization) {
+                isCourseInitialization = false
+                return@setOnItemSelectedListener
+            }
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.CAMPUS,
                 AnalyticsConstant.Label.BUS_TIMETABLE_AREA,
@@ -53,6 +59,10 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
 
         busTimetableRoutesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             shuttleBusTimetableViewModel.setRoutePosition(position)
+            if (isRouteInitialization) {
+                isRouteInitialization = false
+                return@setOnItemSelectedListener
+            }
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.CAMPUS,
                 AnalyticsConstant.Label.BUS_TIMETABLE_TIME,
@@ -67,7 +77,7 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
         withToastError(this@ShuttleBusTimetableFragment, binding.root)
 
         observeLiveData(busCoursesString) { courses ->
-            if(courses.isNullOrEmpty()) {
+            if (courses.isNullOrEmpty()) {
                 binding.busTimetableCoursesSpinner.isVisible = false
             } else {
                 binding.busTimetableCoursesSpinner.isVisible = true
@@ -93,7 +103,7 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
         }
 
         observeLiveData(busRoutes) {
-            if(it.isNullOrEmpty()) {
+            if (it.isNullOrEmpty()) {
                 binding.busTimetableRoutesSpinner.isVisible = false
             } else {
                 binding.busTimetableRoutesSpinner.isVisible = true
@@ -109,7 +119,8 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
         observeLiveData(selectedRoutesPosition) {
             shuttleBusTimetableAdapter.submitList(
                 busTimetables.value?.get(
-                    selectedRoutesPosition.value ?: 0)?.map { it.toShuttleBusTimetableUiItem() }
+                    selectedRoutesPosition.value ?: 0
+                )?.map { it.toShuttleBusTimetableUiItem() }
             )
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ShuttleBusTimetableFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/fragment/ShuttleBusTimetableFragment.kt
@@ -8,6 +8,8 @@ import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.fragment.DataBindingFragment
 import `in`.koreatech.koin.core.progressdialog.IProgressDialog
 import `in`.koreatech.koin.databinding.LayoutShuttleBusTimetableBinding
@@ -42,10 +44,20 @@ class ShuttleBusTimetableFragment : DataBindingFragment<LayoutShuttleBusTimetabl
 
         busTimetableCoursesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             shuttleBusTimetableViewModel.setCoursePosition(position)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE_AREA,
+                busTimetableCoursesSpinner.selectedItem.toString()
+            )
         }
 
         busTimetableRoutesSpinner.setOnItemSelectedListener { _, _, position, _ ->
             shuttleBusTimetableViewModel.setRoutePosition(position)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.BUS_TIMETABLE_TIME,
+                busTimetableRoutesSpinner.selectedItem.toString()
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/bus/viewmodel/BusMainFragmentViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/bus/viewmodel/BusMainFragmentViewModel.kt
@@ -25,6 +25,7 @@ class BusMainFragmentViewModel @Inject constructor(
 
     private val _departure = MutableLiveData<BusNode>(BusNode.Koreatech)
     private val _arrival = MutableLiveData<BusNode>(BusNode.Terminal)
+    var isUserSelection = false
 
     val departure: LiveData<BusNode> get() = _departure
     val arrival: LiveData<BusNode> get() = _arrival

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -13,8 +13,11 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.databinding.ItemDiningBinding
 import `in`.koreatech.koin.domain.model.dining.Dining
+import `in`.koreatech.koin.domain.util.DiningUtil
 
 class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback) {
 
@@ -85,6 +88,19 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
                             .load(dining.imageUrl)
                             .into(imageView)
                         dialog.show()
+                        EventLogger.logClickEvent(
+                            AnalyticsConstant.Domain.CAMPUS,
+                            AnalyticsConstant.Label.MENU_IMAGE,
+                            DiningUtil.getKoreanName(dining.type) + "_" + dining.place
+                        )
+                    }
+                } else {
+                    cardViewDining.setOnClickListener {
+                        EventLogger.logClickEvent(
+                            AnalyticsConstant.Domain.CAMPUS,
+                            AnalyticsConstant.Label.MENU_IMAGE,
+                            DiningUtil.getKoreanName(dining.type) + "_" + dining.place
+                        )
                     }
                 }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
@@ -93,6 +93,11 @@ class LoginActivity : ActivityBase(R.layout.activity_login) {
                     password = loginEdittextPw.text.toString().trim()
                 )
             }
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.USER,
+                AnalyticsConstant.Label.LOGIN,
+                getString(R.string.login)
+            )
         }
 
         loginButtonSignup.setOnClickListener {

--- a/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/login/LoginActivity.kt
@@ -2,17 +2,17 @@ package `in`.koreatech.koin.ui.login
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.common.UiStatus
 import `in`.koreatech.koin.core.activity.ActivityBase
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.databinding.ActivityLoginBinding
 import `in`.koreatech.koin.ui.businesslogin.BusinessLoginActivity
@@ -24,8 +24,6 @@ import `in`.koreatech.koin.util.SnackbarUtil
 import `in`.koreatech.koin.util.ext.hideKeyboard
 import `in`.koreatech.koin.util.ext.textString
 import `in`.koreatech.koin.util.ext.withLoading
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -99,6 +97,11 @@ class LoginActivity : ActivityBase(R.layout.activity_login) {
 
         loginButtonSignup.setOnClickListener {
             startActivity(Intent(this@LoginActivity, SignupActivity::class.java))
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.USER,
+                AnalyticsConstant.Label.START_SIGN_UP,
+                getString(R.string.sign_up)
+            )
         }
 
         forgotPasswordLinearLayout.setOnClickListener {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.ui.main.activity
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
@@ -16,9 +17,11 @@ import `in`.koreatech.koin.core.recyclerview.RecyclerViewClickListener
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.core.viewpager.HorizontalMarginItemDecoration
 import `in`.koreatech.koin.core.viewpager.ScaledViewPager2Transformation
+import `in`.koreatech.koin.data.util.localized
 import `in`.koreatech.koin.data.util.todayOrTomorrow
 import `in`.koreatech.koin.databinding.ActivityMainBinding
 import `in`.koreatech.koin.domain.model.dining.DiningPlace
+import `in`.koreatech.koin.ui.bus.BusActivity
 import `in`.koreatech.koin.ui.main.StoreCategoryRecyclerAdapter
 import `in`.koreatech.koin.ui.main.adapter.BusPagerAdapter
 import `in`.koreatech.koin.ui.main.adapter.DiningContainerViewPager2Adapter
@@ -36,8 +39,22 @@ class MainActivity : KoinNavigationDrawerActivity() {
     private val viewModel by viewModels<MainActivityViewModel>()
 
     private val busPagerAdapter = BusPagerAdapter().apply {
-        setOnCardClickListener { callDrawerItem(R.id.navi_item_bus, Bundle()) }
-        setOnSwitchClickListener { viewModel.switchBusNode() }
+        setOnCardClickListener {
+            startActivity(Intent(this@MainActivity, BusActivity::class.java))
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.MAIN_BUS,
+                getString(R.string.bus)
+            )
+        }
+        setOnSwitchClickListener {
+            viewModel.switchBusNode()
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.MAIN_BUS_CHANGETOFROM,
+                it.localized(this@MainActivity)
+            )
+        }
     }
     private val diningContainerAdapter by lazy { DiningContainerViewPager2Adapter(this) }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -58,7 +58,6 @@ class MainActivity : KoinNavigationDrawerActivity() {
         }
     }
     private lateinit var busViewPagerScrollCallback: ViewPager2.OnPageChangeCallback
-    private var isBusScrollCallbackInitialized = false
 
     private val diningContainerAdapter by lazy { DiningContainerViewPager2Adapter(this) }
 
@@ -164,9 +163,8 @@ class MainActivity : KoinNavigationDrawerActivity() {
 
         observeLiveData(busTimer) {
             busPagerAdapter.setBusTimerItems(it)
-            if (!isBusScrollCallbackInitialized) {
+            if (this@MainActivity::busViewPagerScrollCallback.isInitialized.not()) {
                 initBusViewPagerScrollCallback(it)
-                isBusScrollCallbackInitialized = true
             }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : KoinNavigationDrawerActivity() {
                 gotoStoreActivity(position)
                 EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.BUSINESS,
-                    AnalyticsConstant.Label.MAIN_STORE_CATEGORIES,
+                    AnalyticsConstant.Label.MAIN_SHOP_CATEGORIES,
                     view?.findViewById<TextView>(R.id.text_view_store_category)?.text.toString()
                 )
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.ui.main.activity
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.TextView
@@ -22,7 +21,6 @@ import `in`.koreatech.koin.data.util.todayOrTomorrow
 import `in`.koreatech.koin.databinding.ActivityMainBinding
 import `in`.koreatech.koin.domain.model.bus.timer.BusArrivalInfo
 import `in`.koreatech.koin.domain.model.dining.DiningPlace
-import `in`.koreatech.koin.ui.bus.BusActivity
 import `in`.koreatech.koin.ui.main.StoreCategoryRecyclerAdapter
 import `in`.koreatech.koin.ui.main.adapter.BusPagerAdapter
 import `in`.koreatech.koin.ui.main.adapter.DiningContainerViewPager2Adapter
@@ -41,7 +39,7 @@ class MainActivity : KoinNavigationDrawerActivity() {
 
     private val busPagerAdapter = BusPagerAdapter().apply {
         setOnCardClickListener {
-            startActivity(Intent(this@MainActivity, BusActivity::class.java))
+            callDrawerItem(R.id.navi_item_bus, Bundle())
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.CAMPUS,
                 AnalyticsConstant.Label.MAIN_BUS,

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -120,6 +120,10 @@ class MainActivity : KoinNavigationDrawerActivity() {
         tabDining.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
             override fun onTabSelected(tab: TabLayout.Tab) {
                 viewModel.setSelectedPosition(tab.position)
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.CAMPUS,
+                    AnalyticsConstant.Label.MAIN_MENU_CORNER,
+                    tab.text.toString())
             }
 
             override fun onTabUnselected(tab: TabLayout.Tab) {}

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.ui.main.activity
 
 import android.os.Bundle
 import android.view.View
+import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -9,6 +10,7 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.recyclerview.RecyclerViewClickListener
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.core.viewpager.HorizontalMarginItemDecoration
@@ -42,6 +44,11 @@ class MainActivity : KoinNavigationDrawerActivity() {
         setRecyclerViewClickListener(object : RecyclerViewClickListener {
             override fun onClick(view: View?, position: Int) {
                 gotoStoreActivity(position)
+                logClickEvent(
+                    AnalyticsConstant.Domain.BUSINESS,
+                    AnalyticsConstant.Label.MAIN_STORE_CATEGORIES,
+                    view?.findViewById<TextView>(R.id.text_view_store_category)?.text.toString()
+                )
             }
 
             override fun onLongClick(view: View?, position: Int) {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -74,6 +74,11 @@ class MainActivity : KoinNavigationDrawerActivity() {
     private fun initView() = with(binding) {
         buttonCategory.setOnClickListener {
             toggleNavigationDrawer()
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.USER,
+                AnalyticsConstant.Label.HAMBURGER,
+                getString(R.string.hamburger)
+            )
         }
 
         busViewPager.apply {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -10,6 +10,7 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.recyclerview.RecyclerViewClickListener
 import `in`.koreatech.koin.core.util.dataBinding
@@ -44,7 +45,7 @@ class MainActivity : KoinNavigationDrawerActivity() {
         setRecyclerViewClickListener(object : RecyclerViewClickListener {
             override fun onClick(view: View?, position: Int) {
                 gotoStoreActivity(position)
-                logClickEvent(
+                EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.BUSINESS,
                     AnalyticsConstant.Label.MAIN_STORE_CATEGORIES,
                     view?.findViewById<TextView>(R.id.text_view_store_category)?.text.toString()

--- a/koin/src/main/java/in/koreatech/koin/ui/main/adapter/BusPagerAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/adapter/BusPagerAdapter.kt
@@ -30,7 +30,7 @@ class BusPagerAdapter : RecyclerView.Adapter<BusPagerAdapter.MainCardBusViewHold
         fun bind(busArrivalInfo: BusArrivalInfo) {
             with(binding) {
                 root.setOnClickListener { onCardClickListener?.onCardClick(busArrivalInfo.busType) }
-                imageButtonSwitch.setOnClickListener { onSwitchClickListener?.onSwitchClick() }
+                imageButtonSwitch.setOnClickListener { onSwitchClickListener?.onSwitchClick(busArrivalInfo) }
 
                 textViewDepartures.text = busArrivalInfo.departure.localized(root.context)
                 textViewArrival.text = busArrivalInfo.arrival.localized(root.context)
@@ -94,10 +94,10 @@ class BusPagerAdapter : RecyclerView.Adapter<BusPagerAdapter.MainCardBusViewHold
         notifyDataSetChanged()
     }
 
-    inline fun setOnSwitchClickListener(crossinline onSwitchClick: () -> Unit) {
+    inline fun setOnSwitchClickListener(crossinline onSwitchClick: (BusArrivalInfo) -> Unit) {
         onSwitchClickListener = object : OnSwitchClickListener {
-            override fun onSwitchClick() {
-                onSwitchClick()
+            override fun onSwitchClick(busArrivalInfo: BusArrivalInfo) {
+                onSwitchClick(busArrivalInfo)
             }
         }
     }
@@ -111,7 +111,7 @@ class BusPagerAdapter : RecyclerView.Adapter<BusPagerAdapter.MainCardBusViewHold
     }
 
     interface OnSwitchClickListener {
-        fun onSwitchClick()
+        fun onSwitchClick(busArrivalInfo: BusArrivalInfo)
     }
 
     interface OnCardClickListener {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.ui.main.fragment
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -8,6 +9,8 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.data.util.localized
 import `in`.koreatech.koin.databinding.FragmentDiningContainerBinding
@@ -15,6 +18,7 @@ import `in`.koreatech.koin.domain.model.dining.Dining
 import `in`.koreatech.koin.domain.util.DiningUtil
 import `in`.koreatech.koin.domain.util.ext.arrange
 import `in`.koreatech.koin.domain.util.ext.typeFilter
+import `in`.koreatech.koin.ui.dining.DiningActivity
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.main.viewmodel.MainActivityViewModel
 import `in`.koreatech.koin.util.ext.observeLiveData
@@ -34,10 +38,12 @@ class DiningContainerFragment : Fragment(R.layout.fragment_dining_container) {
 
     private fun initView() = with(binding) {
         diningContainer.setOnClickListener {
-            if (activity is MainActivity) {
-                val mainActivity = activity as MainActivity
-                mainActivity.callDrawerItem(R.id.navi_item_dining)
-            }
+            startActivity(Intent(requireContext(), DiningActivity::class.java))
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.CAMPUS,
+                AnalyticsConstant.Label.MAIN_MENU_MOVEDETAILVIEW,
+                requireContext().getString(R.string.navigation_item_dining)
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.ui.main.fragment
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.core.content.ContextCompat
@@ -18,7 +17,6 @@ import `in`.koreatech.koin.domain.model.dining.Dining
 import `in`.koreatech.koin.domain.util.DiningUtil
 import `in`.koreatech.koin.domain.util.ext.arrange
 import `in`.koreatech.koin.domain.util.ext.typeFilter
-import `in`.koreatech.koin.ui.dining.DiningActivity
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.main.viewmodel.MainActivityViewModel
 import `in`.koreatech.koin.util.ext.observeLiveData

--- a/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/fragment/DiningContainerFragment.kt
@@ -38,7 +38,10 @@ class DiningContainerFragment : Fragment(R.layout.fragment_dining_container) {
 
     private fun initView() = with(binding) {
         diningContainer.setOnClickListener {
-            startActivity(Intent(requireContext(), DiningActivity::class.java))
+            if (activity is MainActivity) {
+                val mainActivity = activity as MainActivity
+                mainActivity.callDrawerItem(R.id.navi_item_dining)
+            }
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.CAMPUS,
                 AnalyticsConstant.Label.MAIN_MENU_MOVEDETAILVIEW,

--- a/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
@@ -25,7 +25,6 @@ class MainActivityViewModel @Inject constructor(
 ) : BaseViewModel() {
     private val _busNode =
         MutableLiveData<Pair<BusNode, BusNode>>(BusNode.Koreatech to BusNode.Terminal)
-    val busNode: LiveData<Pair<BusNode, BusNode>> get() = _busNode
 
     private val _selectedPosition = MutableLiveData(0)
     val selectedPosition : LiveData<Int> get() = _selectedPosition

--- a/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/viewmodel/MainActivityViewModel.kt
@@ -25,6 +25,7 @@ class MainActivityViewModel @Inject constructor(
 ) : BaseViewModel() {
     private val _busNode =
         MutableLiveData<Pair<BusNode, BusNode>>(BusNode.Koreatech to BusNode.Terminal)
+    val busNode: LiveData<Pair<BusNode, BusNode>> get() = _busNode
 
     private val _selectedPosition = MutableLiveData(0)
     val selectedPosition : LiveData<Int> get() = _selectedPosition

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -212,7 +212,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 MenuState.Bus -> {
                     action = AnalyticsConstant.Domain.CAMPUS
                     label = AnalyticsConstant.Label.HAMBURGER_BUS
-                    value = getString(R.string.navigation_item_bus)
+                    value = getString(R.string.bus)
                     goToBusActivity()
                 }
                 MenuState.Dining -> {

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -164,11 +164,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                             }
                             else -> Unit
                         }
-                        EventLogger.logClickEvent(
-                            action,
-                            label,
-                            value
-                        )
+                        EventLogger.logClickEvent(action, label, value)
                     }
                 }
             }
@@ -176,7 +172,6 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
         findViewById<View>(R.id.navi_item_myinfo).setOnClickListener {
             koinNavigationDrawerViewModel.selectMenu(MenuState.UserInfo)
-
         }
 
         val leftArrowButton = findViewById<View>(R.id.drawer_left_arrow_button)

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -132,6 +132,43 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
                     else -> {
                         koinNavigationDrawerViewModel.selectMenu(state)
+                        var action = ""
+                        var label = ""
+                        var value = ""
+                        when(state) {
+                            MenuState.Store -> {
+                                action = AnalyticsConstant.Domain.BUSINESS
+                                label = AnalyticsConstant.Label.HAMBURGER_SHOP
+                                value = getString(R.string.nearby_stores)
+                            }
+                            MenuState.Bus -> {
+                                action = AnalyticsConstant.Domain.CAMPUS
+                                label = AnalyticsConstant.Label.HAMBURGER_BUS
+                                value = getString(R.string.bus)
+                            }
+                            MenuState.Dining -> {
+                                action = AnalyticsConstant.Domain.CAMPUS
+                                label = AnalyticsConstant.Label.HAMBURGER_DINING
+                                value = getString(R.string.navigation_item_dining)
+                            }
+                            MenuState.UserInfo -> {
+                                action = AnalyticsConstant.Domain.USER
+                                value = getString(R.string.navigation_drawer_right_myinfo)
+                                if (koinNavigationDrawerViewModel.userState.value == null || koinNavigationDrawerViewModel.userState.value?.isAnonymous == true) {
+                                    label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITHOUT_LOGIN
+                                    showLoginRequestDialog()
+                                } else {
+                                    label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN
+                                    goToUserInfoActivity()
+                                }
+                            }
+                            else -> Unit
+                        }
+                        EventLogger.logClickEvent(
+                            action,
+                            label,
+                            value
+                        )
                     }
                 }
             }
@@ -139,6 +176,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
         findViewById<View>(R.id.navi_item_myinfo).setOnClickListener {
             koinNavigationDrawerViewModel.selectMenu(MenuState.UserInfo)
+
         }
 
         val leftArrowButton = findViewById<View>(R.id.drawer_left_arrow_button)
@@ -205,31 +243,12 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         }
 
         observeLiveData(menuEvent) { menuState ->
-            var action = ""
-            var label = ""
-            var value = ""
             when (menuState) {
-                MenuState.Bus -> {
-                    action = AnalyticsConstant.Domain.CAMPUS
-                    label = AnalyticsConstant.Label.HAMBURGER_BUS
-                    value = getString(R.string.bus)
-                    goToBusActivity()
-                }
-                MenuState.Dining -> {
-                    action = AnalyticsConstant.Domain.CAMPUS
-                    label = AnalyticsConstant.Label.HAMBURGER_DINING
-                    value = getString(R.string.navigation_item_dining)
-                    goToDiningActivity()
-                }
+                MenuState.Bus -> goToBusActivity()
+                MenuState.Dining -> goToDiningActivity()
                 MenuState.Land -> goToLandActivity()
                 MenuState.Main -> goToMainActivity()
-                MenuState.Store -> {
-                    action = AnalyticsConstant.Domain.BUSINESS
-                    label = AnalyticsConstant.Label.HAMBURGER_SHOP
-                    value = getString(R.string.nearby_stores)
-                    goToStoreActivity()
-                }
-
+                MenuState.Store -> goToStoreActivity()
                 MenuState.Timetable -> {
                     if (userState.value == null || userState.value?.isAnonymous == true) {
                         goToAnonymousTimeTableActivity()
@@ -239,19 +258,14 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 }
 
                 MenuState.UserInfo -> {
-                    action = AnalyticsConstant.Domain.USER
-                    value = getString(R.string.navigation_drawer_right_myinfo)
                     if (userState.value == null || userState.value?.isAnonymous == true) {
-                        label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITHOUT_LOGIN
                         showLoginRequestDialog()
                     } else {
-                        label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN
                         goToUserInfoActivity()
                     }
                 }
                 else -> Unit
             }
-            EventLogger.logClickEvent(action, label, value)
             drawerLayout.closeDrawer()
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -19,6 +19,8 @@ import `in`.koreatech.koin.BuildConfig
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
 import `in`.koreatech.koin.core.activity.WebViewActivity
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.data.constant.URLConstant
 import `in`.koreatech.koin.domain.model.user.User
@@ -203,12 +205,31 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
         }
 
         observeLiveData(menuEvent) { menuState ->
+            var action = ""
+            var label = ""
+            var value = ""
             when (menuState) {
-                MenuState.Bus -> goToBusActivity()
-                MenuState.Dining -> goToDiningActivity()
+                MenuState.Bus -> {
+                    action = AnalyticsConstant.Domain.CAMPUS
+                    label = AnalyticsConstant.Label.HAMBURGER_BUS
+                    value = getString(R.string.navigation_item_bus)
+                    goToBusActivity()
+                }
+                MenuState.Dining -> {
+                    action = AnalyticsConstant.Domain.CAMPUS
+                    label = AnalyticsConstant.Label.HAMBURGER_DINING
+                    value = getString(R.string.navigation_item_dining)
+                    goToDiningActivity()
+                }
                 MenuState.Land -> goToLandActivity()
                 MenuState.Main -> goToMainActivity()
-                MenuState.Store -> goToStoreActivity()
+                MenuState.Store -> {
+                    action = AnalyticsConstant.Domain.BUSINESS
+                    label = AnalyticsConstant.Label.HAMBURGER_STORE
+                    value = getString(R.string.nearby_stores)
+                    goToStoreActivity()
+                }
+
                 MenuState.Timetable -> {
                     if (userState.value == null || userState.value?.isAnonymous == true) {
                         goToAnonymousTimeTableActivity()
@@ -218,15 +239,19 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 }
 
                 MenuState.UserInfo -> {
+                    action = AnalyticsConstant.Domain.USER
+                    value = getString(R.string.navigation_drawer_right_myinfo)
                     if (userState.value == null || userState.value?.isAnonymous == true) {
+                        label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITHOUT_LOGIN
                         showLoginRequestDialog()
                     } else {
+                        label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN
                         goToUserInfoActivity()
                     }
                 }
-
                 else -> Unit
             }
+            EventLogger.logClickEvent(action, label, value)
             drawerLayout.closeDrawer()
         }
     }
@@ -379,6 +404,11 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 )
                 intent.putExtra("FIRST_LOGIN", false)
                 startActivity(intent)
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.USER,
+                    AnalyticsConstant.Label.USER_ONLY_OK,
+                    getString(R.string.user_only_ok)
+                )
                 overridePendingTransition(android.R.anim.slide_in_left, android.R.anim.fade_out)
             }
             .setNegativeButton(getString(R.string.navigation_cancel)) { dialog, _ ->

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -225,7 +225,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                 MenuState.Main -> goToMainActivity()
                 MenuState.Store -> {
                     action = AnalyticsConstant.Domain.BUSINESS
-                    label = AnalyticsConstant.Label.HAMBURGER_STORE
+                    label = AnalyticsConstant.Label.HAMBURGER_SHOP
                     value = getString(R.string.nearby_stores)
                     goToStoreActivity()
                 }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -132,39 +132,51 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
                     else -> {
                         koinNavigationDrawerViewModel.selectMenu(state)
-                        var action = ""
-                        var label = ""
-                        var value = ""
-                        when(state) {
+                        when (state) {
                             MenuState.Store -> {
-                                action = AnalyticsConstant.Domain.BUSINESS
-                                label = AnalyticsConstant.Label.HAMBURGER_SHOP
-                                value = getString(R.string.nearby_stores)
+                                EventLogger.logClickEvent(
+                                    AnalyticsConstant.Domain.BUSINESS,
+                                    AnalyticsConstant.Label.HAMBURGER_SHOP,
+                                    getString(R.string.nearby_stores)
+                                )
                             }
+
                             MenuState.Bus -> {
-                                action = AnalyticsConstant.Domain.CAMPUS
-                                label = AnalyticsConstant.Label.HAMBURGER_BUS
-                                value = getString(R.string.bus)
+                                EventLogger.logClickEvent(
+                                    AnalyticsConstant.Domain.CAMPUS,
+                                    AnalyticsConstant.Label.HAMBURGER_BUS,
+                                    getString(R.string.bus)
+                                )
                             }
+
                             MenuState.Dining -> {
-                                action = AnalyticsConstant.Domain.CAMPUS
-                                label = AnalyticsConstant.Label.HAMBURGER_DINING
-                                value = getString(R.string.navigation_item_dining)
+                                EventLogger.logClickEvent(
+                                    AnalyticsConstant.Domain.CAMPUS,
+                                    AnalyticsConstant.Label.HAMBURGER_DINING,
+                                    getString(R.string.navigation_item_dining)
+                                )
                             }
+
                             MenuState.UserInfo -> {
-                                action = AnalyticsConstant.Domain.USER
-                                value = getString(R.string.navigation_drawer_right_myinfo)
                                 if (koinNavigationDrawerViewModel.userState.value == null || koinNavigationDrawerViewModel.userState.value?.isAnonymous == true) {
-                                    label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITHOUT_LOGIN
+                                    EventLogger.logClickEvent(
+                                        AnalyticsConstant.Domain.USER,
+                                        AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITHOUT_LOGIN,
+                                        getString(R.string.navigation_drawer_right_myinfo)
+                                    )
                                     showLoginRequestDialog()
                                 } else {
-                                    label = AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN
+                                    EventLogger.logClickEvent(
+                                        AnalyticsConstant.Domain.USER,
+                                        AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN,
+                                        getString(R.string.navigation_drawer_right_myinfo)
+                                    )
                                     goToUserInfoActivity()
                                 }
                             }
+
                             else -> Unit
                         }
-                        EventLogger.logClickEvent(action, label, value)
                     }
                 }
             }
@@ -259,6 +271,7 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                         goToUserInfoActivity()
                     }
                 }
+
                 else -> Unit
             }
             drawerLayout.closeDrawer()

--- a/koin/src/main/java/in/koreatech/koin/ui/signup/SignUpWithDetailInfoActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/signup/SignUpWithDetailInfoActivity.kt
@@ -11,6 +11,8 @@ import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
+import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.databinding.ActivitySignUpWithDetailInfoBinding
 import `in`.koreatech.koin.domain.error.signup.SignupAlreadySentEmailException
 import `in`.koreatech.koin.domain.model.user.Gender
@@ -92,6 +94,11 @@ class SignupWithDetailInfoActivity : ActivityBase() {
                     phoneNumber = signupUserEdittextPhoneNumber.text.toString(),
                     studentNumber = signupUserEdittextStudentId.text.toString(),
                     isCheckNickname = signupViewModel.isCheckedNickname
+                )
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.USER,
+                    AnalyticsConstant.Label.COMPLETE_SIGN_UP,
+                    getString(R.string.complete_sign_up)
                 )
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -51,7 +51,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             storeDetailContract.launch(it.uid)
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                "store_${it.name}_click",
+                AnalyticsConstant.Label.STORE_CLICK,
                 it.name)
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.ui.store.activity
 
 import android.os.Bundle
 import android.util.Log
+import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
 import androidx.activity.viewModels
@@ -107,6 +108,18 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             isSearchMode = hasFocus
         }
 
+        binding.searchEditText.setOnTouchListener { v, event ->
+            if(event.action == MotionEvent.ACTION_DOWN) {
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.BUSINESS,
+                    AnalyticsConstant.Label.STORE_CATEGORIES_SEARCH,
+                    "search in " + getStoreCategoryName(viewModel.category.value)
+                )
+            }
+            v.performClick()
+        }
+
+
         binding.storeRecyclerview.apply {
             layoutManager = LinearLayoutManager(this@StoreActivity)
             adapter = storeAdapter
@@ -201,30 +214,34 @@ class StoreActivity : KoinNavigationDrawerActivity() {
         binding.storeCategoryEtcTextview.setCategorySelected(category == StoreCategory.Etc)
     }
 
+    private fun getStoreCategoryName(category: StoreCategory?): String {
+        return when(category) {
+            StoreCategory.Chicken -> getString(R.string.chicken)
+            StoreCategory.Pizza -> getString(R.string.pizza)
+            StoreCategory.DOSIRAK -> getString(R.string.dorisak)
+            StoreCategory.PorkFeet -> getString(R.string.pork_feet)
+            StoreCategory.Chinese -> getString(R.string.chinese)
+            StoreCategory.NormalFood -> getString(R.string.normal_food)
+            StoreCategory.Cafe -> getString(R.string.cafe)
+            StoreCategory.BeautySalon -> getString(R.string.beauty_salon)
+            StoreCategory.Etc -> getString(R.string.etc)
+            null -> getString(R.string.see_all)
+            else -> ""
+        }
+    }
+
     private fun View.setCategoryOnClick(category: StoreCategory) {
         setOnClickListener {
-            var eventValue = when(category) {
-                StoreCategory.Chicken -> getString(R.string.chicken)
-                StoreCategory.Pizza -> getString(R.string.pizza)
-                StoreCategory.DOSIRAK -> getString(R.string.dorisak)
-                StoreCategory.PorkFeet -> getString(R.string.pork_feet)
-                StoreCategory.Chinese -> getString(R.string.chinese)
-                StoreCategory.NormalFood -> getString(R.string.normal_food)
-                StoreCategory.Cafe -> getString(R.string.cafe)
-                StoreCategory.BeautySalon -> getString(R.string.beauty_salon)
-                StoreCategory.Etc -> getString(R.string.etc)
-                else -> ""
-            }
-            if(viewModel.category.value == category)
-                eventValue = getString(R.string.unselect_see_all)
+            binding.searchEditText.clearFocus()
+            viewModel.setCategory(category)
+
+            val eventValue = getStoreCategoryName(viewModel.category.value)
 
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 AnalyticsConstant.Label.STORE_CATEGORIES,
-                eventValue)
-
-            binding.searchEditText.clearFocus()
-            viewModel.setCategory(category)
+                eventValue
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -224,8 +224,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             StoreCategory.Cafe -> getString(R.string.cafe)
             StoreCategory.BeautySalon -> getString(R.string.beauty_salon)
             StoreCategory.Etc -> getString(R.string.etc)
-            null -> getString(R.string.see_all)
-            else -> ""
+            StoreCategory.All, null -> getString(R.string.see_all)
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -14,6 +14,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.appbar.AppBarBase
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.util.dataBinding
@@ -47,7 +48,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
     private val storeAdapter = StoreRecyclerAdapter().apply {
         setOnItemClickListener {
             storeDetailContract.launch(it.uid)
-            logClickEvent(
+            EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 "store_${it.name}_click",
                 it.name)
@@ -217,7 +218,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             if(viewModel.category.value == category)
                 eventValue = getString(R.string.unselect_see_all)
 
-            logClickEvent(
+            EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 AnalyticsConstant.Label.STORE_CATEGORIES,
                 eventValue)

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -51,7 +51,8 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 AnalyticsConstant.Label.SHOP_CLICK,
-                it.name)
+                it.name
+            )
         }
     }
 
@@ -63,29 +64,29 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             field = value
         }
 
-    private var showRemoveQueryButton : Boolean = false
-    set(value) {
-        if (!value) {
-            binding.searchImageView.background = ContextCompat.getDrawable(
-                this,
-                R.drawable.ic_search
-            )
-            binding.searchImageView.layoutParams.apply {
-                width = dpToPx(24)
-                height = dpToPx(24)
+    private var showRemoveQueryButton: Boolean = false
+        set(value) {
+            if (!value) {
+                binding.searchImageView.background = ContextCompat.getDrawable(
+                    this,
+                    R.drawable.ic_search
+                )
+                binding.searchImageView.layoutParams.apply {
+                    width = dpToPx(24)
+                    height = dpToPx(24)
+                }
+            } else {
+                binding.searchImageView.background = ContextCompat.getDrawable(
+                    this,
+                    R.drawable.ic_search_close
+                )
+                binding.searchImageView.layoutParams.apply {
+                    width = dpToPx(16)
+                    height = dpToPx(16)
+                }
             }
-        } else {
-            binding.searchImageView.background = ContextCompat.getDrawable(
-                this,
-                R.drawable.ic_search_close
-            )
-            binding.searchImageView.layoutParams.apply {
-                width = dpToPx(16)
-                height = dpToPx(16)
-            }
+            field = value
         }
-        field = value
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -108,7 +109,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
         }
 
         binding.searchEditText.setOnTouchListener { v, event ->
-            if(event.action == MotionEvent.ACTION_DOWN) {
+            if (event.action == MotionEvent.ACTION_DOWN) {
                 EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.BUSINESS,
                     AnalyticsConstant.Label.SHOP_CATEGORIES_SEARCH,
@@ -129,7 +130,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
         }
 
         binding.searchImageView.setOnClickListener {
-            if(showRemoveQueryButton) binding.searchEditText.setText("")
+            if (showRemoveQueryButton) binding.searchEditText.setText("")
         }
 
         handleCategoryClickEvent()
@@ -214,7 +215,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
     }
 
     private fun getStoreCategoryName(category: StoreCategory?): String {
-        return when(category) {
+        return when (category) {
             StoreCategory.Chicken -> getString(R.string.chicken)
             StoreCategory.Pizza -> getString(R.string.pizza)
             StoreCategory.DOSIRAK -> getString(R.string.dorisak)

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.ui.store.activity
 
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
@@ -51,7 +50,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             storeDetailContract.launch(it.uid)
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                AnalyticsConstant.Label.STORE_CLICK,
+                AnalyticsConstant.Label.SHOP_CLICK,
                 it.name)
         }
     }
@@ -112,7 +111,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
             if(event.action == MotionEvent.ACTION_DOWN) {
                 EventLogger.logClickEvent(
                     AnalyticsConstant.Domain.BUSINESS,
-                    AnalyticsConstant.Label.STORE_CATEGORIES_SEARCH,
+                    AnalyticsConstant.Label.SHOP_CATEGORIES_SEARCH,
                     "search in " + getStoreCategoryName(viewModel.category.value)
                 )
             }
@@ -239,7 +238,7 @@ class StoreActivity : KoinNavigationDrawerActivity() {
 
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                AnalyticsConstant.Label.STORE_CATEGORIES,
+                AnalyticsConstant.Label.SHOP_CATEGORIES,
                 eventValue
             )
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -47,6 +47,10 @@ class StoreActivity : KoinNavigationDrawerActivity() {
     private val storeAdapter = StoreRecyclerAdapter().apply {
         setOnItemClickListener {
             storeDetailContract.launch(it.uid)
+            logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                "store_${it.name}_click",
+                it.name)
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.appbar.AppBarBase
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.databinding.StoreActivityMainBinding
 import `in`.koreatech.koin.domain.model.store.StoreCategory
@@ -197,6 +198,26 @@ class StoreActivity : KoinNavigationDrawerActivity() {
 
     private fun View.setCategoryOnClick(category: StoreCategory) {
         setOnClickListener {
+            var eventValue = when(category) {
+                StoreCategory.Chicken -> getString(R.string.chicken)
+                StoreCategory.Pizza -> getString(R.string.pizza)
+                StoreCategory.DOSIRAK -> getString(R.string.dorisak)
+                StoreCategory.PorkFeet -> getString(R.string.pork_feet)
+                StoreCategory.Chinese -> getString(R.string.chinese)
+                StoreCategory.NormalFood -> getString(R.string.normal_food)
+                StoreCategory.Cafe -> getString(R.string.cafe)
+                StoreCategory.BeautySalon -> getString(R.string.beauty_salon)
+                StoreCategory.Etc -> getString(R.string.etc)
+                else -> ""
+            }
+            if(viewModel.category.value == category)
+                eventValue = getString(R.string.unselect_see_all)
+
+            logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                AnalyticsConstant.Label.STORE_CATEGORIES,
+                eventValue)
+
             binding.searchEditText.clearFocus()
             viewModel.setCategory(category)
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.databinding.StoreActivityDetailBinding
@@ -120,6 +121,10 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
 
         binding.storeDetailCallButton.setOnClickListener {
             showCallDialog()
+            logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                "store_${viewModel.store.value?.name ?: "Unknown"}_call",
+                viewModel.store.value?.name ?: "Unknown")
         }
 
         binding.menuSpreadTextView.setOnClickListener {

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -88,7 +88,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             flyerDialogFragment?.show(supportFragmentManager, DIALOG_TAG)
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                AnalyticsConstant.Label.STORE_PICTURE,
+                AnalyticsConstant.Label.SHOP_PICTURE,
                 viewModel.store.value?.name ?: "Unknown")
         }
     }
@@ -128,7 +128,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             showCallDialog()
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                AnalyticsConstant.Label.STORE_CALL,
+                AnalyticsConstant.Label.SHOP_CALL,
                 viewModel.store.value?.name ?: "Unknown")
         }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -88,7 +88,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             flyerDialogFragment?.show(supportFragmentManager, DIALOG_TAG)
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                "store_${viewModel.store.value?.name ?: "Unknown"}_picture",
+                AnalyticsConstant.Label.STORE_PICTURE,
                 viewModel.store.value?.name ?: "Unknown")
         }
     }
@@ -128,7 +128,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             showCallDialog()
             EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
-                "store_${viewModel.store.value?.name ?: "Unknown"}_call",
+                AnalyticsConstant.Label.STORE_CALL,
                 viewModel.store.value?.name ?: "Unknown")
         }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -85,6 +85,10 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             flyerDialogFragment = StoreFlyerDialogFragment()
             flyerDialogFragment?.initialPosition = position
             flyerDialogFragment?.show(supportFragmentManager, DIALOG_TAG)
+            logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                "store_${viewModel.store.value?.name ?: "Unknown"}_picture",
+                viewModel.store.value?.name ?: "Unknown")
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -8,6 +8,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.core.util.dataBinding
@@ -85,7 +86,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             flyerDialogFragment = StoreFlyerDialogFragment()
             flyerDialogFragment?.initialPosition = position
             flyerDialogFragment?.show(supportFragmentManager, DIALOG_TAG)
-            logClickEvent(
+            EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 "store_${viewModel.store.value?.name ?: "Unknown"}_picture",
                 viewModel.store.value?.name ?: "Unknown")
@@ -125,7 +126,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
 
         binding.storeDetailCallButton.setOnClickListener {
             showCallDialog()
-            logClickEvent(
+            EventLogger.logClickEvent(
                 AnalyticsConstant.Domain.BUSINESS,
                 "store_${viewModel.store.value?.name ?: "Unknown"}_call",
                 viewModel.store.value?.name ?: "Unknown")

--- a/koin/src/main/res/layout/activity_login.xml
+++ b/koin/src/main/res/layout/activity_login.xml
@@ -265,7 +265,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:background="@color/colorPrimary"
-            android:text="회원가입"
+            android:text="@string/sign_up"
             android:textColor="@color/white"
             android:textSize="15sp"
             app:fontName="Normal"

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -381,4 +381,6 @@
     <string name="beauty_salon">미용실</string>
     <string name="etc">기타</string>
     <string name="unselect_see_all">미지정(전체보기)</string>
+    <string name="nearby_stores">주변상점</string>
+    <string name="user_only_ok">회원전용 확인</string>
 </resources>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -371,4 +371,14 @@
     <string name="sold_out">품절</string>
     <string name="changed">변경됨</string>
     <string name="price">%1$s원</string>
+    <string name="chicken">치킨</string>
+    <string name="pizza">피자</string>
+    <string name="dorisak">도시락</string>
+    <string name="pork_feet">족발</string>
+    <string name="chinese">중국집</string>
+    <string name="normal_food">일반음식</string>
+    <string name="cafe">카페</string>
+    <string name="beauty_salon">미용실</string>
+    <string name="etc">기타</string>
+    <string name="unselect_see_all">미지정(전체보기)</string>
 </resources>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -383,4 +383,5 @@
     <string name="unselect_see_all">미지정(전체보기)</string>
     <string name="nearby_stores">주변상점</string>
     <string name="user_only_ok">회원전용 확인</string>
+    <string name="bus">버스</string>
 </resources>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <string name="app_name" tools:ignore="DuplicateDefinition">코인\n커뮤니티</string>
 
-    <string name="sign_up">회원 가입</string>
+    <string name="sign_up">회원가입</string>
 
     <!--left drawer menu -->
     <string name="home">홈</string>
@@ -384,4 +384,5 @@
     <string name="user_only_ok">회원전용 확인</string>
     <string name="bus">버스</string>
     <string name="see_all">전체보기</string>
+    <string name="complete_sign_up">회원가입 완료</string>
 </resources>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
     <string name="app_name" tools:ignore="DuplicateDefinition">코인\n커뮤니티</string>
 
     <string name="sign_up">회원가입</string>
+    <string name="login">로그인</string>
 
     <!--left drawer menu -->
     <string name="home">홈</string>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -380,8 +380,8 @@
     <string name="cafe">카페</string>
     <string name="beauty_salon">미용실</string>
     <string name="etc">기타</string>
-    <string name="unselect_see_all">미지정(전체보기)</string>
     <string name="nearby_stores">주변상점</string>
     <string name="user_only_ok">회원전용 확인</string>
     <string name="bus">버스</string>
+    <string name="see_all">전체보기</string>
 </resources>


### PR DESCRIPTION
## 개요
- close #236 
- GA4 화면 클릭 or 스크롤(ViewPager2) 이벤트 추가
<br/>

## 상세 작업 내용
- 이벤트 Logger 싱글톤 객체 추가 - click, scroll 로깅 함수
- 명세에 따라 필요한 곳에서 로깅
<br/>

### TabLayout + ViewPager2 이슈
- TabLayout의 탭 선택으로 클릭 이벤트, ViewPager2의 스크롤에 의한 스크롤 이벤트를 분리해서 로깅해야 했음
- TabLayout의 addOnTabSelectedListener 사용 불가(탭 선택, 스크롤 이벤트를 모두 수신)
- ViewPager2의 스크롤 콜백리스너를 일반적인 방법으로 사용 불가(탭 선택으로 인한 스크롤도 수신)

**해결 방안**
1. TabLayout의 각 Child에 clickListener 설정 -> 스크롤에는 반응하지 않음
2. ViewPager2의 스크롤 콜백리스너에 탭 선택에 의한 프로그램의 스크롤인지 유저의 스크롤인지 판단하는 로직 추가
<br/>

## 이벤트 명세
```Kotlin
/**
* @param action: 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
* @param category: 이벤트 종류(click, scroll, ...)
* @param label: 이벤트 소분류
* @param value: 이벤트 값
* @sample logEvent("BUSINESS", "click", "main_store_categories", "전체보기")
*/
private fun logEvent(action: String, category: String, label: String, value: String) {
    Firebase.analytics.logEvent(action) {
        param("event_category", category)
        param("event_label", label)
        param("value", value)
    }
}
```



