### PR TITLE
[Fix] 게시글 작성자가 탈퇴한 사용자일 경우, 채팅 버튼을 숨기도록 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -76,6 +76,7 @@ fun LostAndFoundDetail(
                 showDeleteButton = uiState.isMine,
                 showDeleteDialog = uiState.showDeleteDialog,
                 isLoggedIn = uiState.isLoggedIn,
+                isAuthorWithDraw = uiState.isAuthorWithdraw,
                 onArticleListClick = {
                     navigateToArticleList()
                 },

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -76,7 +76,7 @@ fun LostAndFoundDetail(
                 showDeleteButton = uiState.isMine,
                 showDeleteDialog = uiState.showDeleteDialog,
                 isLoggedIn = uiState.isLoggedIn,
-                isAuthorWithDraw = uiState.isAuthorWithdraw,
+                isAuthorWithdraw = uiState.isAuthorWithdraw,
                 onArticleListClick = {
                     navigateToArticleList()
                 },

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
@@ -27,6 +27,7 @@ data class LostAndFoundDetailState(
     val updatedAt: String = "",
     val isWriterCouncil: Boolean = false,
     val isMine: Boolean = false,
+    val isAuthorWithdraw: Boolean = false,
     val hotArticles: List<ArticleHeaderState> = emptyList()
 ) : Parcelable
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -94,6 +94,7 @@ class LostAndFoundDetailViewModel @Inject constructor(
                             updatedAt = article.updatedAt,
                             isWriterCouncil = article.isWriterCouncil,
                             isMine = state.currentLoggedInUser == article.author,
+                            isAuthorWithdraw = article.author == "탈퇴한 사용자",
                             isLoading = false
                         )
                     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
@@ -55,20 +55,18 @@ fun DetailButtonGroup(
     }
 
     Row(
-        modifier =
-            modifier
-                .padding(horizontal = 24.dp, vertical = 16.dp)
-                .fillMaxWidth()
+        modifier = modifier
+            .padding(horizontal = 24.dp, vertical = 16.dp)
+            .fillMaxWidth()
     ) {
         Button(
             modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
             contentPadding = PaddingValues(12.dp, 6.dp),
             onClick = onArticleListClick,
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = KoinTheme.colors.neutral300,
-                    contentColor = KoinTheme.colors.neutral600
-                ),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = KoinTheme.colors.neutral300,
+                contentColor = KoinTheme.colors.neutral600
+            ),
             shape = KoinTheme.shapes.extraSmall
         ) {
             Text(
@@ -91,11 +89,10 @@ fun DetailButtonGroup(
                         "삭제"
                     )
                 },
-                colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = KoinTheme.colors.neutral300,
-                        contentColor = KoinTheme.colors.neutral600
-                    ),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = KoinTheme.colors.neutral300,
+                    contentColor = KoinTheme.colors.neutral600
+                ),
                 shape = KoinTheme.shapes.extraSmall
             ) {
                 Row(
@@ -150,11 +147,10 @@ fun DetailButtonGroup(
                     modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
                     contentPadding = PaddingValues(10.dp, 6.dp),
                     onClick = onReportArticleClick,
-                    colors =
-                        ButtonDefaults.buttonColors(
-                            containerColor = KoinTheme.colors.neutral300,
-                            contentColor = KoinTheme.colors.neutral600
-                        ),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = KoinTheme.colors.neutral300,
+                        contentColor = KoinTheme.colors.neutral600
+                    ),
                     shape = KoinTheme.shapes.extraSmall
                 ) {
                     Image(

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
@@ -113,7 +113,7 @@ fun DetailButtonGroup(
             }
         } else {
             if (isLoggedIn) {
-                if (!isAuthorWithDraw) {
+                if (!isAuthorWithdraw) {
                     Button(
                         modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
                         contentPadding = PaddingValues(10.dp, 6.dp),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
@@ -29,7 +29,7 @@ fun DetailButtonGroup(
     showDeleteButton: Boolean = false,
     showDeleteDialog: Boolean = false,
     isLoggedIn: Boolean = false,
-    isAuthorWithDraw: Boolean = false,
+    isAuthorWithdraw: Boolean = false,
     onShowDeleteDialogChange: (Boolean) -> Unit = {},
     onArticleListClick: () -> Unit = {},
     onDeleteArticleClick: () -> Unit = {},

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailButtonGroup.kt
@@ -29,6 +29,7 @@ fun DetailButtonGroup(
     showDeleteButton: Boolean = false,
     showDeleteDialog: Boolean = false,
     isLoggedIn: Boolean = false,
+    isAuthorWithDraw: Boolean = false,
     onShowDeleteDialogChange: (Boolean) -> Unit = {},
     onArticleListClick: () -> Unit = {},
     onDeleteArticleClick: () -> Unit = {},
@@ -55,19 +56,19 @@ fun DetailButtonGroup(
 
     Row(
         modifier =
-        modifier
-            .padding(horizontal = 24.dp, vertical = 16.dp)
-            .fillMaxWidth()
+            modifier
+                .padding(horizontal = 24.dp, vertical = 16.dp)
+                .fillMaxWidth()
     ) {
         Button(
             modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
             contentPadding = PaddingValues(12.dp, 6.dp),
             onClick = onArticleListClick,
             colors =
-            ButtonDefaults.buttonColors(
-                containerColor = KoinTheme.colors.neutral300,
-                contentColor = KoinTheme.colors.neutral600
-            ),
+                ButtonDefaults.buttonColors(
+                    containerColor = KoinTheme.colors.neutral300,
+                    contentColor = KoinTheme.colors.neutral600
+                ),
             shape = KoinTheme.shapes.extraSmall
         ) {
             Text(
@@ -91,10 +92,10 @@ fun DetailButtonGroup(
                     )
                 },
                 colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = KoinTheme.colors.neutral300,
-                    contentColor = KoinTheme.colors.neutral600
-                ),
+                    ButtonDefaults.buttonColors(
+                        containerColor = KoinTheme.colors.neutral300,
+                        contentColor = KoinTheme.colors.neutral600
+                    ),
                 shape = KoinTheme.shapes.extraSmall
             ) {
                 Row(
@@ -115,32 +116,33 @@ fun DetailButtonGroup(
             }
         } else {
             if (isLoggedIn) {
-                Button(
-                    modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
-                    contentPadding = PaddingValues(10.dp, 6.dp),
-                    onClick = onChatRoomClick,
-                    colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = KoinTheme.colors.neutral300,
-                        contentColor = KoinTheme.colors.neutral600
-                    ),
-                    shape = KoinTheme.shapes.extraSmall
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically
+                if (!isAuthorWithDraw) {
+                    Button(
+                        modifier = Modifier.defaultMinSize(minWidth = 1.dp, minHeight = 1.dp),
+                        contentPadding = PaddingValues(10.dp, 6.dp),
+                        onClick = onChatRoomClick,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = KoinTheme.colors.neutral300,
+                            contentColor = KoinTheme.colors.neutral600
+                        ),
+                        shape = KoinTheme.shapes.extraSmall
                     ) {
-                        Image(
-                            modifier = Modifier.size(20.dp),
-                            painter = painterResource(id = R.drawable.ic_chat),
-                            contentDescription = null
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Image(
+                                modifier = Modifier.size(20.dp),
+                                painter = painterResource(id = R.drawable.ic_chat),
+                                contentDescription = null
+                            )
 
-                        Spacer(modifier = Modifier.width(4.dp))
+                            Spacer(modifier = Modifier.width(4.dp))
 
-                        Text(
-                            style = KoinTheme.typography.regular12,
-                            text = stringResource(R.string.detail_chat_room_button)
-                        )
+                            Text(
+                                style = KoinTheme.typography.regular12,
+                                text = stringResource(R.string.detail_chat_room_button)
+                            )
+                        }
                     }
                 }
 
@@ -149,10 +151,10 @@ fun DetailButtonGroup(
                     contentPadding = PaddingValues(10.dp, 6.dp),
                     onClick = onReportArticleClick,
                     colors =
-                    ButtonDefaults.buttonColors(
-                        containerColor = KoinTheme.colors.neutral300,
-                        contentColor = KoinTheme.colors.neutral600
-                    ),
+                        ButtonDefaults.buttonColors(
+                            containerColor = KoinTheme.colors.neutral300,
+                            contentColor = KoinTheme.colors.neutral600
+                        ),
                     shape = KoinTheme.shapes.extraSmall
                 ) {
                     Image(


### PR DESCRIPTION
## 개요
* 게시글 작성자가 탈퇴한 사용자일 경우, 채팅 버튼을 숨기도록 수정

## 작업 내용
* 분실물 게시글 작성자가 탈퇴한 사용자인 경우, 쪽지 보내기 버튼을 숨김 처리 했습니다.

## 사진
|탈퇴한 사용자|일반 사용자|
|------------------|---------------|
|![Screenshot_20250324-191231_코인D](https://github.com/user-attachments/assets/493c427d-5998-4418-a16f-70c415d06de6)|![Screenshot_20250324-191235_코인D](https://github.com/user-attachments/assets/d32bec6f-ef0e-464e-bf1c-6d74ed399c46)|

## 참고
* https://github.com/BCSDLab/KOIN_API_V2/pull/1391#issue-2940907112