### PR TITLE
[Feature] 식단 아침카드 로직 추가

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningPlace.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/dining/DiningPlace.kt
@@ -6,5 +6,6 @@ enum class DiningPlace(
     CornerA("A코너"),
     CornerB("B코너"),
     CornerC("C코너"),
-    Nungsu("능수관")
+    Nungsu("능수관"),
+    Campus2("2캠퍼스")
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/DiningListExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/DiningListExtensions.kt
@@ -12,7 +12,7 @@ fun List<Dining>.typeFilter(type: DiningType) = this.filter {
 fun List<Dining>.arrange() = this.let {
     val campus1 = this.filter { it.place != "2캠퍼스" }
     campus1.sortedBy { it.place }
-    val allPlaces = DiningPlace.entries.map { it.place }
+    val allPlaces = DiningPlace.entries.map { it.place }.filter { it != "2캠퍼스" }
 
     allPlaces.map { place ->
         campus1.find { it.place == place } ?: Dining(

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -14,6 +14,7 @@ import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.constant.AnalyticsConstant
 import `in`.koreatech.koin.core.dialog.ImageZoomableDialog
 import `in`.koreatech.koin.databinding.ItemDiningBinding
+import `in`.koreatech.koin.domain.constant.BREAKFAST
 import `in`.koreatech.koin.domain.model.dining.Dining
 import `in`.koreatech.koin.domain.util.DiningUtil
 
@@ -33,43 +34,9 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
             with(binding) {
                 val context = root.context
 
-                setDiningImageVisibility(context, dining)
+                setDiningCard(context, dining)
                 setDiningDataText(context, dining)
                 setEmptyDataVisibility(dining)
-
-                if(dining.imageUrl.isNotEmpty()) {
-                    cardViewDining.strokeWidth = 0
-                    textViewNoPhoto.visibility = View.INVISIBLE
-                    imageViewNoPhoto.visibility = View.INVISIBLE
-                    imageViewDining.visibility = View.VISIBLE
-                    Glide.with(context)
-                        .load(dining.imageUrl)
-                        .into(imageViewDining)
-
-                    val dialog = ImageZoomableDialog(context, dining.imageUrl)
-                    dialog.initialScale = 0.75f
-                    cardViewDining.setOnClickListener {
-                        dialog.show()
-                        EventLogger.logClickEvent(
-                            AnalyticsConstant.Domain.CAMPUS,
-                            AnalyticsConstant.Label.MENU_IMAGE,
-                            DiningUtil.getKoreanName(dining.type) + "_" + dining.place
-                        )
-                    }
-                } else {
-                    cardViewDining.strokeWidth =
-                        TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1f, context.resources.displayMetrics).toInt()
-                    textViewNoPhoto.visibility = View.VISIBLE
-                    imageViewNoPhoto.visibility = View.VISIBLE
-                    imageViewDining.visibility = View.INVISIBLE
-                    cardViewDining.setOnClickListener {
-                        EventLogger.logClickEvent(
-                            AnalyticsConstant.Domain.CAMPUS,
-                            AnalyticsConstant.Label.MENU_IMAGE,
-                            DiningUtil.getKoreanName(dining.type) + "_" + dining.place
-                        )
-                    }
-                }
 
                 if(dining.changedAt.isNotEmpty()) {
                     textViewDiningChanged.visibility = View.VISIBLE
@@ -88,13 +55,67 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
             }
         }
 
-        private fun setDiningImageVisibility(context: Context, dining: Dining) {
-            when(dining.place) {
-                context.getString(R.string.dining_nungsu),
-                context.getString(R.string.dining_2campus) -> binding.cardViewDining.visibility = View.GONE
-                else -> binding.cardViewDining.visibility = View.VISIBLE
+        private fun setDiningCard(context: Context, dining: Dining) {
+            with (dining) {
+                // 능수관, 2캠퍼스일 때 이미지 카드 노출 X
+                if (place == context.getString(R.string.dining_nungsu) || place == context.getString(R.string.dining_2campus)) {
+                    binding.cardViewDining.visibility = View.GONE
+                }
+                // 아침 이미지 분기처리
+                else if (type == BREAKFAST) {
+                    if (imageUrl.isNotEmpty()) showDiningImage(context, dining)
+                    else binding.cardViewDining.visibility = View.GONE
+                }
+                // 점심, 저녁
+                else {
+                    if (imageUrl.isNotEmpty()) showDiningImage(context, dining)
+                    else showEmptyDiningImage(context, dining)
+                }
             }
         }
+
+        private fun showDiningImage(context: Context, dining: Dining){
+            binding.cardViewDining.visibility = View.VISIBLE
+            binding.cardViewDining.strokeWidth = 0
+            binding.textViewNoPhoto.visibility = View.INVISIBLE
+            binding.imageViewNoPhoto.visibility = View.INVISIBLE
+            binding.imageViewDining.visibility = View.VISIBLE
+
+            Glide.with(context)
+                .load(dining.imageUrl)
+                .into(binding.imageViewDining)
+            
+            // 이미지 클릭시 dialog 형태로 노출
+            val dialog = ImageZoomableDialog(context, dining.imageUrl)
+            dialog.initialScale = 0.75f
+            binding.cardViewDining.setOnClickListener {
+                dialog.show()
+                EventLogger.logClickEvent(
+                    AnalyticsConstant.Domain.CAMPUS,
+                    AnalyticsConstant.Label.MENU_IMAGE,
+                    DiningUtil.getKoreanName(dining.type) + "_" + dining.place
+                )
+            }
+        }
+
+        private fun showEmptyDiningImage(context: Context, dining: Dining) {
+            with (binding) {
+                cardViewDining.visibility = View.VISIBLE
+                cardViewDining.strokeWidth =
+                    TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, 1f, context.resources.displayMetrics).toInt()
+                textViewNoPhoto.visibility = View.VISIBLE
+                imageViewNoPhoto.visibility = View.VISIBLE
+                imageViewDining.visibility = View.INVISIBLE
+                cardViewDining.setOnClickListener {
+                    EventLogger.logClickEvent(
+                        AnalyticsConstant.Domain.CAMPUS,
+                        AnalyticsConstant.Label.MENU_IMAGE,
+                        DiningUtil.getKoreanName(dining.type) + "_" + dining.place
+                    )
+                }
+            }
+        }
+
         private fun setEmptyDataVisibility(dining: Dining) {
             with(binding) {
                 textViewKcal.visibility = View.VISIBLE

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -16,6 +16,7 @@ import `in`.koreatech.koin.core.dialog.ImageZoomableDialog
 import `in`.koreatech.koin.databinding.ItemDiningBinding
 import `in`.koreatech.koin.domain.constant.BREAKFAST
 import `in`.koreatech.koin.domain.model.dining.Dining
+import `in`.koreatech.koin.domain.model.dining.DiningPlace
 import `in`.koreatech.koin.domain.util.DiningUtil
 
 class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback) {
@@ -58,7 +59,7 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
         private fun setDiningCard(context: Context, dining: Dining) {
             with (dining) {
                 // 능수관, 2캠퍼스일 때 이미지 카드 노출 X
-                if (place == context.getString(R.string.dining_nungsu) || place == context.getString(R.string.dining_2campus)) {
+                if (place == DiningPlace.Nungsu.place || place == DiningPlace.Campus2.place) {
                     binding.cardViewDining.visibility = View.GONE
                 }
                 // 아침 이미지 분기처리

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -75,26 +75,28 @@ class DiningAdapter : ListAdapter<Dining, RecyclerView.ViewHolder>(diffCallback)
         }
 
         private fun showDiningImage(context: Context, dining: Dining){
-            binding.cardViewDining.visibility = View.VISIBLE
-            binding.cardViewDining.strokeWidth = 0
-            binding.textViewNoPhoto.visibility = View.INVISIBLE
-            binding.imageViewNoPhoto.visibility = View.INVISIBLE
-            binding.imageViewDining.visibility = View.VISIBLE
+            with(binding) {
+                cardViewDining.visibility = View.VISIBLE
+                cardViewDining.strokeWidth = 0
+                textViewNoPhoto.visibility = View.INVISIBLE
+                imageViewNoPhoto.visibility = View.INVISIBLE
+                imageViewDining.visibility = View.VISIBLE
 
-            Glide.with(context)
-                .load(dining.imageUrl)
-                .into(binding.imageViewDining)
-            
-            // 이미지 클릭시 dialog 형태로 노출
-            val dialog = ImageZoomableDialog(context, dining.imageUrl)
-            dialog.initialScale = 0.75f
-            binding.cardViewDining.setOnClickListener {
-                dialog.show()
-                EventLogger.logClickEvent(
-                    AnalyticsConstant.Domain.CAMPUS,
-                    AnalyticsConstant.Label.MENU_IMAGE,
-                    DiningUtil.getKoreanName(dining.type) + "_" + dining.place
-                )
+                Glide.with(context)
+                    .load(dining.imageUrl)
+                    .into(imageViewDining)
+
+                // 이미지 클릭시 dialog 형태로 노출
+                val dialog = ImageZoomableDialog(context, dining.imageUrl)
+                dialog.initialScale = 0.75f
+                cardViewDining.setOnClickListener {
+                    dialog.show()
+                    EventLogger.logClickEvent(
+                        AnalyticsConstant.Domain.CAMPUS,
+                        AnalyticsConstant.Label.MENU_IMAGE,
+                        DiningUtil.getKoreanName(dining.type) + "_" + dining.place
+                    )
+                }
             }
         }
 


### PR DESCRIPTION
## 이슈
* closed #310 

## 개요
* 식단 아침카드 관련 기능명세 반영
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b287c387-770e-4b10-89fb-5a088bb1d780">

## 결과화면
<img src="https://github.com/user-attachments/assets/6df9357d-d39d-408c-9bcb-9aa001da56e7" width=200 />
<img src="https://github.com/user-attachments/assets/062e55cb-143e-47d3-8995-c87c116ca725" width=200 />

## 추가사항
* 로직이 추가됨에 따라 `setDiningImageVisibility` 함수를 쪼갰습니다. @ThirFir 이 과정에서 누락된 코드가 있는지 한번 확인해주시면 감사하겠습니다!
* 천원의아침 이미지는 서버에서 내려주기 때문에 따로 작업한 로직은 없습니다.