### PR TITLE
[Fix] 삭제된 게시글에 접근 시 404 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -1,6 +1,8 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.detail
 
 import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
@@ -29,6 +31,7 @@ import `in`.koreatech.koin.feature.lostandfound.ui.detail.LostAndFoundDetailView
 import `in`.koreatech.koin.feature.lostandfound.ui.detail.component.DetailButtonGroup
 import `in`.koreatech.koin.feature.lostandfound.ui.detail.component.DetailContent
 import `in`.koreatech.koin.feature.lostandfound.ui.detail.component.DetailHeader
+import `in`.koreatech.koin.feature.lostandfound.util.findActivity
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -135,7 +138,7 @@ fun LostAndFoundDetail(
 private fun handleSideEffect(
     sideEffect: LostAndFoundDetailSideEffect,
     context: Context,
-    navigateToArticleList: () -> Unit = {},
+    navigateToArticleList: () -> Unit = {}
 ) {
     when (sideEffect) {
         //is LostAndFoundDetailSideEffect.FetchDetail -> {}
@@ -153,6 +156,19 @@ private fun handleSideEffect(
             Toast.makeText(
                 context,
                 context.getString(R.string.detail_delete_failed_toast),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
+        LostAndFoundDetailSideEffect.DeletedArticle -> {
+            context.findActivity()?.finish()
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                data = Uri.parse("koin://article/activity?fragment=article_lost_and_found")
+            }
+            context.startActivity(intent)
+            Toast.makeText(
+                context,
+                context.getString(R.string.detail_deleted_article),
                 Toast.LENGTH_SHORT
             ).show()
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailSideEffect.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailSideEffect.kt
@@ -5,4 +5,5 @@ sealed class LostAndFoundDetailSideEffect {
     //data object FetchHotArticles : LostAndFoundDetailSideEffect()
     data class DeleteArticle(val id: Int) : LostAndFoundDetailSideEffect()
     data object DeleteArticleFailed : LostAndFoundDetailSideEffect()
+    data object DeletedArticle : LostAndFoundDetailSideEffect()
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -14,6 +14,7 @@ import `in`.koreatech.koin.domain.usecase.article.lostandfound.FetchHotArticlesU
 import `in`.koreatech.koin.domain.usecase.article.lostandfound.FetchLostAndFoundArticleUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.lostandfound.model.toArticleHeaderState
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -22,6 +23,7 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import retrofit2.HttpException
 
 @HiltViewModel(assistedFactory = LostAndFoundDetailViewModel.Factory::class)
 class LostAndFoundDetailViewModel @AssistedInject constructor(
@@ -73,8 +75,11 @@ class LostAndFoundDetailViewModel @AssistedInject constructor(
                     isLoading = true
                 )
             }
-
-            fetchLostAndFoundArticleUseCase(articleId).map {
+            fetchLostAndFoundArticleUseCase(articleId).catch {
+                if (it is HttpException && it.code() == 404) {
+                    postSideEffect(LostAndFoundDetailSideEffect.DeletedArticle)
+                }
+            }.map {
                 it.toLostAndFoundDetailState()
             }.collectLatest { article ->
                 reduce {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/util/ContextExtensions.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/util/ContextExtensions.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.feature.lostandfound.util
+
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
+
+internal fun Context.findActivity(): ComponentActivity? = when (this) {
+    is ComponentActivity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -62,6 +62,7 @@
     <string name="detail_delete_dialog_title">게시글을 삭제하시겠습니까?</string>
     <string name="detail_delete_toast">게시글이 삭제되었습니다.</string>
     <string name="detail_delete_failed_toast">게시글 삭제에 실패했습니다.</string>
+    <string name="detail_deleted_article">삭제된 게시글입니다.</string>
 
     <string name="hot_article_title">인기있는 공지</string>
 


### PR DESCRIPTION
## 개요
* 삭제된 게시글에 접근 시 404 오류 수정

## 개발 내용
* 알림을 통해 삭제된 게시글에 접근할 경우 발생하던 404 오류를 해결했습니다.
* ContextExtensions를 추가했습니다. bus 모듈과 내용이 동일해 추후 통합 후 core 모듈로 옮길 필요가 있어보입니다.