### PR TITLE
리뷰어 지정 Github action 추가

### DIFF
--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -5,6 +5,7 @@
  */
 
 import java.io.File
+import kotlin.random.Random
 
 enum class KoinTeam {
     BUSINESS,
@@ -12,7 +13,8 @@ enum class KoinTeam {
     USER
 }
 
-enum class Developer(val githubName: String, val team: Set<KoinTeam>) {
+enum class Developer(val githubName: String, val team: Set<KoinTeam>, val isMentor: Boolean = false) {
+    YUNJAENA("yunjaena", setOf(), true),
     SKDUD0629("skdud0629", setOf(KoinTeam.BUSINESS)),
     JAEYOUNG290("JaeYoung290", setOf(KoinTeam.BUSINESS)),
     KONGWOOJIN("kongwoojin", setOf(KoinTeam.CAMPUS, KoinTeam.USER)),
@@ -26,6 +28,7 @@ enum class Developer(val githubName: String, val team: Set<KoinTeam>) {
  *
  * Pair rule
  * developer and reviewer should not be in the same team
+ * don't add mentor here
  */
 val reviewerPair = listOf(
     Developer.SKDUD0629 to Developer.KYM_P,
@@ -45,6 +48,15 @@ fun exportReviewer(name: String) {
 }
 
 /**
+ * Export the mentor name to GitHub Actions output.
+ * @param name The name of the mentor.
+ */
+fun exportMentor(name: String) {
+    val githubOutput = System.getenv("GITHUB_OUTPUT")
+    File(githubOutput).appendText("mentor=$name\n")
+}
+
+/**
  * Pick a paired reviewer for the developer.
  * The developer and reviewer should not be in the same team.
  */
@@ -60,9 +72,21 @@ fun pickPairedReviewer(developer: Developer) {
 fun pickRandomReviewer(developer: Developer) {
     val otherTeamDevelopers = Developer.entries
         .filter { it != developer }
+        .filter { !it.isMentor }
         .filter { it.team.intersect(developer.team).isEmpty() }
     val randomReviewer = otherTeamDevelopers.random()
     exportReviewer(randomReviewer.githubName)
+}
+
+/**
+ * Pick a mentor.
+ */
+fun pickMentor() {
+    val shouldAddMentor = Random.nextInt() % 4 == 0 // 25%
+    if (shouldAddMentor) {
+        val mentor = Developer.entries.filter { it.isMentor }.random()
+        exportMentor(mentor.githubName)
+    }
 }
 
 fun main() {
@@ -74,6 +98,7 @@ fun main() {
     }
 
     pickPairedReviewer(developer)
+    pickMentor()
 }
 
 main()

--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -1,0 +1,79 @@
+#!/usr/bin/env kotlin
+
+/*
+ * Copyright (c) 2025. BCSD Lab.
+ */
+
+import java.io.File
+
+enum class KoinTeam {
+    BUSINESS,
+    CAMPUS,
+    USER
+}
+
+enum class Developer(val githubName: String, val team: Set<KoinTeam>) {
+    SKDUD0629("skdud0629", setOf(KoinTeam.BUSINESS)),
+    JAEYOUNG290("JaeYoung290", setOf(KoinTeam.BUSINESS)),
+    KONGWOOJIN("kongwoojin", setOf(KoinTeam.CAMPUS, KoinTeam.USER)),
+    KYM_P("KYM-P", setOf(KoinTeam.CAMPUS)),
+    JUSANG3057("jusang3057", setOf(KoinTeam.USER))
+}
+
+/**
+ * Reviewer pairs for each developer.
+ * first element is developer and second element is reviewer.
+ *
+ * Pair rule
+ * developer and reviewer should not be in the same team
+ */
+val reviewerPair = listOf(
+    Developer.SKDUD0629 to Developer.KYM_P,
+    Developer.JAEYOUNG290 to Developer.KONGWOOJIN,
+    Developer.KONGWOOJIN to Developer.JAEYOUNG290,
+    Developer.KYM_P to Developer.JUSANG3057,
+    Developer.JUSANG3057 to Developer.SKDUD0629,
+)
+
+/**
+ * Export the reviewer name to GitHub Actions output.
+ * @param name The name of the reviewer.
+ */
+fun exportReviewer(name: String) {
+    val githubOutput = System.getenv("GITHUB_OUTPUT")
+    File(githubOutput).appendText("reviewer=$name\n")
+}
+
+/**
+ * Pick a paired reviewer for the developer.
+ * The developer and reviewer should not be in the same team.
+ */
+fun pickPairedReviewer(developer: Developer) {
+    val reviewer = reviewerPair.first { it.first == developer }.second
+    exportReviewer(reviewer.githubName)
+}
+
+/**
+ * Pick a random reviewer from the other team members.
+ * The developer and reviewer should not be in the same team.
+ */
+fun pickRandomReviewer(developer: Developer) {
+    val otherTeamDevelopers = Developer.entries
+        .filter { it != developer }
+        .filter { it.team.intersect(developer.team).isEmpty() }
+    val randomReviewer = otherTeamDevelopers.random()
+    exportReviewer(randomReviewer.githubName)
+}
+
+fun main() {
+    val githubActor = System.getenv("GITHUB_ACTOR")
+    val developer = Developer.entries.firstOrNull { it.githubName == githubActor }
+
+    if (developer == null) {
+        return
+    }
+
+    pickPairedReviewer(developer)
+}
+
+main()

--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -1,0 +1,21 @@
+name: "Pick Reviewer"
+on:
+  pull_request:
+    types: opened
+
+jobs:
+  pick-reviewer:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Pick reviewer
+        id: pick_reviewer
+        run: kotlinc -script ./.github/scripts/pick_reviewer.kts
+
+      - name: Add Reviewer
+        uses: madrapps/add-reviewers@v1
+        with:
+          reviewers: ${{ steps.pick_reviewer.outputs.reviewer }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -19,3 +19,10 @@ jobs:
         with:
           reviewers: ${{ steps.pick_reviewer.outputs.reviewer }}
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add Mentor
+        if: ${{ steps.pick_reviewer.outputs.mentor }}
+        uses: madrapps/add-reviewers@v1
+        with:
+          reviewers: ${{ steps.pick_reviewer.outputs.mentor }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 개요
* 리뷰어 지정 Github action 추가

## 작업 내용
* 리뷰어를 자동 지정하는 Github action을 추가했습니다.

## 설명
* 리뷰어는 항상 다른 팀의 개발자가 되어야 합니다.
* 리뷰어는 1대1로 지정되어 있습니다. 현재 현황은 아래와 같습니다.

|개발자|리뷰어|
|---------|--------|
|skdud0629|KYM-P|
|JaeYoung290|kongwoojin|
|kongwoojin|JaeYoung290|
|KYM-P|jusang3057|
|jusang3057|skdud0629|

* 지정 리뷰어 변경 주기 및 방법에 대해 추가적인 논의가 필요합니다.
* 지정 리뷰어 말고, 다른 팀 개발자 중 랜덤으로 한명을 고르는 기능도 구현되어 있습니다. 다만 현재 사용되지 않습니다.
* 멘토의 경우, 25% 확률로 리뷰어로 추가됩니다.

## 유지보수
* 리뷰어 지정 스크립트는 Kotlin Script로 작성되었습니다.
* 추후 개발자가 늘어날 경우, Developer enum에 값을 추가해주고 reviewerPair에도 추가해주면 됩니다.
* [프론트엔드 Github action](https://github.com/BCSDLab/KOIN_WEB_RECODE/blob/develop/.github/workflows/PICK_REVIEWER.yml)이 자바 스크립트로 작성된 것처럼, 코틀린으로 작성 시 유지보수가 원활할 것이라 생각했습니다.
