### PR TITLE
[Refactor] kapt 에서 ksp로 마이그레이션

### DIFF
--- a/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
@@ -12,6 +12,7 @@ internal class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
                 apply("org.jetbrains.kotlin.android")
                 apply("kotlin-kapt")
                 apply("kotlin-parcelize")
+                apply("com.google.devtools.ksp")
             }
             extensions.configure<ApplicationExtension> {
                 configureAndroidCompose(this)

--- a/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationComposeConventionPlugin.kt
@@ -10,7 +10,6 @@ internal class AndroidApplicationComposeConventionPlugin : Plugin<Project> {
             with(pluginManager) {
                 apply("com.android.application")
                 apply("org.jetbrains.kotlin.android")
-                apply("kotlin-kapt")
                 apply("kotlin-parcelize")
                 apply("com.google.devtools.ksp")
             }

--- a/build-logic/convention/src/main/java/AndroidApplicationHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationHiltConventionPlugin.kt
@@ -1,5 +1,6 @@
 import `in`.koreatech.convention.implementation
 import `in`.koreatech.convention.kapt
+import `in`.koreatech.convention.ksp
 import `in`.koreatech.convention.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -13,7 +14,7 @@ internal class AndroidApplicationHiltConventionPlugin : Plugin<Project> {
             }
             dependencies {
                 implementation(libs.findBundle("hilt").get())
-                kapt(libs.findLibrary("hilt-compiler").get())
+                ksp(libs.findLibrary("hilt-compiler").get())
             }
         }
     }

--- a/build-logic/convention/src/main/java/AndroidApplicationHiltConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidApplicationHiltConventionPlugin.kt
@@ -1,5 +1,4 @@
 import `in`.koreatech.convention.implementation
-import `in`.koreatech.convention.kapt
 import `in`.koreatech.convention.ksp
 import `in`.koreatech.convention.libs
 import org.gradle.api.Plugin

--- a/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
@@ -12,7 +12,6 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("com.android.library")
-                apply("org.jetbrains.kotlin.kapt")
                 apply("org.jetbrains.kotlin.android")
                 apply("com.google.devtools.ksp")
             }

--- a/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidLibraryConventionPlugin.kt
@@ -14,6 +14,7 @@ internal class AndroidLibraryConventionPlugin : Plugin<Project> {
                 apply("com.android.library")
                 apply("org.jetbrains.kotlin.kapt")
                 apply("org.jetbrains.kotlin.android")
+                apply("com.google.devtools.ksp")
             }
             extensions.configure<LibraryExtension> {
                 configureAndroidLibrary(this)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ plugins {
     alias(libs.plugins.kotlinx.serialization) apply false
     alias(libs.plugins.google.service) apply false
     alias(libs.plugins.androidLibrary) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -62,7 +62,7 @@ dependencies {
 
     /* Dependency - glide */
     api(libs.glide)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.ksp)
 
     /* Dependency - sticky scroll view */
     api(libs.stickyScrollView)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     debugImplementation(libs.leakcanary.android)
 
     /* Dependency - glide */
-    api(libs.glide)
+    implementation(libs.glide)
     ksp(libs.glide.ksp)
 
     /* Dependency - sticky scroll view */

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -64,10 +64,6 @@ dependencies {
     api(libs.glide)
     kapt(libs.glide.compiler)
 
-    /* Dependency - butterknife */
-    api(libs.butterknife)
-    kapt(libs.butterknife.compiler)
-
     /* Dependency - sticky scroll view */
     api(libs.stickyScrollView)
 

--- a/core/onboarding/build.gradle.kts
+++ b/core/onboarding/build.gradle.kts
@@ -6,9 +6,7 @@ plugins {
 android {
     namespace = "in.koreatech.koin.core.onboarding"
 }
-kapt {
-    correctErrorTypes = true
-}
+
 dependencies {
     implementation(project(":domain"))
 

--- a/core/src/main/java/in/koreatech/koin/core/dialog/ImageZoomableDialog.kt
+++ b/core/src/main/java/in/koreatech/koin/core/dialog/ImageZoomableDialog.kt
@@ -86,15 +86,15 @@ class ImageZoomableDialog(private val context: Context, private val image: Strin
                 override fun onLoadFailed(
                     e: GlideException?,
                     model: Any?,
-                    target: Target<Drawable>?,
+                    target: Target<Drawable>,
                     isFirstResource: Boolean
                 ): Boolean = false
 
                 override fun onResourceReady(
-                    resource: Drawable?,
-                    model: Any?,
-                    target: Target<Drawable>?,
-                    dataSource: DataSource?,
+                    resource: Drawable,
+                    model: Any,
+                    target: Target<Drawable>,
+                    dataSource: DataSource,
                     isFirstResource: Boolean
                 ): Boolean {
                     binding.photoView.post {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,7 +46,7 @@ securityCryptoVersion = "1.1.0-alpha03"
 stickyscrollviewVersion = "1.0.2"
 strictVersionMatcherPlugin = "1.2.4"
 composeCompilerVersion = "1.5.10"
-glideVersion = "4.9.0"
+glideVersion = "4.14.2"
 googleServiceVersion = "4.3.14"
 composeNavigationVersion = "2.7.7"
 orbitVersion = "7.0.1"
@@ -69,6 +69,7 @@ timber = "5.0.1"
 kotlinxCoroutinesTestVersion = "1.9.0"
 turbineVersion = "1.2.0"
 kotlinxCollectionsImmutableVersion = "0.3.8"
+kspVersion = "1.9.22-1.0.16"
 
 
 [libraries]
@@ -150,7 +151,7 @@ rxjava-android = { module = "io.reactivex.rxjava2:rxandroid", version.ref = "rxa
 stickyScrollView = { module = "com.github.amarjain07:StickyScrollView", version.ref = "stickyscrollviewVersion" }
 strict-version-matcher-plugin = { module = "com.google.android.gms:strict-version-matcher-plugin", version.ref = "strictVersionMatcherPlugin" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
-glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
+glide-ksp = { module = "com.github.bumptech.glide:ksp", version.ref = "glideVersion" }
 viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.0.0" }
 
 orbit-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbitVersion" }
@@ -202,6 +203,7 @@ kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", vers
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltVersion" }
 androidLibrary = { id = "com.android.library", version.ref = "androidGradleVersion" }
 google-service = { id = "com.google.gms.google-services", version.ref = "googleServiceVersion" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
 
 koin-application = { id = "in.koreatech.plugin.application", version = "unspecified" }
 koin-compose = { id = "in.koreatech.plugin.compose", version = "unspecified" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,6 @@ stickyscrollviewVersion = "1.0.2"
 strictVersionMatcherPlugin = "1.2.4"
 composeCompilerVersion = "1.5.10"
 glideVersion = "4.9.0"
-butterknifeVersion = "10.1.0"
 googleServiceVersion = "4.3.14"
 composeNavigationVersion = "2.7.7"
 orbitVersion = "7.0.1"
@@ -152,8 +151,6 @@ stickyScrollView = { module = "com.github.amarjain07:StickyScrollView", version.
 strict-version-matcher-plugin = { module = "com.google.android.gms:strict-version-matcher-plugin", version.ref = "strictVersionMatcherPlugin" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glideVersion" }
 glide-compiler = { module = "com.github.bumptech.glide:compiler", version.ref = "glideVersion" }
-butterknife = { module = "com.jakewharton:butterknife", version.ref = "butterknifeVersion" }
-butterknife-compiler = { module = "com.jakewharton:butterknife-compiler", version.ref = "butterknifeVersion" }
 viewpager2 = { module = "androidx.viewpager2:viewpager2", version = "1.0.0" }
 
 orbit-core = { module = "org.orbit-mvi:orbit-core", version.ref = "orbitVersion" }

--- a/koin/build.gradle.kts
+++ b/koin/build.gradle.kts
@@ -115,8 +115,6 @@ dependencies {
     implementation(libs.inApp.update.ktx)
     implementation(libs.feature.delivery.ktx)
 
-    // https://github.com/irshuLx/Android-WYSIWYG-Editor
-    implementation(libs.laser.native.editor)
     implementation(libs.colorpicker)
     implementation(libs.photoview)
 

--- a/koin/build.gradle.kts
+++ b/koin/build.gradle.kts
@@ -105,7 +105,7 @@ dependencies {
     /* Dependency - glide & coil */
     implementation(libs.glide)
     implementation(libs.coil)
-    kapt(libs.glide.compiler)
+    ksp(libs.glide.ksp)
 
     /* Dependency - naver api */
     implementation(libs.map.sdk)

--- a/koin/build.gradle.kts
+++ b/koin/build.gradle.kts
@@ -107,10 +107,6 @@ dependencies {
     implementation(libs.coil)
     kapt(libs.glide.compiler)
 
-    /* Dependency - butterknife api */
-    implementation(libs.butterknife)
-    kapt(libs.butterknife.compiler)
-
     /* Dependency - naver api */
     implementation(libs.map.sdk)
 

--- a/koin/src/main/AndroidManifest.xml
+++ b/koin/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
         android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme.NoActionBar"
+        android:theme="@style/KAPTheme.NoActionBar"
         android:usesCleartextTraffic="true"
         tools:replace="icon,label">
 

--- a/koin/src/main/java/in/koreatech/koin/GlideModule.kt
+++ b/koin/src/main/java/in/koreatech/koin/GlideModule.kt
@@ -1,0 +1,7 @@
+package `in`.koreatech.koin
+
+import com.bumptech.glide.annotation.GlideModule
+import com.bumptech.glide.module.AppGlideModule
+
+@GlideModule
+class GlideModule: AppGlideModule()

--- a/koin/src/main/java/in/koreatech/koin/ui/article/HtmlView.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/HtmlView.kt
@@ -130,17 +130,17 @@ class HtmlView @JvmOverloads constructor(
             override fun onLoadFailed(
                 e: GlideException?,
                 model: Any?,
-                target: com.bumptech.glide.request.target.Target<Drawable>?,
+                target: com.bumptech.glide.request.target.Target<Drawable>,
                 isFirstResource: Boolean
             ): Boolean {
                 return false
             }
 
             override fun onResourceReady(
-                resource: Drawable?,
-                model: Any?,
-                target: com.bumptech.glide.request.target.Target<Drawable>?,
-                dataSource: DataSource?,
+                resource: Drawable,
+                model: Any,
+                target: com.bumptech.glide.request.target.Target<Drawable>,
+                dataSource: DataSource,
                 isFirstResource: Boolean
             ): Boolean {
                 val dialog = ImageZoomableDialog(context, model as String)

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningAdapter.kt
@@ -72,17 +72,17 @@ class DiningAdapter(
                             override fun onLoadFailed(
                                 e: GlideException?,
                                 model: Any?,
-                                target: Target<Drawable>?,
+                                target: Target<Drawable>,
                                 isFirstResource: Boolean
                             ): Boolean {
                                 return false
                             }
 
                             override fun onResourceReady(
-                                resource: Drawable?,
-                                model: Any?,
-                                target: Target<Drawable>?,
-                                dataSource: DataSource?,
+                                resource: Drawable,
+                                model: Any,
+                                target: Target<Drawable>,
+                                dataSource: DataSource,
                                 isFirstResource: Boolean
                             ): Boolean {
                                 binding.lottieImageLoading.pauseAnimation()

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningOriginalAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/adapter/DiningOriginalAdapter.kt
@@ -73,17 +73,17 @@ class DiningOriginalAdapter(
                             override fun onLoadFailed(
                                 e: GlideException?,
                                 model: Any?,
-                                target: Target<Drawable>?,
+                                target: Target<Drawable>,
                                 isFirstResource: Boolean
                             ): Boolean {
                                 return false
                             }
 
                             override fun onResourceReady(
-                                resource: Drawable?,
-                                model: Any?,
-                                target: Target<Drawable>?,
-                                dataSource: DataSource?,
+                                resource: Drawable,
+                                model: Any,
+                                target: Target<Drawable>,
+                                dataSource: DataSource,
                                 isFirstResource: Boolean
                             ): Boolean {
                                 binding.lottieImageLoading.pauseAnimation()

--- a/koin/src/main/java/in/koreatech/koin/ui/error/ErrorActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/error/ErrorActivity.kt
@@ -1,20 +1,10 @@
 package `in`.koreatech.koin.ui.error
 
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import android.view.Gravity
-import android.view.View
-import android.widget.Button
-import android.widget.LinearLayout
-import android.widget.TextView
-import android.widget.Toast
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import butterknife.BindView
-import butterknife.OnClick
 import `in`.koreatech.koin.BuildConfig
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase

--- a/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreDetailFlyerFullRecyclerAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreDetailFlyerFullRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.ui.store.adapter
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,9 +7,6 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnItemClick
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import `in`.koreatech.koin.R

--- a/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreDetailFlyerRecyclerAdapter.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/adapter/StoreDetailFlyerRecyclerAdapter.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.ui.store.adapter
 
-import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -8,9 +7,6 @@ import android.widget.ImageView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import butterknife.BindView
-import butterknife.ButterKnife
-import butterknife.OnItemClick
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import `in`.koreatech.koin.R

--- a/koin/src/main/res/drawable/baseline_arrow_back_24.xml
+++ b/koin/src/main/res/drawable/baseline_arrow_back_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:autoMirrored="true" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/koin/src/main/res/layout/activity_dining_notice.xml
+++ b/koin/src/main/res/layout/activity_dining_notice.xml
@@ -19,7 +19,7 @@
             android:layout_height="0dp"
             android:layout_marginStart="16dp"
             android:padding="8dp"
-            android:src="@drawable/ic_arrow_back_black_24dp"
+            android:src="@drawable/ic_arrow_back_black_24"
             app:layout_constraintBottom_toBottomOf="@id/tv_dining_notice_topbar"
             app:layout_constraintDimensionRatio="1"
             app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### 요약
- 기존 hilt, glide kapt 의존성을 제거하고 ksp 플러그인을 추가했습니다.
- 빌드 시, kapt Java stub task 를 줄일 수 있습니다. 즉, 빌드 속도를 향상할 수 있습니다.
- debug, release, R8, CD 모든 테스트를 성공하고 PR을 올렸습니다!

Test a build (여러번 테스트를 위해서는 Benchmark build 를 참고해보시면 평균적인 build 속도를 테스트해볼 수 있을겁니다!)
```
./gradlew --profile --offline --rerun-tasks :koin:aseembleDebug
```


결과적으로 아래처럼 kapt 대신 ksp를 사용하면서 빌드 속도를 개선할 수 있었습니다.

<img width="518" alt="스크린샷 2024-12-15 오후 11 53 01" src="https://github.com/user-attachments/assets/be2b2aef-2675-4a9c-a11f-1aaa5f411d39" />




### 리뷰어에게
Hilt & Dagger ksp 가 In progress & Alpha 단계에 있어서 걱정하며 마이그레이션을 해도 괜찮을까? 하며 작업했습니다. 
하지만 몇 가지를 이유로 PR을 올리게되었습니다.
- kapt 에서 ksp 마이그레이션으로 빌드 속도 향상을 직관적으로 보여주기 위함입니다.
- KSP 를 Google 에서 권장하는 어노테이션 프로세싱 도구이기 때문입니다.
- 미래지향적으로 KSP를 선도입 해보기도 있습니다.
- 개인적으로 기술적인 호기심도 있습니다.

여러가지 이유가 있지만 그래도 안정적이지 않다는 이유가 제 발목을 잡았는데요. 테스트 결과 괜찮았기 때문에 PR을 올려봤습니다.
팀원들의 의견을 들어 해당 PR을 합쳐도 될지 여쭤보고 싶습니다. 다들 적극적인 의견 달아주세요 ☺️

코인 프로젝트 kapt 에서 ksp로 마이그레이션하면서 트러블 슈팅과 관련 내용을 블로그에 포스팅하였고, 기회가 된다면 작은 세미나를 열어 설명드릴 수 있는 기회가 있으면 좋을 것 같습니다 🙇🏻