### PR TITLE
[Fix] 채팅 서버와 연결이 정상적으로 되지 않은 상황에서 메시지 전송/수신 시 발생하던 크래시 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
@@ -7,16 +7,16 @@ import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import `in`.koreatech.koin.domain.model.chat.ChatMessage
 import `in`.koreatech.koin.domain.model.chat.ChatRoom
 import `in`.koreatech.koin.domain.repository.ChatRepository
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
 class ChatRepositoryImpl @Inject constructor(
     private val chatRemoteDataSource: ChatRemoteDataSource
 ) : ChatRepository {
-    override suspend fun connectWS() {
-        chatRemoteDataSource.connectWS()
+    override suspend fun connectWS(retry: Boolean) {
+        chatRemoteDataSource.connectWS(retry)
     }
 
     override suspend fun disconnectWS() {
@@ -67,8 +67,8 @@ class ChatRepositoryImpl @Inject constructor(
         articleId: Int,
         chatRoomId: Int,
         message: ChatMessage
-    ) {
-        chatRemoteDataSource.sendMessage(articleId, chatRoomId, message.toChatMessageRequest())
+    ): Result<Unit> {
+        return chatRemoteDataSource.sendMessage(articleId, chatRoomId, message.toChatMessageRequest())
     }
 
     override suspend fun blockUser(

--- a/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
@@ -7,10 +7,10 @@ import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import `in`.koreatech.koin.domain.model.chat.ChatMessage
 import `in`.koreatech.koin.domain.model.chat.ChatRoom
 import `in`.koreatech.koin.domain.repository.ChatRepository
+import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import javax.inject.Inject
 
 class ChatRepositoryImpl @Inject constructor(
     private val chatRemoteDataSource: ChatRemoteDataSource

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -7,8 +7,8 @@ import `in`.koreatech.koin.data.response.chat.ChatListItemResponse
 import `in`.koreatech.koin.data.response.chat.ChatMessageResponse
 import `in`.koreatech.koin.data.response.chat.ChatRoomResponse
 import `in`.koreatech.koin.data.stomp.KoinStomp
-import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 class ChatRemoteDataSource @Inject constructor(
     private val chatApi: ChatApi,

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -63,8 +63,8 @@ class ChatRemoteDataSource @Inject constructor(
         return try {
             koinStomp.convertAndSend("/app/chat/$articleId/$chatRoomId", message)
             Result.success(Unit)
-        } catch (t: Throwable) {
-            Result.failure(t)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -7,16 +7,16 @@ import `in`.koreatech.koin.data.response.chat.ChatListItemResponse
 import `in`.koreatech.koin.data.response.chat.ChatMessageResponse
 import `in`.koreatech.koin.data.response.chat.ChatRoomResponse
 import `in`.koreatech.koin.data.stomp.KoinStomp
-import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
 
 class ChatRemoteDataSource @Inject constructor(
     private val chatApi: ChatApi,
     private val chatAuthApi: ChatAuthApi,
     private val koinStomp: KoinStomp
 ) {
-    suspend fun connectWS() {
-        koinStomp.connect()
+    suspend fun connectWS(retry: Boolean) {
+        koinStomp.connect(retry)
     }
 
     suspend fun disconnectWS() {
@@ -59,8 +59,13 @@ class ChatRemoteDataSource @Inject constructor(
         articleId: Int,
         chatRoomId: Int,
         message: ChatMessageRequest
-    ) {
-        koinStomp.convertAndSend("/app/chat/$articleId/$chatRoomId", message)
+    ): Result<Unit> {
+        return try {
+            koinStomp.convertAndSend("/app/chat/$articleId/$chatRoomId", message)
+            Result.success(Unit)
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
     }
 
     suspend fun blockUser(

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -8,6 +8,7 @@ import `in`.koreatech.koin.data.response.chat.ChatMessageResponse
 import `in`.koreatech.koin.data.response.chat.ChatRoomResponse
 import `in`.koreatech.koin.data.stomp.KoinStomp
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 
 class ChatRemoteDataSource @Inject constructor(
@@ -60,11 +61,10 @@ class ChatRemoteDataSource @Inject constructor(
         chatRoomId: Int,
         message: ChatMessageRequest
     ): Result<Unit> {
-        return try {
+        return runCatching {
             koinStomp.convertAndSend("/app/chat/$articleId/$chatRoomId", message)
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        }.onFailure {
+            if (it is CancellationException) throw it
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.data.stomp
 
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.DeserializationStrategy

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -9,7 +9,6 @@ import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json.Default.serializersModule
 import kotlinx.serialization.serializer
 import org.hildan.krossbow.stomp.StompClient
-import org.hildan.krossbow.stomp.StompReceipt
 import org.hildan.krossbow.stomp.StompSession
 import org.hildan.krossbow.stomp.conversions.kxserialization.StompSessionWithKxSerialization
 import org.hildan.krossbow.stomp.conversions.kxserialization.json.withJsonConversions
@@ -68,8 +67,8 @@ class KoinStomp @Inject constructor(
         headers: String,
         body: T? = null,
         serializer: SerializationStrategy<T>
-    ): StompReceipt? {
-        return try {
+    ) {
+        try {
             jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
         } catch (e: UninitializedPropertyAccessException) {
             throw e
@@ -79,9 +78,9 @@ class KoinStomp @Inject constructor(
     suspend inline fun <reified T : Any> convertAndSend(
         headers: String,
         body: T
-    ): StompReceipt? {
+    ) {
         val serializer = serializersModule.serializer<T>()
-        return try {
+        try {
             jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
         } catch (e: UninitializedPropertyAccessException) {
             throw e

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.data.stomp
 
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.DeserializationStrategy
@@ -26,8 +27,8 @@ class KoinStomp @Inject constructor(
     var stompSession: StompSession? = null
     lateinit var jsonStompSession: StompSessionWithKxSerialization
 
-    suspend fun connect() {
-        if (stompSession == null) {
+    suspend fun connect(retry: Boolean) {
+        if (stompSession == null || retry) {
             stompSession =
                 stompClient.connect(
                     url = "${baseUrl.replaceFirst("https", "wss")}/ws-stomp",
@@ -53,8 +54,7 @@ class KoinStomp @Inject constructor(
                         .collect { emit(it) }
                 } catch (e: WebSocketException) {
                     Timber.d("WebSocketException, reconnecting...")
-                    disconnect()
-                    connect()
+                    connect(true)
                     Timber.d("Reconnected. Retrying subscription...")
                 } catch (e: CancellationException) {
                     throw e
@@ -70,7 +70,11 @@ class KoinStomp @Inject constructor(
         body: T? = null,
         serializer: SerializationStrategy<T>
     ): StompReceipt? {
-        return jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
+        return try {
+            jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
+        } catch (e: UninitializedPropertyAccessException) {
+            throw e
+        }
     }
 
     suspend inline fun <reified T : Any> convertAndSend(
@@ -78,6 +82,10 @@ class KoinStomp @Inject constructor(
         body: T
     ): StompReceipt? {
         val serializer = serializersModule.serializer<T>()
-        return jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
+        return try {
+            jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
+        } catch (e: UninitializedPropertyAccessException) {
+            throw e
+        }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/ChatRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/ChatRepository.kt
@@ -6,7 +6,7 @@ import `in`.koreatech.koin.domain.model.chat.ChatRoom
 import kotlinx.coroutines.flow.Flow
 
 interface ChatRepository {
-    suspend fun connectWS()
+    suspend fun connectWS(retry: Boolean = false)
 
     suspend fun disconnectWS()
 
@@ -33,7 +33,7 @@ interface ChatRepository {
         articleId: Int,
         chatRoomId: Int,
         message: ChatMessage
-    )
+    ): Result<Unit>
 
     suspend fun blockUser(
         articleId: Int,

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSConnectUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSConnectUseCase.kt
@@ -10,8 +10,8 @@ class ChatWSConnectUseCase @Inject constructor(
         return try {
             chatRepository.connectWS()
             Result.success(Unit)
-        } catch (t: Throwable) {
-            Result.failure(t)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSConnectUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSConnectUseCase.kt
@@ -2,16 +2,16 @@ package `in`.koreatech.koin.domain.usecase.chat
 
 import `in`.koreatech.koin.domain.repository.ChatRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 
 class ChatWSConnectUseCase @Inject constructor(
     private val chatRepository: ChatRepository
 ) {
     suspend operator fun invoke(): Result<Unit> {
-        return try {
+        return runCatching {
             chatRepository.connectWS()
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        }.onFailure {
+            if (it is CancellationException) throw it
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSDisconnectUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSDisconnectUseCase.kt
@@ -2,16 +2,16 @@ package `in`.koreatech.koin.domain.usecase.chat
 
 import `in`.koreatech.koin.domain.repository.ChatRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 
 class ChatWSDisconnectUseCase @Inject constructor(
     private val chatRepository: ChatRepository
 ) {
     suspend operator fun invoke(): Result<Unit> {
-        return try {
+        return runCatching {
             chatRepository.disconnectWS()
-            Result.success(Unit)
-        } catch (e: Exception) {
-            Result.failure(e)
+        }.onFailure {
+            if (it is CancellationException) throw it
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSDisconnectUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/ChatWSDisconnectUseCase.kt
@@ -10,8 +10,8 @@ class ChatWSDisconnectUseCase @Inject constructor(
         return try {
             chatRepository.disconnectWS()
             Result.success(Unit)
-        } catch (t: Throwable) {
-            Result.failure(t)
+        } catch (e: Exception) {
+            Result.failure(e)
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SendMessageUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SendMessageUseCase.kt
@@ -11,5 +11,16 @@ class SendMessageUseCase @Inject constructor(
         articleId: Int,
         chatRoomId: Int,
         message: ChatMessage
-    ) = chatRepository.sendMessage(articleId, chatRoomId, message)
+    ): Result<Unit> = chatRepository.sendMessage(articleId, chatRoomId, message).onFailure {
+        when (it) {
+            is UninitializedPropertyAccessException -> {
+                chatRepository.connectWS(retry = true)
+                invoke(articleId, chatRoomId, message)
+            }
+
+            else -> {
+                throw it
+            }
+        }
+    }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatRoomUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatRoomUseCase.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.domain.usecase.chat
 
 import `in`.koreatech.koin.domain.repository.ChatRepository
+import kotlinx.coroutines.flow.catch
 import javax.inject.Inject
 
 class SubscribeChatRoomUseCase @Inject constructor(
@@ -9,5 +10,15 @@ class SubscribeChatRoomUseCase @Inject constructor(
     operator fun invoke(
         articleId: Int,
         chatRoomId: Int
-    ) = chatRepository.subscribeChatRoom(articleId, chatRoomId)
+    ) = chatRepository.subscribeChatRoom(articleId, chatRoomId).catch {
+        when (it) {
+            is UninitializedPropertyAccessException -> {
+                chatRepository.connectWS(retry = true)
+            }
+
+            else -> {
+                throw it
+            }
+        }
+    }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatRoomUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatRoomUseCase.kt
@@ -1,8 +1,8 @@
 package `in`.koreatech.koin.domain.usecase.chat
 
 import `in`.koreatech.koin.domain.repository.ChatRepository
-import kotlinx.coroutines.flow.catch
 import javax.inject.Inject
+import kotlinx.coroutines.flow.catch
 
 class SubscribeChatRoomUseCase @Inject constructor(
     private val chatRepository: ChatRepository


### PR DESCRIPTION
##  개요
* 채팅 서버와 연결이 정상적으로 되지 않은 상황에서 메시지 전송/수신 시 발생하던 크래시 수정

## 작업 내용
* 서버에 정상적으로 연결되지 않은 상태에서, 메시지 수신(구독), 메시지 전송을 시도할 경우 크래시가 발생하던 문제를 수정했습니다.
* sendMessage 함수의 경우, Result를 이용해서 성공 / 실패 여부를 반환하도록 수정했습니다. exception 발생 시 실패로 간주합니다.
* connectWS 함수에 retry 값을 추가해, 재시도시 기존의 연결 정보를 무시하고 아예 다시 연결을 시도하도록 수정했습니다.
* 각 UseCase에서 에러를 catch해서 바로 재연결 시도를 하도록 수정했습니다.
* Usecase에서 기타 exception은 일단 viewModel로 전부 던지게 두었습니다. 추후 다른 exception에 대한 에러 핸들링이 필요해 보입니다.
* SendMessageUseCase의 경우, Flow가 아닌 Result로 값을 반환하기 때문에, 재연결 시도 후, 전송 실패한 메시지를 다시 전송하도록 수정했습니다.