### PR TITLE
[Fix] 배너의 요구 버전이 높을 시, 토스트 메시지를 추가

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -27,8 +27,10 @@ import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.domain.constant.KOIN_PLAYSTORE_URL
 import `in`.koreatech.koin.feature.banner.BANNER_AUTO_SCROLL_MILLISECONDS
+import `in`.koreatech.koin.feature.banner.R
 import `in`.koreatech.koin.feature.banner.model.LocalBanner
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
@@ -99,6 +101,7 @@ private fun BannerContent(
     SubcomposeAsyncImage(
         modifier = modifier.fillMaxSize().noRippleClickable {
             if (banner.version > currentKoinVersion) { // If the banner link requires a higher version of the app
+                ToastUtil.getInstance().makeShort(R.string.banner_require_new_version)
                 val intent = Intent(Intent.ACTION_VIEW, KOIN_PLAYSTORE_URL.toUri())
                 context.startActivity(intent)
             } else {

--- a/feature/banner/src/main/res/values/strings.xml
+++ b/feature/banner/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
 <resources>
     <string name="dismiss_for_a_week">일주일 동안 그만 보기</string>
     <string name="dismiss">닫기</string>
+    <string name="banner_require_new_version">해당 기능을 사용하기 위해서는 업데이트가 꼭 필요해요</string>
 </resources>


### PR DESCRIPTION
## 개요
* 배너의 요구 버전이 높을 시, 토스트 메시지를 추가 #598

## 작업 내용
* 배너의 요구 버전이 현재 앱 버전보다 높을 경우, 스토어로 이동함과 동시에 토스트를 띄우도록 수정했습니다.