### PR TITLE
[Refactor] 사용하지 않는 API 확인 로직 삭제

### DIFF
--- a/core/notification/src/main/java/in/koreatech/koin/core/notification/NotifierImpl.kt
+++ b/core/notification/src/main/java/in/koreatech/koin/core/notification/NotifierImpl.kt
@@ -11,7 +11,6 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.media.RingtoneManager
-import android.os.Build
 import android.widget.RemoteViews
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationCompat
@@ -91,8 +90,6 @@ class NotifierImpl @Inject constructor(
     }
 
     private fun Context.ensureNotificationChannelExists() {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
-
         val channel = NotificationChannel(
             CHANNEL_ID,
             CHANNEL_NAME,

--- a/core/src/main/java/in/koreatech/koin/core/util/FontManager.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/FontManager.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.core.util
 
 import android.content.Context
 import android.graphics.Typeface
-import android.os.Build
 import androidx.core.content.res.ResourcesCompat
 import `in`.koreatech.koin.core.R
 import java.util.EnumMap
@@ -29,11 +28,7 @@ object FontManager {
     @JvmStatic
     fun getTypeface(context: Context, fontType: KoinFontType): Typeface {
         return cache[fontType] ?: run {
-            val font = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                getFromResource(context, fontType)
-            } else {
-                getFromAsset(context, fontType)
-            }
+            val font = getFromResource(context, fontType)
             cache[fontType] = font
             return@run font
         }

--- a/core/src/main/java/in/koreatech/koin/core/util/SystemBarsUtils.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/SystemBarsUtils.kt
@@ -48,11 +48,7 @@ class SystemBarsUtils(
     ) {
         WindowInsetsControllerCompat(window, window.decorView).let { controller ->
             controller.isAppearanceLightStatusBars = isLightStatusBar
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                controller.isAppearanceLightNavigationBars = isLightNavigationBar
-            } else {
-                setAppearanceNavigationBarSdk26(window, isLightNavigationBar)
-            }
+            controller.isAppearanceLightNavigationBars = isLightNavigationBar
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/source/local/UploadImageLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/UploadImageLocalDataSource.kt
@@ -4,10 +4,6 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.media.ExifInterface
 import android.net.Uri
-import android.os.Build
-import android.provider.OpenableColumns
-import android.util.Log
-import androidx.annotation.RequiresApi
 import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.koreatech.koin.core.upload.rotateBitmap
 import `in`.koreatech.koin.core.upload.toCompressJPEG
@@ -30,7 +26,6 @@ class UploadImageLocalDataSource @Inject constructor(
 
                     if (bitmapInputStream != null && exifInterfaceInputStream != null) {
                         val bitmap = bitmapInputStream.toResizeBitmap(fileSize)
-                        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.N){
                             val exif = ExifInterface(exifInterfaceInputStream)
                             val rotatedBitmap = when (exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_UNDEFINED)) {
                                 ExifInterface.ORIENTATION_ROTATE_90 -> bitmap?.rotateBitmap(90f)
@@ -41,10 +36,6 @@ class UploadImageLocalDataSource @Inject constructor(
                             if(rotatedBitmap != null){
                                 imageBitmap = rotatedBitmap
                             }
-                        }
-                        else{
-                            if(bitmap != null) imageBitmap = bitmap
-                        }
                     }
 
                     bitmapInputStream?.close()

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/EditSemesterDialog.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/EditSemesterDialog.kt
@@ -1,7 +1,5 @@
 package `in`.koreatech.koin.feature.timetable.view.dialog
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -248,7 +246,6 @@ private fun SelectYearDialog(
 }
 
 
-@RequiresApi(Build.VERSION_CODES.O)
 @Preview
 @Composable
 private fun EditSemesterDialogPreview() {
@@ -276,7 +273,6 @@ private fun SelectYearDialogContentPreview() {
 
 @Preview
 @Composable
-@RequiresApi(Build.VERSION_CODES.O)
 private fun EditSemesterDialogImplPreview() {
     var userSemesters by remember { mutableStateOf(listOf<SemesterModel>()) }
     EditSemesterDialogImpl(

--- a/koin/src/main/java/in/koreatech/koin/ui/businesssignup/fragment/AttachmentDialogFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/businesssignup/fragment/AttachmentDialogFragment.kt
@@ -11,12 +11,9 @@ import android.Manifest
 import android.app.Activity
 import android.content.Intent
 import android.net.Uri
-import android.os.Build
-import android.provider.MediaStore
 import android.provider.OpenableColumns
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
@@ -65,12 +62,7 @@ class AttachmentDialogFragment : DialogFragment() {
         }
 
         binding.attachFileButton.setOnClickListener {
-            if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                checkPermission()
-            }
-            else {
-                getImageFile()
-            }
+            checkPermission()
         }
 
         return view

--- a/koin/src/main/java/in/koreatech/koin/util/ext/ActivityExtensions.kt
+++ b/koin/src/main/java/in/koreatech/koin/util/ext/ActivityExtensions.kt
@@ -4,12 +4,10 @@ import `in`.koreatech.koin.core.activity.ActivityBase
 import `in`.koreatech.koin.core.progressdialog.IProgressDialog
 import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import android.app.Activity
-import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
 import android.os.Parcelable
-import android.util.DisplayMetrics
 import android.view.WindowInsets
 import android.view.inputmethod.InputMethodManager
 import androidx.core.view.WindowInsetsCompat
@@ -25,15 +23,10 @@ inline val Activity.windowHeight: Int
             val metrics = windowManager.currentWindowMetrics
             val insets = metrics.windowInsets.getInsets(WindowInsets.Type.systemBars())
             metrics.bounds.height() - insets.bottom - insets.top
-        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else {
             val view = window.decorView
             val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets, view).getInsets(WindowInsetsCompat.Type.systemBars())
             resources.displayMetrics.heightPixels - insets.bottom - insets.top
-        } else {
-            DisplayMetrics().let { displayMetrics ->
-                windowManager.defaultDisplay.getMetrics(displayMetrics)
-                displayMetrics.heightPixels
-            }
         }
     }
 
@@ -43,15 +36,10 @@ inline val Activity.windowWidth: Int
             val metrics = windowManager.currentWindowMetrics
             val insets = metrics.windowInsets.getInsets(WindowInsets.Type.systemBars())
             metrics.bounds.width() - insets.left - insets.right
-        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else {
             val view = window.decorView
             val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets, view).getInsets(WindowInsetsCompat.Type.systemBars())
             resources.displayMetrics.widthPixels - insets.left - insets.right
-        } else {
-            DisplayMetrics().let { displayMetrics ->
-                windowManager.defaultDisplay.getMetrics(displayMetrics)
-                displayMetrics.widthPixels
-            }
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/util/ext/FragmentExtensions.kt
+++ b/koin/src/main/java/in/koreatech/koin/util/ext/FragmentExtensions.kt
@@ -1,16 +1,9 @@
 package `in`.koreatech.koin.util.ext
 
-import `in`.koreatech.koin.core.toast.ToastUtil
-import `in`.koreatech.koin.core.viewmodel.BaseViewModel
-import android.app.Activity
 import android.os.Build
-import android.util.DisplayMetrics
-import android.view.View
 import android.view.WindowInsets
-import androidx.activity.ComponentActivity
 import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
-
 
 inline val Fragment.windowHeight: Int
     get() {
@@ -18,15 +11,10 @@ inline val Fragment.windowHeight: Int
             val metrics = requireActivity().windowManager.currentWindowMetrics
             val insets = metrics.windowInsets.getInsets(WindowInsets.Type.systemBars())
             metrics.bounds.height() - insets.bottom - insets.top
-        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else {
             val view = requireActivity().window.decorView
             val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets, view).getInsets(WindowInsetsCompat.Type.systemBars())
             resources.displayMetrics.heightPixels - insets.bottom - insets.top
-        } else {
-            DisplayMetrics().let { displayMetrics ->
-                requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
-                displayMetrics.heightPixels
-            }
         }
     }
 
@@ -36,14 +24,9 @@ inline val Fragment.windowWidth: Int
             val metrics = requireActivity().windowManager.currentWindowMetrics
             val insets = metrics.windowInsets.getInsets(WindowInsets.Type.systemBars())
             metrics.bounds.width() - insets.left - insets.right
-        } else if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else {
             val view = requireActivity().window.decorView
             val insets = WindowInsetsCompat.toWindowInsetsCompat(view.rootWindowInsets, view).getInsets(WindowInsetsCompat.Type.systemBars())
             resources.displayMetrics.widthPixels - insets.left - insets.right
-        } else {
-            DisplayMetrics().let { displayMetrics ->
-                requireActivity().windowManager.defaultDisplay.getMetrics(displayMetrics)
-                displayMetrics.widthPixels
-            }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/util/ext/WindowExtensions.kt
+++ b/koin/src/main/java/in/koreatech/koin/util/ext/WindowExtensions.kt
@@ -20,8 +20,7 @@ fun Window.statusBarColor(
             )
 
             this.statusBarColor = color
-
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        } else {
             var flags: Int = decorView.systemUiVisibility
             flags = if(lightStatusBar) {
                 flags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
@@ -31,8 +30,6 @@ fun Window.statusBarColor(
 
             decorView.systemUiVisibility = flags
 
-            statusBarColor = color
-        } else {
             statusBarColor = color
         }
     }
@@ -44,9 +41,5 @@ fun Window.blueStatusBar() {
 }
 
 fun Window.whiteStatusBar() {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        statusBarColor(ContextCompat.getColor(context, R.color.background), true)
-    } else {
-        statusBarColor(ContextCompat.getColor(context, R.color.gray8))
-    }
+    statusBarColor(ContextCompat.getColor(context, R.color.background), true)
 }


### PR DESCRIPTION
## 요약
사용하지 않는 API 확인 로직 삭제

## 개발 내용
* minSdk를 API 26(O)으로 올린 후, 필요하지 않게 된 API 확인 로직을 삭제했습니다.
* API 26 미만 버전을 위한 코드를 삭제했습니다.
* API 26으로 설정된 RequiresApi annotation을 삭제했습니다.