### PR TITLE
[Refactor] onBackPressed 제거

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/ActivityBase.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.core.activity
 import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Bundle
+import androidx.activity.OnBackPressedCallback
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
@@ -22,8 +23,16 @@ abstract class ActivityBase : AppCompatActivity, IProgressDialog {
     private var customProgressDialog: CustomProgressDialog? = null
     protected abstract val screenTitle: String      // for GA4
 
+    open val onBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
         try {
             requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
         } catch (ignore: IllegalStateException) {

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.webkit.*
+import androidx.activity.OnBackPressedCallback
 import `in`.koreatech.koin.core.R
 import `in`.koreatech.koin.core.databinding.ActivityWebviewBinding
 import `in`.koreatech.koin.core.toast.ToastUtil
@@ -15,6 +16,16 @@ class WebViewActivity : ActivityBase(R.layout.activity_webview) {
 
     private val binding by dataBinding<ActivityWebviewBinding>()
     override val screenTitle: String = "웹뷰"
+
+    override val onBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (binding.webView.canGoBack()) {
+                binding.webView.goBack()
+            } else {
+                finish()
+            }
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,17 +40,9 @@ class WebViewActivity : ActivityBase(R.layout.activity_webview) {
         return super.onCreateOptionsMenu(menu)
     }
 
-    override fun onBackPressed() {
-        if (binding.webView.canGoBack()) {
-            binding.webView.goBack()
-        } else {
-            super.onBackPressed()
-        }
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
-            R.id.home -> onBackPressed()
+            R.id.home -> onBackPressedDispatcher.onBackPressed()
             R.id.menu_webview_finish -> finish()
         }
         return super.onOptionsItemSelected(item)

--- a/koin/src/main/java/in/koreatech/koin/ui/changepassword/ChangePasswordActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/changepassword/ChangePasswordActivity.kt
@@ -29,7 +29,7 @@ class ChangePasswordActivity : ActivityBase() {
         ChangePasswordPageAdapter(this)
     }
 
-    val onBackPressedCallback: OnBackPressedCallback by lazy {
+    override val onBackPressedCallback: OnBackPressedCallback by lazy {
         object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
                 if (viewModel.currentStep.value == ChangePasswordPage.entries.first())
@@ -46,7 +46,6 @@ class ChangePasswordActivity : ActivityBase() {
         setContentView(binding.root)
 
         initView()
-        initListeners()
         initObservers()
     }
 
@@ -63,10 +62,6 @@ class ChangePasswordActivity : ActivityBase() {
             adapter = viewPager
             isUserInputEnabled = false
         }
-    }
-
-    private fun initListeners() {
-        onBackPressedDispatcher.addCallback(this, onBackPressedCallback)
     }
 
     private fun initObservers() {

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -59,6 +59,18 @@ class DiningActivity : KoinNavigationDrawerActivity() {
         }
     }
 
+    override val onBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (isTaskRoot) {
+                val intent = Intent(this@DiningActivity, MainActivity::class.java)
+                startActivity(intent)
+                finish()
+            } else {
+                isEnabled = false
+                onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
     @Inject
     lateinit var onboardingManager: OnboardingManager
 
@@ -93,7 +105,7 @@ class DiningActivity : KoinNavigationDrawerActivity() {
 
         binding.koinBaseAppBarDark.setOnClickListener {
             when (it.id) {
-                AppBarBase.getLeftButtonId() -> onBackPressed()
+                AppBarBase.getLeftButtonId() -> onBackPressedDispatcher.onBackPressed()
                 AppBarBase.getRightButtonId() -> {
                     EventLogger.logClickEvent(
                         EventAction.CAMPUS,
@@ -104,19 +116,6 @@ class DiningActivity : KoinNavigationDrawerActivity() {
                 }
             }
         }
-
-        onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
-            override fun handleOnBackPressed() {
-                if (isTaskRoot) {
-                    val intent = Intent(this@DiningActivity, MainActivity::class.java)
-                    startActivity(intent)
-                    finish()
-                } else {
-                    isEnabled = false
-                    onBackPressedDispatcher.onBackPressed()
-                }
-            }
-        })
     }
 
     private fun selectInitialPositions() {

--- a/koin/src/main/java/in/koreatech/koin/ui/error/ErrorActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/error/ErrorActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import android.view.Gravity
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import `in`.koreatech.koin.BuildConfig
 import `in`.koreatech.koin.R
@@ -17,6 +18,14 @@ import `in`.koreatech.koin.util.ext.goToKakaoTalkBcsdlabFriend
 class ErrorActivity : ActivityBase() {
     private val binding by dataBinding<ActivityErrorBinding>(R.layout.activity_error)
     override val screenTitle: String = "에러"
+
+    override var onBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            onBackPressedDispatcher.onBackPressed()
+            val goToHomeIntent = Intent(this@ErrorActivity, SplashActivity::class.java)
+            startActivity(goToHomeIntent)
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,12 +60,6 @@ class ErrorActivity : ActivityBase() {
     override fun onPause() {
         super.onPause()
         finish()
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed()
-        val goToHomeIntent = Intent(this, SplashActivity::class.java)
-        startActivity(goToHomeIntent)
     }
 
     private fun onClickKakaoTalk() {

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -9,6 +9,7 @@ import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
 import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -149,6 +150,26 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
             }.create()
     }
 
+    override val onBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (drawerLayout.isDrawerOpened()) {
+                drawerLayout.closeDrawer()
+            } else {
+                if (menuState == MenuState.Main) {
+                    if (System.currentTimeMillis() > pressTime + 2000) {
+                        pressTime = System.currentTimeMillis()
+                        ToastUtil.getInstance().makeShort(getString(R.string.press_again_to_exit))
+                    } else {
+                        finishAffinity()
+                    }
+                } else {
+                    isEnabled = false
+                    onBackPressedDispatcher.onBackPressed()
+                }
+            }
+        }
+    }
+
     override fun onPostCreate(savedInstanceState: Bundle?) {
         super.onPostCreate(savedInstanceState)
 
@@ -261,23 +282,6 @@ abstract class KoinNavigationDrawerActivity : ActivityBase(),
 
         leftNavigationView.layoutParams =
             leftNavigationView.layoutParams.apply { width = windowWidth }
-    }
-
-    override fun onBackPressed() {
-        if (drawerLayout.isDrawerOpened()) {
-            drawerLayout.closeDrawer()
-        } else {
-            if (menuState == MenuState.Main) {
-                if (System.currentTimeMillis() > pressTime + 2000) {
-                    pressTime = System.currentTimeMillis()
-                    ToastUtil.getInstance().makeShort(getString(R.string.press_again_to_exit))
-                } else {
-                    finishAffinity()
-                }
-            } else {
-                super.onBackPressed()
-            }
-        }
     }
 
     private fun initDrawerViewModel() = with(koinNavigationDrawerViewModel) {

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -221,7 +221,7 @@ class StoreActivity : KoinNavigationDrawerTimeActivity() {
                 else -> {
                     viewModel.refreshStores()
                     isEnabled = false
-                    onBackPressed()
+                    onBackPressedDispatcher.onBackPressed()
                 }
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreDetailActivity.kt
@@ -4,10 +4,12 @@ import android.Manifest
 import android.annotation.SuppressLint
 import android.content.ClipData
 import android.content.ClipboardManager
+import android.content.Intent
 import android.os.Bundle
 import android.view.MotionEvent
 import android.view.View
 import android.widget.TextView
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AlertDialog
@@ -31,6 +33,7 @@ import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.databinding.StoreActivityDetailBinding
 import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
 import `in`.koreatech.koin.ui.navigation.state.MenuState
+import `in`.koreatech.koin.ui.splash.SplashActivity
 import `in`.koreatech.koin.ui.splash.state.TokenState
 import `in`.koreatech.koin.ui.store.adapter.StoreDetailFlyerRecyclerAdapter
 import `in`.koreatech.koin.ui.store.adapter.StoreDetailImageViewpagerAdapter
@@ -92,6 +95,18 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
     }
     private val storeDetailViewpagerAdapter = StoreDetailViewpagerAdapter(this)
 
+    override val onBackPressedCallback: OnBackPressedCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            if (flyerDialogFragment?.isVisible == true) {
+                flyerDialogFragment!!.dismiss()
+                flyerDialogFragment = null
+                return
+            }
+            isEnabled = false
+            onBackPressedDispatcher.onBackPressed()
+        }
+    }
+
     @SuppressLint("ClickableViewAccessibility")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -108,7 +123,7 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
                 AppBarBase.getLeftButtonId() -> {
                     storeElapsedTime = System.currentTimeMillis() - storeCurrentTime
                     isSwipeGesture = false
-                    onBackPressed()
+                    onBackPressedDispatcher.onBackPressed()
                 }
 
                 AppBarBase.getRightButtonId() -> {
@@ -264,15 +279,6 @@ class StoreDetailActivity : KoinNavigationDrawerActivity() {
             isSwipeGesture = true
         }
         return super.onTouchEvent(event)
-    }
-
-    override fun onBackPressed() {
-        if (flyerDialogFragment?.isVisible == true) {
-            flyerDialogFragment!!.dismiss()
-            flyerDialogFragment = null
-            return
-        }
-        super.onBackPressed()
     }
 
     private fun initCallFunction() {

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreReviewReportActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreReviewReportActivity.kt
@@ -56,7 +56,7 @@ class StoreReviewReportActivity:  ActivityBase() {
 
         reportAppbar.setOnClickListener {
             when (it.id) {
-                AppBarBase.getLeftButtonId() -> onBackPressed()
+                AppBarBase.getLeftButtonId() -> onBackPressedDispatcher.onBackPressed()
             }
         }
         storeName = intent.extras?.getString("storeName")

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -405,7 +405,7 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
     private fun setAppbarEvent(rightButtonClickable: () -> Unit = {}) {
         binding.koinBaseAppbar.setOnClickListener {
             when (it.id) {
-                AppBarBase.getLeftButtonId() -> onBackPressed()
+                AppBarBase.getLeftButtonId() -> onBackPressedDispatcher.onBackPressed()
                 AppBarBase.getRightButtonId() -> rightButtonClickable()
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
@@ -42,7 +42,7 @@ class TimetableSemesterActivity : ActivityBase() {
     private val binding by dataBinding<ActivityTimetableSemesterBinding>()
     private val viewModel by viewModels<SemesterViewModel>()
 
-    private val onBackPressedCallback = object : OnBackPressedCallback(true) {
+    override val onBackPressedCallback = object : OnBackPressedCallback(true) {
         override fun handleOnBackPressed() {
             if (viewModel.screenState.value.userTimetableFrames.isEmpty()) {
                 finishActivityWithResult(
@@ -70,7 +70,6 @@ class TimetableSemesterActivity : ActivityBase() {
             val frameName = bundle.getString(TimetableActivity.FRAME_NAME).orEmpty()
             viewModel.updateIntentData(isAnonymous, frameId, semester, frameName)
         }
-        onBackPressedDispatcher.addCallback(onBackPressedCallback)
 
         binding.timetableListComposeView.setContent {
             KoinTheme {

--- a/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoActivity.kt
@@ -48,7 +48,7 @@ class UserInfoActivity : ActivityBase() {
     private fun initView() = with(binding) {
         appbarUserInfo.setAppBarButtonClickedListener(
             leftButtonClicked = {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
             },
             rightButtonClicked = {
                 userInfoEditActivityNew.launch(Unit)

--- a/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/userinfo/UserInfoEditActivity.kt
@@ -51,7 +51,7 @@ class UserInfoEditActivity : ActivityBase() {
     private fun initView() = with(binding) {
         appbarUserInfoEdit.setAppBarButtonClickedListener(
             leftButtonClicked = {
-                onBackPressed()
+                onBackPressedDispatcher.onBackPressed()
             },
             rightButtonClicked = {}
         )


### PR DESCRIPTION
## 요약
onBackPressed 제거

## 개발 내용
* ActivityBase에 onBackPressedCallback을 추가했습니다.
* onBackPressed 대신 onBackPressedCallback을 override 하도록 수정했습니다.
* onBackPressed()를 호출하던 부분을 전부 onBackPressedDispatcher.onBackPressed()를 호출하도록 수정했습니다.
* 기존에 ActivityBase를 상속하던 Activity 중, 이미 onBackPressedCallback을 사용하는 Activity는 override 키워드를 추가하고 addCallback을 제거했습니다.

## 추가적인 내용
