### PR TITLE
[Feature] 다이얼로그, 윤곽선 버튼 컴포넌트 추가

### DIFF
--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/button/FilledButton.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/button/FilledButton.kt
@@ -8,28 +8,57 @@ import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 
+
+enum class FilledButtonColors {
+    Primary,
+    Warning,
+    Danger,
+}
+
 @Composable
 fun FilledButton(
-    modifier: Modifier = Modifier,
     text: String,
-    textStyle: TextStyle = KoinTheme.typography.medium15,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = KoinTheme.typography.medium15,
     shape: Shape = RoundedCornerShape(5.dp),
     enabled: Boolean = true,
-    colors: ButtonColors = ButtonDefaults.buttonColors(
-        containerColor = KoinTheme.colors.primary500,
-        contentColor = Color.White,
-        disabledContainerColor = KoinTheme.colors.neutral300,
-        disabledContentColor = KoinTheme.colors.neutral600
-    ),
+    colors: FilledButtonColors = FilledButtonColors.Primary,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+) {
+    val buttonColors = filledButtonColorByType(type = colors)
+    Button(
+        modifier = modifier,
+        onClick = onClick,
+        shape = shape,
+        enabled = enabled,
+        colors = buttonColors,
+        contentPadding = contentPadding
+    ) {
+        Text(
+            text = text,
+            style = textStyle
+        )
+    }
+}
+
+@Composable
+fun FilledButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = KoinTheme.typography.medium15,
+    shape: Shape = RoundedCornerShape(5.dp),
+    enabled: Boolean = true,
+    colors: ButtonColors,
     contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
 ) {
     Button(
@@ -45,6 +74,31 @@ fun FilledButton(
             style = textStyle
         )
     }
+}
+
+@Composable
+@Stable
+internal fun filledButtonColorByType(type: FilledButtonColors): ButtonColors = when (type) {
+    FilledButtonColors.Primary -> ButtonColors(
+        containerColor = KoinTheme.colors.primary500,
+        contentColor = KoinTheme.colors.neutral0,
+        disabledContainerColor = KoinTheme.colors.neutral300,
+        disabledContentColor = KoinTheme.colors.neutral600
+    )
+
+    FilledButtonColors.Warning -> ButtonColors(
+        containerColor = KoinTheme.colors.sub500,
+        contentColor = KoinTheme.colors.neutral0,
+        disabledContainerColor = KoinTheme.colors.neutral300,
+        disabledContentColor = KoinTheme.colors.neutral600
+    )
+
+    FilledButtonColors.Danger -> ButtonColors(
+        containerColor = KoinTheme.colors.danger700,
+        contentColor = KoinTheme.colors.neutral0,
+        disabledContainerColor = KoinTheme.colors.neutral300,
+        disabledContentColor = KoinTheme.colors.neutral600
+    )
 }
 
 @Preview
@@ -69,4 +123,16 @@ private fun FilledButtonDisabledPreview() {
 @Composable
 private fun FilledButtonCustomColorPreview() {
     FilledButton(text = "조회하기", onClick = {}, enabled = false, modifier = Modifier.fillMaxWidth())
+}
+
+@Preview
+@Composable
+private fun FilledButtonWarningPreview() {
+    FilledButton(text = "조회하기", onClick = {}, colors = FilledButtonColors.Warning)
+}
+
+@Preview
+@Composable
+private fun FilledButtonDangerPreview() {
+    FilledButton(text = "조회하기", onClick = {}, colors = FilledButtonColors.Danger)
 }

--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/button/OutlinedBoxButton.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/button/OutlinedBoxButton.kt
@@ -1,0 +1,166 @@
+package `in`.koreatech.koin.core.designsystem.component.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+
+
+enum class OutlinedBoxButtonColors {
+    Primary,
+    Neutral
+}
+
+/**
+ * 테두리 선이 있는 텍스트 버튼
+ * @param text 텍스트
+ * @param onClick 버튼 클릭시 실행할 함수
+ * @param textStyle 텍스트 스타일
+ * @param shape 버튼 모양
+ * @param enabled 버튼 활성화 여부
+ * @param colors 버튼 색상 타입
+ * @param contentPadding 버튼 내부 padding
+ * @see OutlinedBoxButtonColors
+ */
+@Composable
+fun OutlinedBoxButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = KoinTheme.typography.medium15,
+    shape: Shape = KoinTheme.shapes.extraSmall,
+    enabled: Boolean = true,
+    colors: OutlinedBoxButtonColors = OutlinedBoxButtonColors.Primary,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+) {
+    val buttonColors = outlinedBoxButtonColorByType(colors)
+    val buttonBorder = outlinedBoxButtonBorderByType(colors)
+
+    OutlinedButton(
+        modifier = modifier,
+        onClick = onClick,
+        enabled = enabled,
+        shape = shape,
+        colors = buttonColors,
+        border = buttonBorder,
+        contentPadding = contentPadding,
+    ) {
+        Text(
+            text = text,
+            style = textStyle
+        )
+    }
+}
+
+
+/**
+ * 테두리 선이 있는 텍스트 버튼
+ * @param text 텍스트
+ * @param onClick 버튼 클릭시 실행할 함수
+ * @param textStyle 텍스트 스타일
+ * @param shape 버튼 모양
+ * @param enabled 버튼 활성화 여부
+ * @param colors 버튼 색상
+ * @param border 테두리 선
+ * @param contentPadding 버튼 내부 padding
+ * @see OutlinedBoxButtonColors
+ */
+@Composable
+fun OutlinedBoxButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = KoinTheme.typography.medium15,
+    shape: Shape = KoinTheme.shapes.extraSmall,
+    enabled: Boolean = true,
+    colors: ButtonColors = ButtonColors(
+        containerColor = KoinTheme.colors.neutral0,
+        contentColor = KoinTheme.colors.neutral0,
+        disabledContainerColor = KoinTheme.colors.neutral400,
+        disabledContentColor = KoinTheme.colors.neutral500
+    ),
+    border: BorderStroke,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+) {
+    OutlinedButton(
+        modifier = modifier,
+        onClick = onClick,
+        enabled = enabled,
+        shape = shape,
+        colors = colors,
+        border = border,
+        contentPadding = contentPadding,
+    ) {
+        Text(
+            text = text,
+            style = textStyle
+        )
+    }
+}
+
+@Composable
+@Stable
+internal fun outlinedBoxButtonColorByType(type: OutlinedBoxButtonColors): ButtonColors = when (type) {
+    OutlinedBoxButtonColors.Primary -> ButtonColors(
+        containerColor = KoinTheme.colors.neutral0,
+        contentColor = KoinTheme.colors.primary500,
+        disabledContainerColor = KoinTheme.colors.neutral400,
+        disabledContentColor = KoinTheme.colors.neutral500
+    )
+
+    OutlinedBoxButtonColors.Neutral -> ButtonColors(
+        containerColor = KoinTheme.colors.neutral0,
+        contentColor = KoinTheme.colors.neutral500,
+        disabledContainerColor = KoinTheme.colors.neutral400,
+        disabledContentColor = KoinTheme.colors.neutral500
+    )
+}
+
+
+@Composable
+@Stable
+internal fun outlinedBoxButtonBorderByType(type: OutlinedBoxButtonColors): BorderStroke = when (type) {
+    OutlinedBoxButtonColors.Primary -> BorderStroke(
+        1.0.dp,
+        color = KoinTheme.colors.primary500
+    )
+
+    OutlinedBoxButtonColors.Neutral -> BorderStroke(
+        1.0.dp,
+        color = KoinTheme.colors.neutral500
+    )
+}
+
+
+@Preview
+@Composable
+private fun OutlinedButtonPrimaryPreview() {
+    KoinTheme {
+        OutlinedBoxButton(
+            text = "대체하기",
+            onClick = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun OutlinedButtonNeutralPreview() {
+    KoinTheme {
+        OutlinedBoxButton(
+            text = "대체하기",
+            colors = OutlinedBoxButtonColors.Neutral,
+            onClick = {}
+        )
+    }
+}

--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/dialog/ChoiceDialog.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/dialog/ChoiceDialog.kt
@@ -1,0 +1,229 @@
+package `in`.koreatech.koin.core.designsystem.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.R
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButtonColors
+import `in`.koreatech.koin.core.designsystem.component.button.OutlinedBoxButton
+import `in`.koreatech.koin.core.designsystem.component.button.OutlinedBoxButtonColors
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+
+
+/**
+ * 긍정, 부정 버튼이 있는 다이얼로그
+ * @param title 다이얼로그 제목 텍스트
+ * @param description 제목에 대한 설명 텍스트
+ * @param onPositive 긍정 버튼 클릭시 동작할 함수
+ * @param onNegative 부정 버튼 클릭시 동작할 함수
+ * @param titleStyle 제목 텍스트 스타일
+ * @param descriptionStyle 설명 텍스트 스타일
+ * @param negativeButtonText 부정 버튼 텍스트
+ * @param positiveButtonText 긍정 버튼 텍스트
+ * @param positiveButtonColors 긍정 버튼 색상
+ * @param negativeButtonColors 부정 버튼 색상
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChoiceDialog(
+    title: String,
+    description: String,
+    onPositive: () -> Unit,
+    onNegative: () -> Unit,
+    modifier: Modifier = Modifier,
+    titleStyle: TextStyle = KoinTheme.typography.medium18,
+    descriptionStyle: TextStyle = KoinTheme.typography.regular14,
+    positiveButtonText: String = stringResource(id = R.string.common_confirmation),
+    negativeButtonText: String = stringResource(id = R.string.common_cancellation),
+    positiveButtonColors: FilledButtonColors = FilledButtonColors.Primary,
+    negativeButtonColors: OutlinedBoxButtonColors = OutlinedBoxButtonColors.Neutral,
+//    cancellable: Boolean = true,
+) {
+    BasicAlertDialog(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .background(
+                color = KoinTheme.colors.neutral0,
+                shape = KoinTheme.shapes.extraSmall
+            )
+            .padding(horizontal = 32.dp, vertical = 24.dp),
+        onDismissRequest = { onNegative() }
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                style = titleStyle
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = description,
+                style = descriptionStyle
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedBoxButton(
+                    modifier = Modifier.weight(1.0F),
+                    text = negativeButtonText,
+                    onClick = onNegative,
+                    colors = negativeButtonColors
+                )
+                FilledButton(
+                    modifier = Modifier.weight(1.0F),
+                    text = positiveButtonText,
+                    onClick = onPositive,
+                    colors = positiveButtonColors
+                )
+            }
+        }
+    }
+}
+
+
+/**
+ * 긍정, 부정 버튼이 있는 다이얼로그
+ * @param title 다이얼로그 제목 컴포저블
+ * @param description 제목에 대한 설명 컴포저블
+ * @param onPositive 긍정 버튼 클릭시 동작할 함수
+ * @param onNegative 부정 버튼 클릭시 동작할 함수
+ * @param negativeButtonText 부정 버튼 텍스트
+ * @param positiveButtonText 긍정 버튼 텍스트
+ * @param positiveButtonColors 긍정 버튼 색상
+ * @param negativeButtonColors 부정 버튼 색상
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChoiceDialog(
+    title: @Composable () -> Unit,
+    description: @Composable () -> Unit,
+    onPositive: () -> Unit,
+    onNegative: () -> Unit,
+    modifier: Modifier = Modifier,
+    positiveButtonText: String = stringResource(id = R.string.common_confirmation),
+    negativeButtonText: String = stringResource(id = R.string.common_cancellation),
+    positiveButtonColors: FilledButtonColors = FilledButtonColors.Primary,
+    negativeButtonColors: OutlinedBoxButtonColors = OutlinedBoxButtonColors.Neutral,
+//    cancellable: Boolean = true,
+) {
+    BasicAlertDialog(
+        modifier = modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+            .background(
+                color = KoinTheme.colors.neutral0,
+                shape = KoinTheme.shapes.extraSmall
+            )
+            .padding(horizontal = 32.dp, vertical = 24.dp),
+        onDismissRequest = { onNegative() }
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            title()
+            Spacer(modifier = Modifier.height(8.dp))
+            description()
+            Spacer(modifier = Modifier.height(24.dp))
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                OutlinedBoxButton(
+                    modifier = Modifier.weight(1.0F),
+                    text = negativeButtonText,
+                    onClick = onNegative,
+                    colors = negativeButtonColors
+                )
+                FilledButton(
+                    modifier = Modifier.weight(1.0F),
+                    text = positiveButtonText,
+                    onClick = onPositive,
+                    colors = positiveButtonColors
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ChoiceDialogPreview() {
+    KoinTheme {
+        ChoiceDialog(
+            title = "다이얼로그 제목",
+            description = "이러쿵 저러쿵 이러쿵 저러쿵 이러쿵 저러쿵 이러쿵 저러쿵 ",
+            descriptionStyle = KoinTheme.typography.regular14.copy(
+                color = KoinTheme.colors.neutral500
+            ),
+            onPositive = {},
+            onNegative = {},
+        )
+    }
+}
+
+
+@Preview
+@Composable
+private fun ChoiceDialogComposableTextPreview() {
+    KoinTheme {
+        ChoiceDialog(
+            title = {
+                Text(
+                    text = buildAnnotatedString {
+                        withStyle(KoinTheme.typography.medium16.toSpanStyle()) {
+                            append("이렇게 ")
+                        }
+                        withStyle(KoinTheme.typography.bold16.toSpanStyle()) {
+                            append("강조하는")
+                        }
+                        withStyle(KoinTheme.typography.medium16.toSpanStyle()) {
+                            append(" 제목은 컴포저블로")
+                        }
+                    },
+                    textAlign = TextAlign.Center
+                )
+            },
+            description = {
+                Text(
+                    text = buildAnnotatedString {
+                        withStyle(KoinTheme.typography.regular16.toSpanStyle()) {
+                            append("설명하는 부분도 ")
+                        }
+                        withStyle(KoinTheme.typography.medium16.copy(color = KoinTheme.colors.danger700).toSpanStyle()) {
+                            append("이렇게 강조하는")
+                        }
+                        withStyle(KoinTheme.typography.regular16.toSpanStyle()) {
+                            append(" 컴포저블로 추가할 수 있습니다")
+                        }
+                    },
+                    textAlign = TextAlign.Center
+                )
+            },
+            onPositive = {},
+            onNegative = {},
+            positiveButtonColors = FilledButtonColors.Warning
+        )
+    }
+}

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
+    <string name="common_cancellation">취소</string>
+    <string name="common_confirmation">확인</string>
     <!-- Content Description -->
     <string name="navigate_up_content_description">뒤로가기</string>
 </resources>

--- a/data/src/main/java/in/koreatech/koin/data/response/ErrorResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/ErrorResponse.kt
@@ -1,10 +1,14 @@
 package `in`.koreatech.koin.data.response
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ErrorResponse(
+    @SerialName("message")
     val message: String?,
+    @SerialName("code")
     val code: String?,
+    @SerialName("errorTraceId")
     val errorTraceId: String?
 )

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/TextCheckbox.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/TextCheckbox.kt
@@ -1,0 +1,86 @@
+package `in`.koreatech.koin.feature.timetable.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalMinimumInteractiveComponentEnforcement
+import androidx.compose.material3.Text
+import androidx.compose.material3.TriStateCheckbox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.state.ToggleableState
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.noRippleClickable
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TextCheckbox(
+    text: String,
+    textStyle: TextStyle,
+    isChecked: Boolean,
+    onCheckChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.noRippleClickable {
+            onCheckChanged(!isChecked)
+        },
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
+            TriStateCheckbox(
+                state = ToggleableState(isChecked),
+                onClick = null,
+                colors = CheckboxDefaults.colors().copy(
+                    checkedBoxColor = KoinTheme.colors.primary500,
+                    checkedCheckmarkColor = KoinTheme.colors.neutral0,
+                    checkedBorderColor = KoinTheme.colors.primary500,
+                    uncheckedBoxColor = KoinTheme.colors.neutral0,
+                    uncheckedCheckmarkColor = KoinTheme.colors.neutral0,
+                    uncheckedBorderColor = KoinTheme.colors.neutral400
+                )
+            )
+        }
+        Text(
+            text = text,
+            style = textStyle
+        )
+    }
+}
+
+@Preview()
+@Composable
+private fun TextCheckboxCheckedPreview() {
+    KoinTheme {
+        TextCheckbox(
+            modifier = Modifier.background(KoinTheme.colors.neutral0),
+            text = "체크박스",
+            textStyle = KoinTheme.typography.regular15,
+            isChecked = true,
+            onCheckChanged = {}
+        )
+    }
+}
+
+@Preview()
+@Composable
+private fun TextCheckboxUncheckedPreview() {
+    KoinTheme {
+        TextCheckbox(
+            modifier = Modifier.background(KoinTheme.colors.neutral0),
+            text = "체크박스",
+            textStyle = KoinTheme.typography.regular15,
+            isChecked = false,
+            onCheckChanged = {}
+        )
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 긍정, 부정 버튼이 존재하는 다이얼로그 컴포넌트 `ChoiceDialog`를 추가했습니다
- 테두리만 존재하는 버튼 컴포넌트 `OutlinedBoxButton`을 추가했습니다
- 색 채운 버튼 컴포넌트 `FilledButton` 의 색상을 개선해봤습니다
- ErrorResponse 에 SerialName 을 명시해주었습니다.

## 사진
### ChoiceDialog
<img src="https://github.com/user-attachments/assets/fff2bc27-0fbb-41f5-aead-cd23838b20c4" width=250>

### OutlinedBoxButton
<img src="https://github.com/user-attachments/assets/7b4c8643-4de2-4161-9ab5-cdabc9fa1347" width=250>

### FilledButton
<img src="https://github.com/user-attachments/assets/33d536a0-9f0b-4546-86d6-50c34c8103d7" width=250>

## 하고 싶은 말
자주 사용하는 버튼 색상은 컬러 타입을 지정해서 간단하게 구현하면 좋을 거 같아서 한번 개선해봤어요!

`OutlinedButton` 이름이 머터리얼에서 사용중이라 컴포넌트 이름을 `OutlinedBoxButton` 이라고 해줬는데, 일관성을 위해서 `FilledButton` 컴포넌트 이름을 `FilledBoxButton` 으로 변경하는건 어떨까요? 🙄