### PR TITLE
[Fix] 배너가 없을때 발생하던 크래시 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -13,7 +13,6 @@ import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -35,24 +34,17 @@ class BannerActivity : ComponentActivity() {
         setContent {
             val uiState by viewModel.bannerState.collectAsState()
 
-            LaunchedEffect(uiState.isLoading) {
-                if (!uiState.isLoading && uiState.bannerList.isEmpty()) {
-                    finish()
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                        overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
-                        overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
-                    } else {
-                        overridePendingTransition(0, 0)
-                    }
-                }
-            }
-
             KoinTheme {
                 Scaffold(
                     modifier = Modifier.fillMaxSize(),
                     containerColor = Color.Transparent,
                     contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets.navigationBars)
                 ) { contentPadding ->
+                    if (uiState.isLoading) return@Scaffold // Don't render banner if not loaded yet
+                    if (uiState.bannerList.isEmpty()) { // Finish activity if banner list is empty
+                        finishActivity()
+                        return@Scaffold
+                    }
                     Box(
                         modifier = Modifier
                             .fillMaxSize()
@@ -62,28 +54,25 @@ class BannerActivity : ComponentActivity() {
                             bannerList = uiState.bannerList,
                             currentKoinVersion = uiState.currentVersionCode,
                             dismiss = {
-                                finish()
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                                    overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
-                                    overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
-                                } else {
-                                    overridePendingTransition(0, 0)
-                                }
+                                finishActivity()
                             },
                             dismissWithRefusal = {
                                 viewModel.setBannerRefusal()
-                                finish()
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                                    overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
-                                    overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
-                                } else {
-                                    overridePendingTransition(0, 0)
-                                }
+                                finishActivity()
                             }
                         )
                     }
                 }
             }
+        }
+    }
+    private fun finishActivity() {
+        finish()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            overrideActivityTransition(OVERRIDE_TRANSITION_OPEN, 0, 0)
+            overrideActivityTransition(OVERRIDE_TRANSITION_CLOSE, 0, 0)
+        } else {
+            overridePendingTransition(0, 0)
         }
     }
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -35,32 +35,33 @@ class BannerActivity : ComponentActivity() {
             val uiState by viewModel.bannerState.collectAsState()
 
             KoinTheme {
-                Scaffold(
-                    modifier = Modifier.fillMaxSize(),
-                    containerColor = Color.Transparent,
-                    contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets.navigationBars)
-                ) { contentPadding ->
-                    if (uiState.isLoading) return@Scaffold // Don't render banner if not loaded yet
+                if (!uiState.isLoading) {
                     if (uiState.bannerList.isEmpty()) { // Finish activity if banner list is empty
                         finishActivity()
-                        return@Scaffold
+                        return@KoinTheme
                     }
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(contentPadding)
-                    ) {
-                        BannerA(
-                            bannerList = uiState.bannerList,
-                            currentKoinVersion = uiState.currentVersionCode,
-                            dismiss = {
-                                finishActivity()
-                            },
-                            dismissWithRefusal = {
-                                viewModel.setBannerRefusal()
-                                finishActivity()
-                            }
-                        )
+                    Scaffold(
+                        modifier = Modifier.fillMaxSize(),
+                        containerColor = Color.Transparent,
+                        contentWindowInsets = ScaffoldDefaults.contentWindowInsets.exclude(WindowInsets.navigationBars)
+                    ) { contentPadding ->
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(contentPadding)
+                        ) {
+                            BannerA(
+                                bannerList = uiState.bannerList,
+                                currentKoinVersion = uiState.currentVersionCode,
+                                dismiss = {
+                                    finishActivity()
+                                },
+                                dismissWithRefusal = {
+                                    viewModel.setBannerRefusal()
+                                    finishActivity()
+                                }
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## 개요
* 배너가 없을때 발생하던 크래시 수정

## 작업 내용
* 배너가 없을 때 발생하던 divide by zero 오류를 수정했습니다.
* 기존에 배너가 로딩되지 않았을 때 및 배너가 없을때가 정상적으로 처리되지 않던 문제를 수정했습니다.
* 액티비티 종료를 함수로 분리했습니다.