### PR TITLE
[Hotfix] 로그 이벤트 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,8 +12,8 @@ buildscript {
         compileSdkVersion = 34
         minSdkVersion = 21
         targetSdkVersion = 34
-        versionName = "3.4.1"
-        minVersionCode = 30401
+        versionName = "3.4.2"
+        minVersionCode = 30402
     }
 
     dependencies {

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -17,6 +17,7 @@ object AnalyticsConstant {
         const val MAIN_SHOP_CATEGORIES = "main_shop_categories"
         const val SHOP_CATEGORIES = "shop_categories"
         const val SHOP_CATEGORIES_SEARCH = "shop_categories_search"
+        const val SHOP_CATEGORIES_EVENT = "shop_categories_event"
         const val HAMBURGER = "hamburger"
         const val HAMBURGER_SHOP = "${HAMBURGER}_shop"
         const val HAMBURGER_DINING = "${HAMBURGER}_dining"

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -43,6 +43,7 @@ object AnalyticsConstant {
         const val SHOP_PICTURE = "shop_picture"
         const val SHOP_CALL = "shop_call"
         const val SHOP_CLICK = "shop_click"
+        const val SHOP_BACK_BUTTON = "shop_back_button"
     }
 
 }

--- a/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
+++ b/core/src/main/java/in/koreatech/koin/core/constant/AnalyticsConstant.kt
@@ -45,6 +45,7 @@ object AnalyticsConstant {
         const val SHOP_CALL = "shop_call"
         const val SHOP_CLICK = "shop_click"
         const val SHOP_BACK_BUTTON = "shop_back_button"
+        const val SHOP_DETAIL_VIEW_EVENT = "shop_detail_view_event"
     }
 
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -9,10 +9,10 @@ import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
-import `in`.koreatech.koin.core.util.dataBinding
-import `in`.koreatech.koin.core.viewpager.HorizontalMarginItemDecoration
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
+import `in`.koreatech.koin.core.util.dataBinding
+import `in`.koreatech.koin.core.viewpager.HorizontalMarginItemDecoration
 import `in`.koreatech.koin.data.util.localized
 import `in`.koreatech.koin.data.util.todayOrTomorrow
 import `in`.koreatech.koin.databinding.ActivityMainBinding
@@ -26,7 +26,6 @@ import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
 import `in`.koreatech.koin.ui.navigation.state.MenuState
 import `in`.koreatech.koin.ui.store.contract.StoreActivityContract
 import `in`.koreatech.koin.util.ext.observeLiveData
-import androidx.activity.result.contract.ActivityResultContracts
 
 @AndroidEntryPoint
 class MainActivity : KoinNavigationDrawerActivity() {
@@ -58,8 +57,13 @@ class MainActivity : KoinNavigationDrawerActivity() {
     private val diningContainerAdapter by lazy { DiningContainerViewPager2Adapter(this) }
 
     private val storeCategoriesRecyclerAdapter = StoreCategoriesRecyclerAdapter().apply {
-        setOnItemClickListener {
-            gotoStoreActivity(it)
+        setOnItemClickListener { id, name ->
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                AnalyticsConstant.Label.MAIN_SHOP_CATEGORIES,
+                name
+            )
+            gotoStoreActivity(id)
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/main/adapter/StoreCategoriesRecyclerAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/adapter/StoreCategoriesRecyclerAdapter.kt
@@ -33,7 +33,7 @@ diffCallback
 
         with(holder){
             container.setOnClickListener {
-                onItemClickListener?.onItemClick(event.id)
+                onItemClickListener?.onItemClick(event.id, event.name)
             }
 
             Glide.with(storeCategoryImage)
@@ -47,13 +47,13 @@ diffCallback
     }
 
     interface OnItemClickListener {
-        fun onItemClick(id: Int)
+        fun onItemClick(id: Int, name: String)
     }
 
-    inline fun setOnItemClickListener(crossinline onItemClick: (Id: Int) -> Unit) {
+    inline fun setOnItemClickListener(crossinline onItemClick: (Id: Int, name: String) -> Unit) {
         onItemClickListener = object : StoreCategoriesRecyclerAdapter.OnItemClickListener {
-            override fun onItemClick(id: Int) {
-                onItemClick(id)
+            override fun onItemClick(id: Int, name: String) {
+                onItemClick(id, name)
             }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -76,6 +76,12 @@ class StoreActivity : KoinNavigationDrawerActivity() {
         setOnItemClickListener {
             viewModel.setCategory(it.toStoreCategory())
             binding.searchEditText.text.clear()
+            val eventValue = getStoreCategoryName(viewModel.category.value)
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                AnalyticsConstant.Label.SHOP_CATEGORIES,
+                eventValue
+            )
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -69,6 +69,11 @@ class StoreActivity : KoinNavigationDrawerActivity() {
 
     private val storeEventPagerAdapter = StoreEventPagerAdapter().apply {
         setOnItemClickListener {
+            EventLogger.logClickEvent(
+                AnalyticsConstant.Domain.BUSINESS,
+                AnalyticsConstant.Label.SHOP_CATEGORIES_EVENT,
+                it.shopName
+            )
             storeDetailContract.launch(it.shopId)
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -8,8 +8,8 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
+import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.analytics.EventLogger
@@ -23,7 +23,6 @@ import `in`.koreatech.koin.ui.navigation.state.MenuState
 import `in`.koreatech.koin.ui.store.adapter.StoreDetailFlyerRecyclerAdapter
 import `in`.koreatech.koin.ui.store.adapter.StoreDetailMenuRecyclerAdapter
 import `in`.koreatech.koin.ui.store.adapter.StoreDetailViewpagerAdapter
-import `in`.koreatech.koin.ui.store.adapter.StoreRecyclerAdapter
 import `in`.koreatech.koin.ui.store.contract.StoreCallContract
 import `in`.koreatech.koin.ui.store.contract.StoreDetailActivityContract
 import `in`.koreatech.koin.ui.store.fragment.StoreFlyerDialogFragment
@@ -102,6 +101,21 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
                 else -> throw IllegalArgumentException("Invalid position")
             }
         }.attach()
+
+        binding.storeDetailTabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab?) {
+                if (tab?.position == 1)
+                    EventLogger.logClickEvent(
+                        AnalyticsConstant.Domain.BUSINESS,
+                        AnalyticsConstant.Label.SHOP_DETAIL_VIEW_EVENT,
+                        viewModel.store.value?.name ?: "Unknown"
+                    )
+            }
+
+            override fun onTabUnselected(p0: TabLayout.Tab?) {}
+
+            override fun onTabReselected(p0: TabLayout.Tab?) {}
+        })
 
         initViewModel()
         val storeId = intent.extras?.getInt(StoreDetailActivityContract.STORE_ID)

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -39,9 +39,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
     override val screenTitle = "상점 상세"
     private val viewModel by viewModels<StoreDetailViewModel>()
     private var flyerDialogFragment: StoreFlyerDialogFragment? = null
-
-
-
+    
     private val callPermission =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {
             if (it) {
@@ -72,14 +70,19 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
     }
     private val storeDetailViewpagerAdapter =StoreDetailViewpagerAdapter(this)
 
-
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         binding.koinBaseAppbar.setOnClickListener {
             when (it.id) {
-                AppBarBase.getLeftButtonId() -> onBackPressed()
+                AppBarBase.getLeftButtonId() -> {
+                    EventLogger.logClickEvent(
+                        AnalyticsConstant.Domain.BUSINESS,
+                        AnalyticsConstant.Label.SHOP_BACK_BUTTON,
+                        viewModel.store.value?.name ?: "Unknown"
+                    )
+                    onBackPressed()
+                }
                 AppBarBase.getRightButtonId() -> toggleNavigationDrawer()
             }
         }


### PR DESCRIPTION
### 개요
누락된 이벤트 추가

### 상세 작업 내용
- 이벤트 배너 클릭
- 이벤트 탭 클릭
- 상점 카테고리 클릭
- 상점 목록 스크롤
- 상점 네비게이션 뒤로가기 클릭