### PR TITLE
[Feature] 내 상점 페이지 메뉴 관리/추가 버튼 추가

### DIFF
--- a/business/src/main/java/in/koreatech/business/feature/store/modifyinfo/ModifyInfoScreen.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/modifyinfo/ModifyInfoScreen.kt
@@ -225,28 +225,29 @@ fun ModifyInfoScreen(
                 ) {
                     AvailableRadioButton(
                         text = stringResource(id = R.string.delivery_available),
-                        selected = state.storeInfo?.isDeliveryOk ?: false,
+                        selected = state.storeInfo.isDeliveryOk,
                         onClick = viewModel::onDeliveryAvailableChanged
                     )
                     AvailableRadioButton(
                         text = stringResource(id = R.string.card_payment_available),
-                        selected = state.storeInfo?.isCardOk ?: false,
+                        selected = state.storeInfo.isCardOk,
                         onClick = viewModel::onCardAvailableChanged
                     )
                     AvailableRadioButton(
                         text = stringResource(id = R.string.bank_transfer_available),
-                        selected = state.storeInfo?.isBankOk ?: false,
+                        selected = state.storeInfo.isBankOk ,
                         onClick = viewModel::onTransferAvailableChanged
                     )
                 }
             }
+
             item {
                 Box(modifier = Modifier.fillMaxWidth()) {
                     Button(
                         onClick = {
                             viewModel.modifyStoreInfo(
                                 storeInfoState.storeId,
-                                state.storeInfo ?: return@Button
+                                state.storeInfo
                             )
                             viewModel.onBackButtonClicked()
                         },

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailScreen.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailScreen.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
@@ -19,6 +21,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
@@ -65,6 +69,8 @@ fun MyStoreDetailScreen(
     navigateToLoginScreen: () -> Unit = {},
     navigateToUploadEventScreen: () -> Unit = {},
     navigateToModifyScreen: () -> Unit = {},
+    navigateToManageMenuScreen: () -> Unit = {},
+    navigateToRegisterMenuScreen: () -> Unit = {},
 ) {
     val state = viewModel.collectAsState().value
     val pagerState = rememberPagerState(0, 0f) { 2 }
@@ -103,6 +109,14 @@ fun MyStoreDetailScreen(
 
             MyStoreDetailSideEffect.NavigateToUploadEventScreen -> navigateToUploadEventScreen()
             MyStoreDetailSideEffect.NavigateToModifyScreen -> navigateToModifyScreen()
+            MyStoreDetailSideEffect.NavigateToManageMenuScreen -> {
+                navigateToManageMenuScreen()
+            }
+
+            MyStoreDetailSideEffect.NavigateToRegisterMenuScreen -> {
+                navigateToRegisterMenuScreen()
+            }
+
             MyStoreDetailSideEffect.ShowErrorModifyEventToast -> ToastUtil.getInstance().makeShort(
                 context.getString(R.string.error_modify_event)
             )
@@ -181,6 +195,60 @@ fun MyStoreScrollScreen(
                             )
                         }
                         Spacer(modifier = Modifier.width(10.dp))
+                    }
+                }
+            }
+            item {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 5.dp),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    Button(
+                        onClick = { viewModel.onManageMenuClicked() },
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                            .border(1.dp, ColorPrimary, RoundedCornerShape(0.dp))
+                            .width(107.dp)
+                            .height(40.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = Color.White,
+                            contentColor = Color.White
+                        ),
+                        shape = RoundedCornerShape(0.dp),
+                        elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.manage_menu),
+                            style = TextStyle(
+                                color = ColorPrimary,
+                                fontSize = 15.sp
+                            )
+                        )
+                    }
+
+                    Button(
+                        onClick = { viewModel.onRegisterMenuClicked() },
+                        modifier = Modifier
+                            .padding(end = 20.dp)
+                            .width(107.dp)
+                            .height(40.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            backgroundColor = ColorPrimary,
+                            contentColor = Color.White
+                        ),
+                        shape = RoundedCornerShape(0.dp),
+                        elevation = ButtonDefaults.elevation(defaultElevation = 0.dp, pressedElevation = 0.dp),
+
+                    ) {
+                        Text(
+                            text = stringResource(R.string.register_menu),
+                            style = TextStyle(
+                                color = Color.White,
+                                fontSize = 15.sp
+                            )
+                        )
                     }
                 }
             }

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailSideEffect.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailSideEffect.kt
@@ -1,8 +1,12 @@
 package `in`.koreatech.business.feature.store.storedetail
 
+import `in`.koreatech.business.feature.store.modifyinfo.ModifyInfoSideEffect
+
 sealed class MyStoreDetailSideEffect {
     data object NavigateToUploadEventScreen : MyStoreDetailSideEffect()
     data object NavigateToModifyScreen : MyStoreDetailSideEffect()
+    data object NavigateToManageMenuScreen :  MyStoreDetailSideEffect()
+    data object NavigateToRegisterMenuScreen :  MyStoreDetailSideEffect()
     data class ShowErrorMessage(val errorMessage: String) : MyStoreDetailSideEffect()
     data object ShowErrorModifyEventToast : MyStoreDetailSideEffect()
 }

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
@@ -165,9 +165,17 @@ class MyStoreDetailViewModel @Inject constructor(
     }
 
     fun navigateToModifyScreen() = intent {
+        if (state.storeId == -1) return@intent
         postSideEffect(MyStoreDetailSideEffect.NavigateToModifyScreen)
     }
 
+    fun onManageMenuClicked() = intent {
+        postSideEffect(MyStoreDetailSideEffect.NavigateToManageMenuScreen)
+    }
+
+    fun onRegisterMenuClicked() = intent {
+        postSideEffect(MyStoreDetailSideEffect.NavigateToRegisterMenuScreen)
+    }
     fun modifyEventError() = intent {
         postSideEffect(MyStoreDetailSideEffect.ShowErrorModifyEventToast)
     }

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreTopBar.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreTopBar.kt
@@ -9,10 +9,12 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Divider
@@ -127,7 +129,8 @@ fun StoreInfoScreen(
                     painter = painterResource(id = R.drawable.ic_setting),
                     contentDescription = stringResource(R.string.shop_management),
                 )
-                Text(text = stringResource(R.string.shop_management))
+                Spacer(modifier = Modifier.width(1.dp))
+                Text(text = stringResource(R.string.shop_management), color = ColorPrimary, fontSize = 16.sp)
             }
         }
         Text(

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/event/EventToolbar.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/event/EventToolbar.kt
@@ -28,6 +28,7 @@ import `in`.koreatech.business.R
 import `in`.koreatech.business.feature.store.storedetail.MyStoreDetailState
 import `in`.koreatech.business.feature.store.storedetail.MyStoreDetailViewModel
 import `in`.koreatech.business.ui.theme.ColorTextField
+import `in`.koreatech.business.ui.theme.Gray1
 import `in`.koreatech.business.ui.theme.Gray4
 import `in`.koreatech.business.ui.theme.Gray6
 
@@ -139,7 +140,7 @@ fun EventToolbar() {
                 contentDescription = stringResource(R.string.edit)
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text(text = stringResource(R.string.edit))
+            Text(text = stringResource(R.string.edit), color= Gray1)
         }
         Button(
             onClick = { /*TODO*/ },
@@ -155,7 +156,7 @@ fun EventToolbar() {
                 contentDescription = stringResource(R.string.add)
             )
             Spacer(modifier = Modifier.width(8.dp))
-            Text(text = stringResource(R.string.add))
+            Text(text = stringResource(R.string.add), color= Gray1)
         }
     }
 }

--- a/business/src/main/java/in/koreatech/business/feature/storemenu/registermenu/registermenu/RegisterMenuSideEffect.kt
+++ b/business/src/main/java/in/koreatech/business/feature/storemenu/registermenu/registermenu/RegisterMenuSideEffect.kt
@@ -1,15 +1,11 @@
 package `in`.koreatech.business.feature.storemenu.registermenu.registermenu
 
-import `in`.koreatech.business.feature.insertstore.insertmaininfo.BasicInfoErrorType
-import `in`.koreatech.business.feature.insertstore.insertmaininfo.InsertBasicInfoScreenSideEffect
-import `in`.koreatech.business.feature_changepassword.changepassword.ChangePasswordSideEffect
-
 sealed class RegisterMenuSideEffect {
 
-    object GoToCheckMenuScreen: RegisterMenuSideEffect()
+    object GoToCheckMenuScreen : RegisterMenuSideEffect()
 
-    object FinishRegisterMenu: RegisterMenuSideEffect()
-    data class ShowMessage(val type: RegisterMenuErrorType): RegisterMenuSideEffect()
+    object FinishRegisterMenu : RegisterMenuSideEffect()
+    data class ShowMessage(val type: RegisterMenuErrorType) : RegisterMenuSideEffect()
 }
 enum class RegisterMenuErrorType {
     NullMenuName,

--- a/business/src/main/res/values/strings.xml
+++ b/business/src/main/res/values/strings.xml
@@ -175,4 +175,6 @@
     <string name="account_verification_step">1. 계정 인증</string>
     <string name="change_password_step">2. 비밀번호 변경</string>
     <string name="input_auth_code">인증번호를 입력해주세요.</string>
+    <string name="manage_menu">메뉴 관리</string>
+    <string name="register_menu">메뉴 추가</string>
 </resources>


### PR DESCRIPTION

<img src= https://github.com/user-attachments/assets/26945f1e-55ec-46a5-bd26-e99b6fe940ed width="220" height="400">

 2024년도 ui에서는 메뉴 관리/추가 진입점이 없어서 22년도 디자인 참고해서 임의로 추가했습니다..!

[피그마](https://www.figma.com/design/tDCzPQyt4AeWSW7937T10a/KOIN-Mobile?node-id=1-20479&t=6U3PlGB2XH77nu83-0)