### PR TITLE
[Feature] 메인 화면 배너 무한 스크롤 구현

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -35,7 +35,7 @@ fun BannerImage(
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {}
 ) {
-    val pagerState = rememberPagerState { bannerList.size }
+    val pagerState = rememberPagerState { Int.MAX_VALUE }
 
     Box(
         modifier = modifier
@@ -44,8 +44,9 @@ fun BannerImage(
             modifier = Modifier,
             state = pagerState
         ) { page ->
+            val realPage = page % bannerList.size
             BannerContent(
-                banner = bannerList[page],
+                banner = bannerList[realPage],
                 dismiss = dismiss,
                 currentKoinVersion = currentKoinVersion
             )
@@ -63,7 +64,7 @@ fun BannerImage(
                     .padding(horizontal = 12.dp),
                 text = buildAnnotatedString {
                     withStyle(SpanStyle(color = KoinTheme.colors.neutral0)) {
-                        append("${pagerState.currentPage + 1}")
+                        append("${(pagerState.currentPage % bannerList.size) + 1}")
                     }
                     withStyle(SpanStyle(color = KoinTheme.colors.neutral400)) {
                         append("/${bannerList.size}")


### PR DESCRIPTION
## 개요
* 메인 화면 배너 무한 스크롤 구현

## 작업 내용
* 메인 화면 배너에 무한 스크롤 기능을 추가했습니다.

## 기타
* 아직 배너가 develop에 머지되지 않아서 develop이 아닌 배너 작업 브랜치로 날렸습니다.
* 추후 수정하겠습니다.