### PR TITLE
[Fix] 앱링크 주소가 /로 끝날때 실행되지 않던 문제 수정

### DIFF
--- a/koin/src/main/AndroidManifest.xml
+++ b/koin/src/main/AndroidManifest.xml
@@ -182,7 +182,7 @@
 
                 <data android:host="${appLinkUri}"
                     tools:replace="host"/>
-                <data android:path="/articles/lost-item"/>
+                <data android:pathPrefix="/articles/lost-item"/>
             </intent-filter>
         </activity>
         <activity


### PR DESCRIPTION
## 개요
* 앱링크 주소가 /로 끝날때 실행되지 않던 문제 수정

## 작업 내용
* 앱링크 주소가 /articles/lost-item이 아니라 /articles/lost-item/ 일 경우, 정상적으로 실행되지 않던 문제를 수정했습니다.