### PR TITLE
fix: 드로어가 열린 상태에서 activity가 resume 되면 상단바 색이 파란색이던 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -300,6 +300,13 @@ abstract class KoinNavigationDrawerActivity :
         initDrawerViewModel()
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (drawerLayout.isDrawerOpened(GravityCompat.END)) {
+            window.whiteStatusBar()
+        }
+    }
+
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 


### PR DESCRIPTION
## 개요
* 드로어가 열린 상태에서 activity가 resume 되면 상단바 색이 파란색이던 문제 수정

## 개발 내용
* 네비게이션 드로어가 열린 상태에서, 다크 모드 전환, density 변경 등의 이유로 activity가 resume 될 경우, 상단바가 하얀색이 아닌 파란색으로 나타나던 오류를 수정했습니다.