### PR TITLE
[Fix] 배너를 좌측으로 스크롤 가능하도록 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -40,7 +40,9 @@ fun BannerImage(
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {}
 ) {
-    val pagerState = rememberPagerState { Int.MAX_VALUE }
+    val pagerState = rememberPagerState(
+        initialPage = (Int.MAX_VALUE / 2) - (Int.MAX_VALUE / 2) % bannerList.size
+    ) { Int.MAX_VALUE }
 
     LaunchedEffect(Unit) {
         while (bannerList.size > 1) {


### PR DESCRIPTION
## 개요
* 배너를 좌측으로 스크롤 가능하도록 수정 #598 

## 작업 내용
* pager의 초깃값을 0이 아닌 Int.MAX_VALUE를 반으로 나눈 값을 사용해서 좌우 모두 스크롤이 가능하도록 수정했습니다.