### PR TITLE
[Fix] 18시 30분 이후 DiningActivity에서 내일을 기본으로 표시하도록 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -200,22 +200,22 @@ class DiningActivity : KoinNavigationDrawerActivity() {
 
     private fun initCalendar() {
         with(binding) {
-            val diningType = DiningUtil.getCurrentType()
             recyclerViewCalendar.adapter = diningDateAdapter
             dates.clear()
             val current = TimeUtil.getCurrentTime()
             dates.add(current)
-            repeat(if (diningType == DiningType.NextBreakfast) 2 else 3) {
+            repeat(3) {
                 dates.add(0, TimeUtil.getPreviousDayDate(dates.first()))
             }
-            repeat(if (diningType == DiningType.NextBreakfast) 4 else 3) {
+            repeat(3) {
                 dates.add(TimeUtil.getNextDayDate(dates.last()))
             }
             diningDateAdapter.submitList(dates)
 
             val todayPos = dates.size / 2
             scrollDateTodayToCenter(todayPos)
-            initialDateTab = todayPos
+            initialDateTab =
+                if (DiningUtil.getCurrentType() == DiningType.NextBreakfast) todayPos + 1 else todayPos
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -200,14 +200,15 @@ class DiningActivity : KoinNavigationDrawerActivity() {
 
     private fun initCalendar() {
         with(binding) {
+            val diningType = DiningUtil.getCurrentType()
             recyclerViewCalendar.adapter = diningDateAdapter
             dates.clear()
             val current = TimeUtil.getCurrentTime()
             dates.add(current)
-            repeat(3) {
+            repeat(if (diningType == DiningType.NextBreakfast) 2 else 3) {
                 dates.add(0, TimeUtil.getPreviousDayDate(dates.first()))
             }
-            repeat(3) {
+            repeat(if (diningType == DiningType.NextBreakfast) 4 else 3) {
                 dates.add(TimeUtil.getNextDayDate(dates.last()))
             }
             diningDateAdapter.submitList(dates)


### PR DESCRIPTION
## 개요
* 18시 30분 이후 DiningActivity에서 내일을 기본으로 표시하도록 수정하였습니다.

## 개발 내용
* 기존에는 오늘 저녁 시간이 지나면 MainActivity에는 내일 아침 식단을 표시하지만, DiningActivity 진입 시 오늘 식단을 기본으로 표시하고 있었습니다.
* 이제 오늘 저녁 시간이 지났다면, DiningActivity에서도 내일 아침을 기본으로 표시하도록 수정했습니다.
## 수정
* 최초에는 중앙의 날짜를 내일로 변경했었는데, iOS 확인 결과 중앙에 오늘 날짜를 표시하고, 다음 날이 선택되는 것으로 되어있어서 동일하게 수정했습니다. (250311)