### PR TITLE
[Fix] 분실물 목록 화면이 항상 새로고침 되던 문제 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -17,10 +17,10 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -43,6 +43,7 @@ import `in`.koreatech.koin.feature.lostandfound.ui.lostandfound.component.LostAn
 import `in`.koreatech.koin.feature.lostandfound.ui.lostandfound.component.LostAndFoundKeywordGroup
 import `in`.koreatech.koin.feature.lostandfound.ui.lostandfound.component.LostAndFoundPagination
 import `in`.koreatech.koin.feature.lostandfound.ui.lostandfound.component.lostAndFoundDialogStyle
+import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -56,11 +57,8 @@ fun LostAndFoundList(
     navigateToLoginActivity: () -> Unit = {}
 ) {
     val uiState by viewModel.collectAsState()
-    viewModel.collectSideEffect { sideEffect ->
-        handleSideEffect(sideEffect, viewModel)
-    }
     val isLoading = uiState.isLoading
-
+    val coroutineScope = rememberCoroutineScope()
     val lazyListState = rememberLazyListState()
     val firstItemPosition by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
     val fabBottomPadding: Dp by animateDpAsState(
@@ -70,6 +68,18 @@ fun LostAndFoundList(
             0.dp
         }
     )
+
+    viewModel.collectSideEffect { sideEffect ->
+        handleSideEffect(
+            sideEffect = sideEffect,
+            viewModel = viewModel,
+            scrollToTop = {
+                coroutineScope.launch {
+                    lazyListState.scrollToItem(0)
+                }
+            }
+        )
+    }
 
     val context = LocalContext.current
 
@@ -236,10 +246,6 @@ fun LostAndFoundList(
                     }
                 }
 
-                LaunchedEffect(uiState.currentPage) {
-                    lazyListState.scrollToItem(0)
-                }
-
                 if (isLoading) {
                     LoadingDialog()
                 }
@@ -269,11 +275,13 @@ fun LostAndFoundList(
 
 fun handleSideEffect(
     sideEffect: LostAndFoundSideEffect,
-    viewModel: LostAndFoundViewModel
+    viewModel: LostAndFoundViewModel,
+    scrollToTop: () -> Unit = {}
 ) {
     when (sideEffect) {
         is LostAndFoundSideEffect.PageChanged -> {
             viewModel.fetchLostAndFoundList()
+            scrollToTop()
         }
 
         LostAndFoundSideEffect.KeywordUpdated -> {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -141,10 +141,9 @@ fun LostAndFoundList(
         ) { contentPadding ->
             val myKeywords = uiState.myKeywords
             Column(
-                modifier =
-                    modifier
-                        .padding(contentPadding)
-                        .consumeWindowInsets(contentPadding)
+                modifier = modifier
+                    .padding(contentPadding)
+                    .consumeWindowInsets(contentPadding)
             ) {
                 LazyColumn(
                     modifier = modifier,
@@ -153,11 +152,10 @@ fun LostAndFoundList(
                     item {
                         LostAndFoundKeywordGroup(
                             keyWords = myKeywords,
-                            selectedKeywordIndex =
-                                when (uiState.selectedKeyword) {
-                                    "" -> 0
-                                    else -> myKeywords.indexOf(uiState.selectedKeyword) + 1
-                                },
+                            selectedKeywordIndex = when (uiState.selectedKeyword) {
+                                "" -> 0
+                                else -> myKeywords.indexOf(uiState.selectedKeyword) + 1
+                            },
                             navigateToKeywordFragment = navigateToKeywordFragment
                         ) {
                             viewModel.selectKeyword(it)
@@ -194,10 +192,9 @@ fun LostAndFoundList(
                     if (uiState.lostAndFoundList.isEmpty()) {
                         item {
                             Text(
-                                modifier =
-                                    modifier
-                                        .fillMaxWidth()
-                                        .padding(top = 16.dp),
+                                modifier = modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 16.dp),
                                 textAlign = TextAlign.Center,
                                 fontSize = 16.sp,
                                 text = stringResource(R.string.empty_articles)
@@ -231,9 +228,8 @@ fun LostAndFoundList(
                         }
                         item {
                             LostAndFoundPagination(
-                                modifier =
-                                    Modifier
-                                        .fillMaxWidth(),
+                                modifier = Modifier
+                                    .fillMaxWidth(),
                                 currentPage = uiState.currentPage,
                                 totalPage = uiState.totalPage
                             ) {
@@ -254,11 +250,10 @@ fun LostAndFoundList(
                     LostAndFoundDialog(
                         title = stringResource(R.string.request_login_dialog_title),
                         description = stringResource(R.string.request_login_dialog_description),
-                        lostAndFoundDialogStyle =
-                            lostAndFoundDialogStyle().copy(
-                                titleStyle = KoinTheme.typography.medium18.copy(textAlign = TextAlign.Center),
-                                descriptionStyle = KoinTheme.typography.regular14.copy(textAlign = TextAlign.Center)
-                            ),
+                        lostAndFoundDialogStyle = lostAndFoundDialogStyle().copy(
+                            titleStyle = KoinTheme.typography.medium18.copy(textAlign = TextAlign.Center),
+                            descriptionStyle = KoinTheme.typography.regular14.copy(textAlign = TextAlign.Center)
+                        ),
                         onPositive = {
                             navigateToLoginActivity()
                             viewModel.setShowLoginRequestDialog(false)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -61,10 +61,6 @@ fun LostAndFoundList(
     }
     val isLoading = uiState.isLoading
 
-    LaunchedEffect(uiState.selectedKeyword) {
-        viewModel.fetchLostAndFoundList()
-    }
-
     val lazyListState = rememberLazyListState()
     val firstItemPosition by remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }
     val fabBottomPadding: Dp by animateDpAsState(
@@ -136,9 +132,9 @@ fun LostAndFoundList(
             val myKeywords = uiState.myKeywords
             Column(
                 modifier =
-                modifier
-                    .padding(contentPadding)
-                    .consumeWindowInsets(contentPadding)
+                    modifier
+                        .padding(contentPadding)
+                        .consumeWindowInsets(contentPadding)
             ) {
                 LazyColumn(
                     modifier = modifier,
@@ -148,10 +144,10 @@ fun LostAndFoundList(
                         LostAndFoundKeywordGroup(
                             keyWords = myKeywords,
                             selectedKeywordIndex =
-                            when (uiState.selectedKeyword) {
-                                "" -> 0
-                                else -> myKeywords.indexOf(uiState.selectedKeyword) + 1
-                            },
+                                when (uiState.selectedKeyword) {
+                                    "" -> 0
+                                    else -> myKeywords.indexOf(uiState.selectedKeyword) + 1
+                                },
                             navigateToKeywordFragment = navigateToKeywordFragment
                         ) {
                             viewModel.selectKeyword(it)
@@ -189,9 +185,9 @@ fun LostAndFoundList(
                         item {
                             Text(
                                 modifier =
-                                modifier
-                                    .fillMaxWidth()
-                                    .padding(top = 16.dp),
+                                    modifier
+                                        .fillMaxWidth()
+                                        .padding(top = 16.dp),
                                 textAlign = TextAlign.Center,
                                 fontSize = 16.sp,
                                 text = stringResource(R.string.empty_articles)
@@ -226,8 +222,8 @@ fun LostAndFoundList(
                         item {
                             LostAndFoundPagination(
                                 modifier =
-                                Modifier
-                                    .fillMaxWidth(),
+                                    Modifier
+                                        .fillMaxWidth(),
                                 currentPage = uiState.currentPage,
                                 totalPage = uiState.totalPage
                             ) {
@@ -253,10 +249,10 @@ fun LostAndFoundList(
                         title = stringResource(R.string.request_login_dialog_title),
                         description = stringResource(R.string.request_login_dialog_description),
                         lostAndFoundDialogStyle =
-                        lostAndFoundDialogStyle().copy(
-                            titleStyle = KoinTheme.typography.medium18.copy(textAlign = TextAlign.Center),
-                            descriptionStyle = KoinTheme.typography.regular14.copy(textAlign = TextAlign.Center)
-                        ),
+                            lostAndFoundDialogStyle().copy(
+                                titleStyle = KoinTheme.typography.medium18.copy(textAlign = TextAlign.Center),
+                                descriptionStyle = KoinTheme.typography.regular14.copy(textAlign = TextAlign.Center)
+                            ),
                         onPositive = {
                             navigateToLoginActivity()
                             viewModel.setShowLoginRequestDialog(false)
@@ -277,6 +273,10 @@ fun handleSideEffect(
 ) {
     when (sideEffect) {
         is LostAndFoundSideEffect.PageChanged -> {
+            viewModel.fetchLostAndFoundList()
+        }
+
+        LostAndFoundSideEffect.KeywordUpdated -> {
             viewModel.fetchLostAndFoundList()
         }
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundSideEffect.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundSideEffect.kt
@@ -2,4 +2,5 @@ package `in`.koreatech.koin.feature.lostandfound.ui.lostandfound
 
 sealed class LostAndFoundSideEffect {
     data class PageChanged(val page: Int) : LostAndFoundSideEffect()
+    data object KeywordUpdated : LostAndFoundSideEffect() // Called if keyword updated
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundViewModel.kt
@@ -39,6 +39,7 @@ class LostAndFoundViewModel @Inject constructor(
         )
 
     init {
+        fetchLostAndFoundList()
         fetchMyKeyword()
         getUserType()
     }
@@ -135,6 +136,7 @@ class LostAndFoundViewModel @Inject constructor(
                             myKeywords = it
                         )
                     }
+                    postSideEffect(LostAndFoundSideEffect.KeywordUpdated)
                 }
             }
         }


### PR DESCRIPTION
## 개요
* 분실물 목록 화면이 항상 새로고침 되던 문제 수정

## 작업 내용
* 분실물 목록 화면에서 분실물 게시글을 선택했다 돌아왔을 때, 분실물 게시글 API를 다시 요청하던 문제를 수정했습니다.
* 분실물 목록 화면으로 돌아왔을 때, 분실물 목록이 항상 최상단으로 돌아오던 문제를 수정했습니다.