### PR TITLE
Fix random store menu width

### DIFF
--- a/koin/src/main/res/layout/fragment_store_detail_menu.xml
+++ b/koin/src/main/res/layout/fragment_store_detail_menu.xml
@@ -103,7 +103,7 @@
 
             <LinearLayout
                 android:id="@+id/store_detail_menu_linear_layout"
-                android:layout_width="413dp"
+                android:layout_width="match_parent"
                 android:layout_height="0dp"
                 android:orientation="vertical"
                 android:paddingStart="16dp"


### PR DESCRIPTION
### 이슈 해결
- 상점 세부항목 아래 랜덤 추천 상점 3개 width 짤림 해결