### PR TITLE
[Fix] 화면이 회전된 상태에서 앱 실행시 크래시 픽스

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
@@ -104,8 +104,12 @@ class LandActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
         if (mapFragment == null) {
             mapFragment = NaverMapFragment().newInstance(options)
         }
-        supportFragmentManager.beginTransaction().add(R.id.activity_land_navermap, mapFragment!!)
-            .commit()
+
+        if (!mapFragment!!.isAdded) {
+            supportFragmentManager.beginTransaction().add(R.id.activity_land_navermap, mapFragment!!)
+                .commit()
+        }
+
         mapFragment.getMapAsync(this)
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/land/LandDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/land/LandDetailActivity.kt
@@ -1,15 +1,5 @@
 package `in`.koreatech.koin.ui.land
 
-import `in`.koreatech.koin.R
-import `in`.koreatech.koin.constant.LAND
-import `in`.koreatech.koin.core.appbar.AppBarBase
-import `in`.koreatech.koin.databinding.LandActivityDetailBinding
-import `in`.koreatech.koin.domain.model.land.LandDetail
-import `in`.koreatech.koin.ui.land.adapter.LandDetailViewPagerAdapter
-import `in`.koreatech.koin.ui.land.viewmodel.LandDetailViewModel
-import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
-import `in`.koreatech.koin.ui.navigation.state.MenuState
-import `in`.koreatech.koin.util.ext.dpToIntPx
 import android.graphics.PorterDuff
 import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
@@ -29,6 +19,16 @@ import com.naver.maps.map.NaverMapOptions
 import com.naver.maps.map.OnMapReadyCallback
 import com.naver.maps.map.overlay.Marker
 import com.naver.maps.map.overlay.OverlayImage
+import `in`.koreatech.koin.R
+import `in`.koreatech.koin.constant.LAND
+import `in`.koreatech.koin.core.appbar.AppBarBase
+import `in`.koreatech.koin.databinding.LandActivityDetailBinding
+import `in`.koreatech.koin.domain.model.land.LandDetail
+import `in`.koreatech.koin.ui.land.adapter.LandDetailViewPagerAdapter
+import `in`.koreatech.koin.ui.land.viewmodel.LandDetailViewModel
+import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
+import `in`.koreatech.koin.ui.navigation.state.MenuState
+import `in`.koreatech.koin.util.ext.dpToIntPx
 
 class LandDetailActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
     override val menuState = MenuState.Land
@@ -204,8 +204,10 @@ class LandDetailActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
         if (mapFragment == null) {
             mapFragment = NaverMapFragment().newInstance(options)
         }
-        supportFragmentManager.beginTransaction()
-            .add(R.id.activity_land_detail_navermap, mapFragment!!).commit()
+        if (!mapFragment!!.isAdded) {
+            supportFragmentManager.beginTransaction()
+                .add(R.id.activity_land_detail_navermap, mapFragment!!).commit()
+        }
         mapFragment.getMapAsync(this)
     }
 

--- a/koin/src/main/java/in/koreatech/koin/util/ext/SpinnerExtension.kt
+++ b/koin/src/main/java/in/koreatech/koin/util/ext/SpinnerExtension.kt
@@ -9,13 +9,13 @@ import android.widget.Spinner
 inline fun <T : Adapter> AdapterView<T>.setOnItemSelectedListener(
     crossinline nothingSelected: (AdapterView<*>) -> Unit = {},
     crossinline itemSelected: (
-        parent: AdapterView<*>,
-        view: View,
+        parent: AdapterView<*>?,
+        view: View?,
         position: Int,
         id: Long) -> Unit
 ) {
     this.onItemSelectedListener = object : OnItemSelectedListener {
-        override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+        override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
             itemSelected(parent, view, position, id)
         }
 


### PR DESCRIPTION
### 작업내용
* 화면이 가로로 돌아간 상태에서 복덕방 및버스/교통 진입 시 크래시가 나는 문제를 해결하였습니다.

### 고민
현재 코인은 가로모드를 지원하지 않습니다.
그로 인해, ActivityBase에 아래와 같은 코드를 사용하여 세로모드를 강제하고 있습니다.
```
requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
```
다만, 해당 코드는 액티비티 실행 후 적용되는데 약간의 시간이 소요되는것 같습니다.
그로 인해, 가로로 기기를 돌린 상태에서 액티비티를 실행하면, 가로모드로 켜졌다가 세로로 고정되는 걸 확인할 수 있습니다.

그렇기 때문에 manifest에 `android:screenOrientation="portrait"`를 각 액티비티마다 넣어서 처음부터 세로모드로 강제되도록 하는게 어떨까 싶은데, 다른 분들의 의견이 궁금합니다!