### PR TITLE
Dark theme에서 Status bar 색상 수정

### DIFF
--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/theme/Theme.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.core.designsystem.theme
 
+import android.app.Activity
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -10,7 +11,10 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
 
 internal val LocalKoinColorPalette = staticCompositionLocalOf {
     KoinLightColorPalette
@@ -58,6 +62,7 @@ internal val LocalShapes = staticCompositionLocalOf {
 fun KoinTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicTheme: Boolean = true,
+    isLightStatusBar: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val extendedColors =
@@ -129,6 +134,20 @@ fun KoinTheme(
             shapes = Shapes,
             content = content
         )
+    }
+
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            if (view.context is Activity) {
+                /*
+                We need to check view.context is Activity
+                because when we call KoinTheme inside ComposeView, view.context is not Activity
+                */
+                val window = (view.context as Activity).window
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLightStatusBar
+            }
+        }
     }
 }
 

--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/theme/Theme.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.core.designsystem.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.annotation.ChecksSdkIntAtLeast
 import androidx.compose.foundation.isSystemInDarkTheme
@@ -11,10 +10,7 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.staticCompositionLocalOf
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 internal val LocalKoinColorPalette = staticCompositionLocalOf {
     KoinLightColorPalette
@@ -62,7 +58,6 @@ internal val LocalShapes = staticCompositionLocalOf {
 fun KoinTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicTheme: Boolean = true,
-    isLightStatusBar: Boolean = false,
     content: @Composable () -> Unit
 ) {
     val extendedColors =
@@ -134,20 +129,6 @@ fun KoinTheme(
             shapes = Shapes,
             content = content
         )
-    }
-
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            if (view.context is Activity) {
-                /*
-                We need to check view.context is Activity
-                because when we call KoinTheme inside ComposeView, view.context is not Activity
-                */
-                val window = (view.context as Activity).window
-                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = isLightStatusBar
-            }
-        }
     }
 }
 

--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/util/EdgeToEdgeExtensions.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/util/EdgeToEdgeExtensions.kt
@@ -13,8 +13,8 @@ fun ComponentActivity.enableEdgeToEdgeWithLightStatusBar() = enableEdgeToEdge(
 )
 
 /**
- * Enables the edge-to-edge display for this [ComponentActivity] with blue status bar.
+ * Enables the edge-to-edge display for this [ComponentActivity] with dark status bar.
  */
-fun ComponentActivity.enableEdgeToEdgeWithBlueStatusBar() = enableEdgeToEdge(
-    statusBarStyle = SystemBarStyle.dark(Color.parseColor("#FF175C8E"))
+fun ComponentActivity.enableEdgeToEdgeWithDarkStatusBar() = enableEdgeToEdge(
+    statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT)
 )

--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/util/EdgeToEdgeExtensions.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/util/EdgeToEdgeExtensions.kt
@@ -1,0 +1,20 @@
+package `in`.koreatech.koin.core.designsystem.util
+
+import android.graphics.Color
+import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
+
+/**
+ * Enables the edge-to-edge display for this [ComponentActivity] with light status bar.
+ */
+fun ComponentActivity.enableEdgeToEdgeWithLightStatusBar() = enableEdgeToEdge(
+    statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+)
+
+/**
+ * Enables the edge-to-edge display for this [ComponentActivity] with blue status bar.
+ */
+fun ComponentActivity.enableEdgeToEdgeWithBlueStatusBar() = enableEdgeToEdge(
+    statusBarStyle = SystemBarStyle.dark(Color.parseColor("#FF175C8E"))
+)

--- a/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
@@ -16,9 +16,7 @@ class BusSearchActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            KoinTheme(
-                isLightStatusBar = true
-            ) {
+            KoinTheme {
                 BusSearchNavigation(
                     modifier = Modifier.fillMaxSize()
                 )

--- a/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
@@ -3,18 +3,18 @@ package `in`.koreatech.bus
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.bus.navigation.BusSearchNavigation
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
 
 @AndroidEntryPoint
 class BusSearchActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdgeWithLightStatusBar()
         setContent {
             KoinTheme {
                 BusSearchNavigation(

--- a/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusSearchActivity.kt
@@ -16,7 +16,9 @@ class BusSearchActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            KoinTheme {
+            KoinTheme(
+                isLightStatusBar = true
+            ) {
                 BusSearchNavigation(
                     modifier = Modifier.fillMaxSize()
                 )

--- a/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
@@ -16,9 +16,7 @@ class BusTimetableActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            KoinTheme(
-                isLightStatusBar = true
-            ) {
+            KoinTheme {
                 BusTimetableNavigation(
                     modifier = Modifier.fillMaxSize()
                 )

--- a/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
@@ -16,7 +16,9 @@ class BusTimetableActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
-            KoinTheme {
+            KoinTheme(
+                isLightStatusBar = true
+            ) {
                 BusTimetableNavigation(
                     modifier = Modifier.fillMaxSize()
                 )

--- a/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/BusTimetableActivity.kt
@@ -3,18 +3,18 @@ package `in`.koreatech.bus
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.bus.navigation.BusTimetableNavigation
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
 
 @AndroidEntryPoint
 class BusTimetableActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdgeWithLightStatusBar()
         setContent {
             KoinTheme {
                 BusTimetableNavigation(

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
@@ -23,6 +23,7 @@ import `in`.koreatech.koin.databinding.ActivityArticleBinding
 import `in`.koreatech.koin.ui.article.ArticleDetailFragment.Companion.ARTICLE_ID
 import `in`.koreatech.koin.ui.article.ArticleDetailFragment.Companion.NAVIGATED_BOARD_ID
 import `in`.koreatech.koin.ui.article.viewmodel.ArticleListViewModel
+import `in`.koreatech.koin.util.ext.whiteStatusBar
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -45,6 +46,8 @@ class ArticleActivity : ActivityBase() {
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, imeInsets.bottom or systemBars.bottom)
             WindowInsetsCompat.CONSUMED
         }
+
+        window.whiteStatusBar()
 
         val navHostFragment =
             supportFragmentManager.findFragmentById(R.id.nav_host_article_fragment) as NavHostFragment

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningNoticeActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningNoticeActivity.kt
@@ -14,6 +14,7 @@ import `in`.koreatech.koin.databinding.ActivityDiningNoticeBinding
 import `in`.koreatech.koin.ui.dining.adapter.DiningNoticeAdapter
 import `in`.koreatech.koin.ui.dining.viewmodel.DiningNoticeViewModel
 import `in`.koreatech.koin.util.ext.observeLiveData
+import `in`.koreatech.koin.util.ext.whiteStatusBar
 import `in`.koreatech.koin.util.ext.withLoading
 
 @AndroidEntryPoint
@@ -54,6 +55,8 @@ class DiningNoticeActivity : ActivityBase() {
                 itemAnimator = null
             }
         }
+
+        window.whiteStatusBar()
     }
 
     private fun initViewModel() = with(viewModel) {


### PR DESCRIPTION
## 작업 내용
* Dark theme이 활성화 된 경우, 하얀색 toolbar를 사용하는 화면(공지사항, 학생식당정보, 버스 시간표)의 status bar 색상이 잘못된 문제를 고쳤습니다.
* ~~Design system의 KoinTheme에 isLightStatusBar라는 변수를 추가했습니다. 해당 변수 값에 따라 status bar의 텍스트 색상이 변경됩니다.~~
* ~~위의 변경사항에 따라, isLightStatusBar 선언이 필요한 Composable(시간표)에 값을 선언해줬습니다.~~
* enableEdgeToEdgeWithLightStatusBar()와 enableEdgeToEdgeWithDarkStatusBar()를 추가했습니다.

## 사진
||수정 전|수정 후|
|-|---------|---------|
|버스 시간표|![Screenshot_20250127-070640_코인D](https://github.com/user-attachments/assets/0f0dccaf-10de-4ae0-92b1-751f1025bac7)|![Screenshot_20250127-070722_코인D](https://github.com/user-attachments/assets/cf29d99a-758d-4f17-9bfa-515fd9057f3a)|
|공지사항|![Screenshot_20250127-070645_코인D](https://github.com/user-attachments/assets/1e3f275a-edd8-4df7-93b8-b5d728831aa9)|![Screenshot_20250127-070728_코인D](https://github.com/user-attachments/assets/57e79344-3070-4a81-ad2e-88b3a09c9733)|

## 고민 사항
* ~~isLightStatusBar의 기본값을 기존 WindowExtensions과 동일하게 false로 선언했는데, 값 선언을 강제하도록 기본값을 제거하는게 좋을지 고민입니다.~~