### PR TITLE
[Fix] 배너 이미지 리사이징 적용

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -30,6 +30,7 @@ import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.domain.constant.KOIN_PLAYSTORE_URL
 import `in`.koreatech.koin.feature.banner.BANNER_AUTO_SCROLL_MILLISECONDS
 import `in`.koreatech.koin.feature.banner.model.LocalBanner
+import `in`.koreatech.koin.feature.banner.util.ImageUtil
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
 
@@ -110,7 +111,7 @@ private fun BannerContent(
             dismiss()
         },
         model = ImageRequest.Builder(LocalContext.current)
-            .data(banner.imageUrl)
+            .data(ImageUtil.getResizedImageUrl(banner.imageUrl, width = 400))
             .crossfade(true)
             .build(),
         alignment = Alignment.BottomCenter,

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/util/ImageUtil.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/util/ImageUtil.kt
@@ -1,0 +1,37 @@
+package `in`.koreatech.koin.feature.banner.util
+
+import androidx.annotation.IntRange
+
+/**
+ * ImageUtil
+ */
+object ImageUtil {
+    /**
+     * Return resized image url with given width, height, format and quality.
+     * Don't define width and height at the same time.
+     * Image will cropped if both width and height are defined.
+     * @param imageUrl Original image url
+     * @param width Width of the image
+     * @param height Height of the image
+     * @param format Format of the image
+     * @param quality Quality of the image 0-100
+     * @see [ImageFormat]
+     * @return Resized image url
+     */
+    fun getResizedImageUrl(
+        imageUrl: String,
+        width: Int = 0,
+        height: Int = 0,
+        format: ImageFormat = ImageFormat.WEBP,
+        @IntRange(from = 0, to = 100) quality: Int = 100
+    ): String {
+        return "$imageUrl?w=$width&h=$height&format=${format.name}&q=$quality"
+    }
+}
+
+enum class ImageFormat {
+    PNG,
+    JPEG,
+    WEBP,
+    GIF
+}


### PR DESCRIPTION
## 개요
* 배너 이미지 리사이징을 적용했습니다 #598 

## 작업 내용
* 이미지 리사이징을 위한 ImageUtil을 추가했습니다.
* 배너 이미지에 리사이징을 적용했습니다.
* 원본 이미지 사이즈가 1600x1200이기 때문에 1/4 사이즈인 400x300으로 하드코딩 했습니다.

## 고민
* ImageUtil을 core 모듈로 옮기는게 나을까요?