### PR TITLE
[Fix] 배너 링크가 null 일 경우 배너를 닫지 않도록 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -98,11 +98,12 @@ private fun BannerContent(
     val context = LocalContext.current
     SubcomposeAsyncImage(
         modifier = modifier.fillMaxSize().noRippleClickable {
+            if (banner.redirectLink == null) return@noRippleClickable
             if (banner.version > currentKoinVersion) { // If the banner link requires a higher version of the app
                 val intent = Intent(Intent.ACTION_VIEW, KOIN_PLAYSTORE_URL.toUri())
                 context.startActivity(intent)
             } else {
-                if (!banner.redirectLink.isNullOrEmpty()) {
+                if (banner.redirectLink.isNotEmpty()) {
                     val intent = Intent(Intent.ACTION_VIEW, banner.redirectLink.toUri())
                     context.startActivity(intent)
                 }


### PR DESCRIPTION
## 개요
* 배너 링크가 null 일 경우 배너를 닫지 않도록 수정 #598 

## 작업 내용
* 배너의 링크가 null 일 경우, 배너가 닫히지 않도록 수정했습니다.