### PR TITLE
[Fix] 유저 정보 액티비티 중복 호출

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,6 @@ napier = "2.6.1"
 composeNumberPickerVersion = "1.0.3"
 powerSpinner = "1.2.7"
 firebaseCrashlyticsBuildtoolsVersion = "2.9.9"
-composeNumberPickerVersion = "1.0.3"
 
 [libraries]
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "activityKtxVersion" }
@@ -147,7 +146,6 @@ coil-svg = {module = "io.coil-kt:coil-svg", version.ref ="coilVersion"}
 
 compose-numberPicker = {module = "com.chargemap.compose:numberpicker", version.ref = "composeNumberPickerVersion"}
 powerSpinner = {module = "com.github.skydoves:powerspinner", version.ref = "powerSpinner"}
-compose-numberPicker = {module = "com.chargemap.compose:numberpicker", version.ref = "composeNumberPickerVersion"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradleVersion" }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -197,7 +197,6 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
                                         AnalyticsConstant.Label.HAMBURGER_MY_INFO_WITH_LOGIN,
                                         getString(R.string.navigation_drawer_right_myinfo)
                                     )
-                                    goToUserInfoActivity()
                                 }
                             }
 


### PR DESCRIPTION
로깅 로직에서 유저 정보 액티비티 중복 호출이 일어나서, 유저 정보 화면이 2번 호출되고 있었습니다.
해당 부분 해결 PR 입니다.

별 이슈 없어서 확인해주신 뒤 approve 해주시면 감사하겠습니다!