### PR TITLE
[Fix] 유저팀 및 캠퍼스 팀 login_prompt 로깅 추가

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -84,7 +84,6 @@ object AnalyticsConstant {
         const val ADD_KEYWORD = "add_keyword"
         const val RECOMMENDED_KEYWORD = "recommended_keyword"
         const val KEYWORD_NOTIFICATION = "keyword_notification"
-        const val LOGIN_POPUP_KEYWORD = "login_popup_keyword"
         const val NOTICE_SEARCH_EVENT = "notice_search_event"
         const val NOTICE_ORIGINAL_SHORTCUT = "notice_original_shortcut"
 

--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -99,6 +99,8 @@ object AnalyticsConstant {
         const val POPULAR_NOTICE_BANNER = "popular_notice_banner"
         const val TO_MANAGE_KEYWORD = "to_manage_keyword"
 
+        const val LOGIN_PROMPT = "login_prompt"
+
         object LostAndFound {
             const val LOST_ITEM_ADD_ITEM = "lost_item_add_item"
             const val FIND_USER_ADD_ITEM = "find_user_add_item"

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -258,6 +258,10 @@ fun LostAndFoundList(
                             descriptionStyle = KoinTheme.typography.regular14.copy(textAlign = TextAlign.Center)
                         ),
                         onPositive = {
+                            EventLogger.logCampusClickEvent(
+                                AnalyticsConstant.Label.LOGIN_PROMPT,
+                                "게시글 작성 팝업"
+                            )
                             navigateToLoginActivity()
                             viewModel.setShowLoginRequestDialog(false)
                         },

--- a/feature/timetable/build.gradle.kts
+++ b/feature/timetable/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":domain"))
     implementation(project(":core:designsystem"))
+    implementation(project(":core:analytics"))
 
     implementation(libs.core.ktx)
     implementation(libs.appcompat)

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/RequestLoginDialog.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/RequestLoginDialog.kt
@@ -26,6 +26,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventAction
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.timetable.R
 import `in`.koreatech.koin.feature.timetable.component.FilledTextButton
@@ -106,7 +109,14 @@ fun RequestLoginDialog(
                             .height(48.dp)
                             .weight(1.0F),
                         text = stringResource(id = R.string.request_login_confirmation),
-                        onClick = { onConfirm() }
+                        onClick = {
+                            EventLogger.logClickEvent(
+                                EventAction.USER,
+                                AnalyticsConstant.Label.LOGIN_PROMPT,
+                                "시간표 관리 팝업"
+                            )
+                            onConfirm()
+                        }
                     )
                 }
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
@@ -53,6 +53,10 @@ class ArticleKeywordFragment : Fragment() {
                 positiveButtonText = R.string.action_login
             ),
             onPositiveButtonClicked = {
+                EventLogger.logCampusClickEvent(
+                    AnalyticsConstant.Label.LOGIN_PROMPT,
+                    "키워드 알림 팝업"
+                )
                 val intent =
                     Intent(Intent.ACTION_VIEW).apply {
                         data = Uri.parse("koin://login/login?link=koin://article/activity?fragment=article_keyword")

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
@@ -53,11 +53,6 @@ class ArticleKeywordFragment : Fragment() {
                 positiveButtonText = R.string.action_login
             ),
             onPositiveButtonClicked = {
-                EventLogger.logClickEvent(
-                    EventAction.CAMPUS,
-                    AnalyticsConstant.Label.LOGIN_POPUP_KEYWORD,
-                    getString(R.string.action_login)
-                )
                 val intent =
                     Intent(Intent.ACTION_VIEW).apply {
                         data = Uri.parse("koin://login/login?link=koin://article/activity?fragment=article_keyword")
@@ -66,11 +61,6 @@ class ArticleKeywordFragment : Fragment() {
                 startActivity(intent)
             },
             onNegativeButtonClicked = {
-                EventLogger.logClickEvent(
-                    EventAction.CAMPUS,
-                    AnalyticsConstant.Label.LOGIN_POPUP_KEYWORD,
-                    getString(R.string.close)
-                )
                 it.dismiss()
             }
         )


### PR DESCRIPTION
## 개요
* 유저팀 및 캠퍼스 팀 login_prompt 로깅 추가

## 작업 내용
* 기존 키워드 알림에 있던 login_popup_keyword 로깅을 제거했습니다.
* timetable 모듈에 analytics 모듈 의존성을 추가했습니다.
* 비로그인 유저가 분실물 게시글 작성을 시도할 시 표출되는 로그인 요청 다이얼로그에 login_prompt 로깅을 추가헀습니다.
* 비로그인 유저가 키워드 알림을 활성화 할 때 표출되는 로그인 요청 다이얼로그에 login_prompt 로깅을 추가했습니다.
* 비로그인 유저가 시간표 관리 기능을 이용하려고 할 때 표출되는 로그인 요청 다이얼로그에 login_prompt 로깅을 추가했습니다.
