### PR TITLE
[Feature] 분실물 게시판 앱 링크 지원

### DIFF
--- a/koin/build.gradle.kts
+++ b/koin/build.gradle.kts
@@ -44,6 +44,7 @@ android {
             )
             manifestPlaceholders["appName"] = "@string/app_name_dev"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_koin"
+            manifestPlaceholders["appLinkUri"] = "stage.koreatech.in"
             buildConfigField("Boolean", "IS_DEBUG", "true")
             buildConfigField(
                 "String",
@@ -62,6 +63,7 @@ android {
             )
             manifestPlaceholders["appName"] = "@string/app_name"
             manifestPlaceholders["appIcon"] = "@mipmap/ic_launcher_koin"
+            manifestPlaceholders["appLinkUri"] = "koreatech.in"
             buildConfigField("Boolean", "IS_DEBUG", "false")
             signingConfig = signingConfigs.getByName("release")
             buildConfigField(

--- a/koin/src/main/AndroidManifest.xml
+++ b/koin/src/main/AndroidManifest.xml
@@ -167,6 +167,18 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="http" />
+                <data android:scheme="https" />
+
+                <data android:host="${appLinkUri}"
+                    tools:replace="host"/>
+                <data android:path="/articles/lost-item"/>
+            </intent-filter>
         </activity>
         <activity
             android:name=".ui.login.LoginActivity"

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
@@ -1,14 +1,15 @@
 package `in`.koreatech.koin.ui.splash
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.viewModels
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
-import dagger.hilt.android.AndroidEntryPoint
-import android.util.Log
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.play.core.install.model.UpdateAvailability
+import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.BuildConfig
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
@@ -20,6 +21,7 @@ import `in`.koreatech.koin.core.navigation.utils.EXTRA_TYPE
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.core.util.SystemBarsUtils
 import `in`.koreatech.koin.domain.state.version.VersionUpdatePriority
+import `in`.koreatech.koin.ui.article.ArticleActivity
 import `in`.koreatech.koin.ui.forceupdate.ForceUpdateActivity
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.splash.viewmodel.SplashViewModel
@@ -85,7 +87,7 @@ class SplashActivity : ActivityBase() {
         }
 
         observeLiveData(tokenState) {
-            gotoMainActivityOrDelay()
+            handleIntentOrLaunch()
         }
     }
 
@@ -127,6 +129,39 @@ class SplashActivity : ActivityBase() {
             // 업데이트 정보를 받아오는데 실패한 경우 현재 버전 저장
             Log.e("SplashActivity", "Fail to get latest app: exception: ${e}")
             splashViewModel.updateLatestVersion(BuildConfig.VERSION_CODE)
+        }
+    }
+
+    private fun handleIntentOrLaunch() {
+        val uriPrefix = intent.data?.path?.split("/")?.getOrNull(1)
+        when (uriPrefix) {
+            "articles" -> {
+                gotoArticleActivityOrDelay()
+            }
+            else -> {
+                gotoMainActivityOrDelay()
+            }
+        }
+    }
+
+    private fun gotoArticleActivityOrDelay() {
+        val path = intent.data?.path?.split("/")?.getOrNull(2)
+        lifecycleScope.launch {
+            delay()
+            val intent = when (path) {
+                "lost-item" -> {
+                    Intent(Intent.ACTION_VIEW).apply {
+                        data = Uri.parse("koin://article/activity?fragment=article_lost_and_found")
+                    }
+                }
+                else -> {
+                    Intent(this@SplashActivity, ArticleActivity::class.java)
+                }
+            }
+            startActivity(intent)
+            overridePendingTransition(R.anim.fade, R.anim.hold)
+            finish()
+            firebasePerformanceUtil.stop()
         }
     }
 


### PR DESCRIPTION
## 개요
* 분실물 게시판 앱 링크 지원

## 개발 내용
* 분실물 게시판에 앱 링크 기능을 추가했습니다.
* https://koreatech.in/articles/lost-item 으로 접속하면 코인 앱이 실행됩니다.
* 지원하는 링크를 클릭 시, SplashActivity가 실행되며, uri path에 맞는 액티비티로 실행됩니다.
* 추후 앱 링크 기능이 확장될 것은 대비하여, SplashActivity에 분기처리를 해두었습니다.

## 추가적인 내용
* assetlinks.json 파일 https://stage.koreatech.in/.well-known/assetlinks.json 및 https://koreatech.in/.well-known/assetlinks.json 경로에 업로드 됩니다.

## 논의해야 할 내용
* stage의 경우, 사람마다 다른 사이닝 키를 사용하고 있기 때문에, 현재 릴리즈 키의 해시값을 업로드 했습니다.
* 이에 대해서 디버깅 빌드용 키를 통합할 지, 사용자별 사이닝 키를 전부 업로드할지에 대해 논의가 필요합니다.