### PR TITLE
[Fix] 유니버스 약관 동의 불가 수정

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -167,9 +167,11 @@ internal class KoinWebChromeClient(
                         },
                     )
             }
-        val transport = resultMsg?.obj as WebView.WebViewTransport
-        transport.webView = newWebView
-        resultMsg.sendToTarget()
+        if (resultMsg?.obj is WebView.WebViewTransport) {
+            val transport = resultMsg.obj as WebView.WebViewTransport
+            transport.webView = newWebView
+            resultMsg.sendToTarget()
+        }
         return true
     }
 }

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -94,7 +94,7 @@ class WebViewActivity : ActivityBase(R.layout.activity_webview) {
     }
 }
 
-class KoinWebViewClient(
+internal class KoinWebViewClient(
     private val context: Context,
     private val openInNewTab: Boolean = false,
     private val showProgressDialog: () -> Unit,
@@ -141,7 +141,7 @@ class KoinWebViewClient(
     }
 }
 
-class KoinWebChromeClient(
+internal class KoinWebChromeClient(
     private val context: Context,
     private val showProgressDialog: () -> Unit,
     private val hideProgressDialog: () -> Unit,

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -1,8 +1,11 @@
 package `in`.koreatech.koin.core.activity
 
 import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
+import android.os.Message
 import android.view.Menu
 import android.view.MenuItem
 import android.webkit.WebChromeClient
@@ -61,41 +64,112 @@ class WebViewActivity : ActivityBase(R.layout.activity_webview) {
         setTitle(title)
 
         binding.webView.apply {
-            webChromeClient = WebChromeClient()
-            settings.javaScriptEnabled = true
-            webViewClient =
-                object : WebViewClient() {
-                    override fun onPageStarted(
-                        view: WebView,
-                        url: String,
-                        favicon: Bitmap?,
-                    ) {
-                        super.onPageStarted(view, url, favicon)
+            webChromeClient =
+                KoinWebChromeClient(
+                    context = this@WebViewActivity,
+                    showProgressDialog = {
                         showProgressDialog(R.string.loading)
-                    }
-
-                    override fun onPageFinished(
-                        view: WebView,
-                        url: String,
-                    ) {
-                        super.onPageFinished(view, url)
+                    },
+                    hideProgressDialog = {
                         hideProgressDialog()
-                    }
-
-                    override fun onReceivedError(
-                        view: WebView,
-                        request: WebResourceRequest,
-                        error: WebResourceError,
-                    ) {
-                        super.onReceivedError(view, request, error)
+                    },
+                )
+            settings.javaScriptEnabled = true
+            settings.setSupportMultipleWindows(true)
+            webViewClient =
+                KoinWebViewClient(
+                    context = this@WebViewActivity,
+                    showProgressDialog = {
+                        showProgressDialog(R.string.loading)
+                    },
+                    hideProgressDialog = {
                         hideProgressDialog()
-                        ToastUtil.getInstance().makeShort(R.string.error_network)
-                    }
-                }
+                    },
+                )
             settings.loadWithOverviewMode = true
             settings.useWideViewPort = true
             settings.mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
             loadUrl(url ?: "https://bcsdlab.com/")
         }
+    }
+}
+
+class KoinWebViewClient(
+    private val context: Context,
+    private val openInNewTab: Boolean = false,
+    private val showProgressDialog: () -> Unit,
+    private val hideProgressDialog: () -> Unit,
+) : WebViewClient() {
+    override fun onPageStarted(
+        view: WebView,
+        url: String,
+        favicon: Bitmap?,
+    ) {
+        super.onPageStarted(view, url, favicon)
+        showProgressDialog()
+    }
+
+    override fun onPageFinished(
+        view: WebView,
+        url: String,
+    ) {
+        super.onPageFinished(view, url)
+        hideProgressDialog()
+    }
+
+    override fun onReceivedError(
+        view: WebView,
+        request: WebResourceRequest,
+        error: WebResourceError,
+    ) {
+        super.onReceivedError(view, request, error)
+        hideProgressDialog()
+        ToastUtil.getInstance().makeShort(R.string.error_network)
+    }
+
+    override fun shouldOverrideUrlLoading(
+        view: WebView?,
+        request: WebResourceRequest?,
+    ): Boolean {
+        if (openInNewTab) {
+            val intent = Intent(context, WebViewActivity::class.java)
+            intent.putExtra("url", request?.url.toString())
+            context.startActivity(intent)
+            return true
+        }
+        return super.shouldOverrideUrlLoading(view, request)
+    }
+}
+
+class KoinWebChromeClient(
+    private val context: Context,
+    private val showProgressDialog: () -> Unit,
+    private val hideProgressDialog: () -> Unit,
+) : WebChromeClient() {
+    override fun onCreateWindow(
+        view: WebView,
+        isDialog: Boolean,
+        isUserGesture: Boolean,
+        resultMsg: Message?,
+    ): Boolean {
+        val newWebView =
+            WebView(view.context).apply {
+                webChromeClient = this@KoinWebChromeClient
+                webViewClient =
+                    KoinWebViewClient(
+                        context = context,
+                        openInNewTab = true,
+                        showProgressDialog = {
+                            showProgressDialog()
+                        },
+                        hideProgressDialog = {
+                            hideProgressDialog()
+                        },
+                    )
+            }
+        val transport = resultMsg?.obj as WebView.WebViewTransport
+        transport.webView = newWebView
+        resultMsg.sendToTarget()
+        return true
     }
 }

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -167,11 +167,9 @@ internal class KoinWebChromeClient(
                         },
                     )
             }
-        if (resultMsg?.obj is WebView.WebViewTransport) {
-            val transport = resultMsg.obj as WebView.WebViewTransport
-            transport.webView = newWebView
-            resultMsg.sendToTarget()
-        }
+        val transport = resultMsg?.obj as? WebView.WebViewTransport
+        transport?.webView = newWebView
+        resultMsg?.sendToTarget()
         return true
     }
 }


### PR DESCRIPTION
## 개요
* 유니버스 회원가입 페이지에서 약관 보기를 누르고 기존 페이지로 복귀했을 때, 약관 동의 체크가 불가능한 문제를 수정했습니다.

## 개발 내용
* 새 탭으로 페이지가 열려야 하는 경우, 새로운 WebViewActivity가 실행되도록 수정했습니다.
* 기존 코드에서 KoinWebViewClient 및 KoinWebChromeClient를 분리했습니다.