### PR TITLE
[Fix] 다른 계정으로 로그인 할 시 유저 정보 갱신 안되는 문제 수정 

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -2,9 +2,9 @@ package `in`.koreatech.koin.data.repository
 
 import `in`.koreatech.koin.data.mapper.toUser
 import `in`.koreatech.koin.data.mapper.toUserRequest
+import `in`.koreatech.koin.data.mapper.toUserRequestWithPassword
 import `in`.koreatech.koin.data.request.owner.OwnerLoginRequest
 import `in`.koreatech.koin.data.request.user.ABTestRequest
-import `in`.koreatech.koin.data.mapper.toUserRequestWithPassword
 import `in`.koreatech.koin.data.request.user.IdRequest
 import `in`.koreatech.koin.data.request.user.LoginRequest
 import `in`.koreatech.koin.data.request.user.PasswordRequest
@@ -43,15 +43,21 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override fun ownerTokenIsValid(): Boolean {
-        return runBlocking{
+        return runBlocking {
             try {
                 userRemoteDataSource.ownerTokenIsValid()
                 true
-            } catch (e: HttpException){
+            } catch (e: HttpException) {
                 if (e.code() == 401) false
                 else throw e
             }
 
+        }
+    }
+
+    override suspend fun fetchUserInfo() {
+        userRemoteDataSource.getUserInfo().toUser().also {
+            userLocalDataSource.updateUserInfo(it)
         }
     }
 
@@ -131,6 +137,7 @@ class UserRepositoryImpl @Inject constructor(
             return ABTest(it.variableName, it.accessHistoryId)
         }
     }
+
     override suspend fun updateUserPassword(user: User, hashedPassword: String) {
         when (user) {
             User.Anonymous -> throw IllegalAccessException("Updating anonymous user is not supported")

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
@@ -17,6 +17,7 @@ interface UserRepository {
     ): AuthToken
 
     fun ownerTokenIsValid(): Boolean
+    suspend fun fetchUserInfo()
     suspend fun getUserInfo(): User
     fun getUserInfoFlow(): Flow<User>
     suspend fun requestPasswordResetEmail(email: String)

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCase.kt
@@ -20,6 +20,7 @@ class UserLoginUseCase @Inject constructor(
             val authToken = userRepository.getToken(email, password.toSHA256())
             tokenRepository.saveAccessToken(authToken.token)
             tokenRepository.saveRefreshToken(authToken.refreshToken)
+            userRepository.fetchUserInfo()
             Unit to null
         } catch (throwable: Throwable) {
             null to userErrorHandler.handleGetTokenError(throwable)


### PR DESCRIPTION
### 개요
다른 계정으로 로그인 시 이전 계정의 유저 정보가 보이던 문제입니다

### 작업 내용 
로그인 시 유저 정보를 한 번 가져오도록 수정했어요

### 하고싶은 말
유저 정보 부분이 많이 복잡하네요.. 😥 시간표 작업 끝내고 시간 나는대로 개선해보도록 하겠습니당