### PR TITLE
[Fix] 분실물 화면이 무한대로 Recomposition 되던 문제 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -67,8 +67,9 @@ fun LostAndFoundList(
 
     val lazyListState = rememberLazyListState()
     val firstItemPosition by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
+    val isScrolledToTheEnd by remember { derivedStateOf { lazyListState.isScrolledToTheEnd() } }
     val fabBottomPadding: Dp by animateDpAsState(
-        if (lazyListState.isScrolledToTheEnd() && firstItemPosition != 0) {
+        if (isScrolledToTheEnd && firstItemPosition != 0) {
             64.dp
         } else {
             0.dp


### PR DESCRIPTION
## 개요
* 분실물 화면이 무한대로 Recomposition 되던 문제 수정

## 작업 내용
* 분실물 화면이 무한대로 Recomposition 되던 문제를 수정했습니다.