### PR TITLE
[FEAT] 배너 차단 기능 구현

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/di/datastore/DataStoreModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/datastore/DataStoreModule.kt
@@ -10,6 +10,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import `in`.koreatech.koin.data.source.datastore.ArticleDataStore
+import `in`.koreatech.koin.data.source.datastore.BannerDataStore
 import `in`.koreatech.koin.data.source.datastore.BusDataStore
 import `in`.koreatech.koin.data.source.datastore.TimetableDataStore
 import javax.inject.Singleton
@@ -27,6 +28,10 @@ object DataStoreModule {
 
     private val Context.busDataStore: DataStore<Preferences> by preferencesDataStore(
         name = "bus.ds"
+    )
+
+    private val Context.bannerDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "banner_data_Store"
     )
 
     @Provides
@@ -51,5 +56,13 @@ object DataStoreModule {
         @ApplicationContext context: Context
     ): BusDataStore {
         return BusDataStore(context.busDataStore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideBannerDataStore(
+        @ApplicationContext context: Context
+    ): BannerDataStore {
+        return BannerDataStore(context.bannerDataStore)
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/di/repository/RepositoryModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/repository/RepositoryModule.kt
@@ -26,6 +26,7 @@ import `in`.koreatech.koin.data.repository.UploadUrlRepositoryImpl
 import `in`.koreatech.koin.data.repository.UserRepositoryImpl
 import `in`.koreatech.koin.data.repository.VersionRepositoryImpl
 import `in`.koreatech.koin.data.source.local.ArticleLocalDataSource
+import `in`.koreatech.koin.data.source.local.BannerLocalDataSource
 import `in`.koreatech.koin.data.source.local.DeptLocalDataSource
 import `in`.koreatech.koin.data.source.local.SignupTermsLocalDataSource
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
@@ -228,7 +229,13 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideBannerRepository(bannerRemoteDataSource: BannerRemoteDataSource): BannerRepository {
-        return BannerRepositoryImpl(bannerRemoteDataSource)
+    fun provideBannerRepository(
+        bannerRemoteDataSource: BannerRemoteDataSource,
+        bannerLocalDataSource: BannerLocalDataSource
+    ): BannerRepository {
+        return BannerRepositoryImpl(
+            bannerRemoteDataSource,
+            bannerLocalDataSource
+        )
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/BannerRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/BannerRepositoryImpl.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.data.repository
 
 import `in`.koreatech.koin.data.mapper.toListOfBanner
 import `in`.koreatech.koin.data.mapper.toListOfBannerCategory
+import `in`.koreatech.koin.data.source.local.BannerLocalDataSource
 import `in`.koreatech.koin.data.source.remote.BannerRemoteDataSource
 import `in`.koreatech.koin.domain.model.banner.Banner
 import `in`.koreatech.koin.domain.model.banner.BannerCategory
@@ -11,7 +12,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class BannerRepositoryImpl @Inject constructor(
-    private val bannerRemoteDataSource: BannerRemoteDataSource
+    private val bannerRemoteDataSource: BannerRemoteDataSource,
+    private val bannerLocalDataSource: BannerLocalDataSource
 ) : BannerRepository {
     override suspend fun getBannersByCategory(
         categoryId: Int,
@@ -30,5 +32,12 @@ class BannerRepositoryImpl @Inject constructor(
                 bannerRemoteDataSource.getBannerCategories().categories.toListOfBannerCategory()
             )
         }
+    }
+
+    override suspend fun getBannerRefusalDate(): Int =
+        bannerLocalDataSource.getBannerRefusalDate()
+
+    override suspend fun saveBannerRefusalDate(date: Int) {
+        bannerLocalDataSource.saveBannerRefusalDate(date)
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/source/datastore/BannerDataStore.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/datastore/BannerDataStore.kt
@@ -1,0 +1,33 @@
+package `in`.koreatech.koin.data.source.datastore
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.emptyPreferences
+import androidx.datastore.preferences.core.intPreferencesKey
+import javax.inject.Inject
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+class BannerDataStore @Inject constructor(
+    private val dataStore: DataStore<Preferences>
+) {
+    suspend fun getBannerRefusalDate(): Int {
+        return dataStore.data.catch {
+            emit(emptyPreferences())
+        }.map { preferences ->
+            preferences[KEY_BANNER_REFUSAL_DATE] ?: 0
+        }.first()
+    }
+
+    suspend fun saveBannerRefusalDate(date: Int) {
+        dataStore.edit { preferences ->
+            preferences[KEY_BANNER_REFUSAL_DATE] = date
+        }
+    }
+
+    companion object {
+        private val KEY_BANNER_REFUSAL_DATE = intPreferencesKey("banner_refusal_date")
+    }
+}

--- a/data/src/main/java/in/koreatech/koin/data/source/local/BannerLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/BannerLocalDataSource.kt
@@ -1,0 +1,16 @@
+package `in`.koreatech.koin.data.source.local
+
+import `in`.koreatech.koin.data.source.datastore.BannerDataStore
+import javax.inject.Inject
+
+class BannerLocalDataSource @Inject constructor(
+    private val bannerDataStore: BannerDataStore
+) {
+    suspend fun getBannerRefusalDate(): Int {
+        return bannerDataStore.getBannerRefusalDate()
+    }
+
+    suspend fun saveBannerRefusalDate(date: Int) {
+        bannerDataStore.saveBannerRefusalDate(date)
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/BannerRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/BannerRepository.kt
@@ -11,4 +11,8 @@ interface BannerRepository {
     ): Flow<List<Banner>>
 
     suspend fun getBannerCategories(): Flow<List<BannerCategory>>
+
+    suspend fun getBannerRefusalDate(): Int
+
+    suspend fun saveBannerRefusalDate(date: Int)
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/banner/CheckBannerRefusalUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/banner/CheckBannerRefusalUseCase.kt
@@ -1,0 +1,16 @@
+package `in`.koreatech.koin.domain.usecase.banner
+
+import `in`.koreatech.koin.domain.repository.BannerRepository
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class CheckBannerRefusalUseCase @Inject constructor(
+    private val bannerRepository: BannerRepository
+) {
+    suspend operator fun invoke(): Boolean {
+        return bannerRepository.getBannerRefusalDate().let {
+            LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE).toInt() - it < 7
+        }
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/banner/SetBannerRefusalUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/banner/SetBannerRefusalUseCase.kt
@@ -1,0 +1,16 @@
+package `in`.koreatech.koin.domain.usecase.banner
+
+import `in`.koreatech.koin.domain.repository.BannerRepository
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import javax.inject.Inject
+
+class SetBannerRefusalUseCase @Inject constructor(
+    private val bannerRepository: BannerRepository
+) {
+    suspend operator fun invoke() {
+        bannerRepository.saveBannerRefusalDate(
+            LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE).toInt()
+        )
+    }
+}


### PR DESCRIPTION
feat: add BannerRefusal DataStore and UseCase

주요 기능 설명

**UseCase**
- SetBannerRefusalUseCase()
 DataStore 에 현재 날짜 저장 (현재 날짜를 배너 차단 날짜로 지정)

- CheckBannerRefusalUseCase(): Boolean
 DataStore 에 저장한 시간과 현재 시간을 비교해 7일 이내라면 true 아니면 false 반환
 즉 현재 거절된 상태인지 반환

**DataStore**
- saveBannerRefusalDate(date: Int)
 DataStore 에 해당 날짜 저장
- getBannerRefusalDate(): Int
 DataStore 에 저장된 날짜 반환

이 외 di, repo, source 등 설명은 생략하겠습니다.

dataStore 기능을 usecase 단계에서 재구성하여 사용하기 쉽게 만들어봤습니다.
배너 차단 해제에 관해서는 아직 모르기에 데이터 delete 혹은 초기화 기능은 만들지 않은 상태입니다.
피드백 부탁드립니다.

+ usecase 사용 예시
<img src="https://github.com/user-attachments/assets/df7f4674-357b-42c9-a1e2-96e6cd8865d3" width="40%">