### PR TITLE
[Fix] 배너 누락된 로깅 추가

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -47,6 +47,21 @@ object EventLogger {
         logEvent(action, EventCategory.CLICK, label, value, *extras)
     }
 
+    /** 화면 진입 이벤트 로깅
+     * @param action 이벤트 발생 도메인(BUSINESS, CAMPUS, USER)
+     * @param label 이벤트 소분류
+     * @param value 이벤트 값
+     * @param extras 추가 이벤트 값
+     */
+    fun logEntryEvent(
+        action: EventAction,
+        label: String,
+        value: String,
+        vararg extras: EventExtra
+    ) {
+        logEvent(action, EventCategory.ENTRY, label, value, *extras)
+    }
+
     /**
      * CAPMUS 클릭 이벤트 로깅
      * @param label 이벤트 소분류
@@ -227,7 +242,8 @@ enum class EventCategory(val value: String) {
     CLICK("click"),
     SCROLL("scroll"),
     SWIPE("swipe"), // 하단 뒤로가기(아이폰의 swipe 뒤로가기와 대응)
-    NOTIFICATION("notification")
+    NOTIFICATION("notification"),
+    ENTRY("entry")
 }
 
 data class EventExtra(val key: String, val value: String)

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
@@ -70,6 +70,10 @@ fun BannerA(
             ) {
                 TextButton(
                     onClick = {
+                        EventLogger.logCampusClickEvent(
+                            label = "main_modal_hide_7d",
+                            value = bannerList[bannerIndex].title
+                        )
                         dismissWithRefusal()
                     }
                 ) {

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.banner.R
 import `in`.koreatech.koin.feature.banner.model.LocalBanner
@@ -35,9 +36,11 @@ import kotlinx.collections.immutable.persistentListOf
 fun BannerA(
     bannerList: ImmutableList<LocalBanner>,
     currentKoinVersion: Int,
+    bannerIndex: Int,
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {},
-    dismissWithRefusal: () -> Unit = {}
+    dismissWithRefusal: () -> Unit = {},
+    onBannerIndexChange: (Int) -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth by remember { mutableStateOf(configuration.screenWidthDp.dp) }
@@ -79,6 +82,10 @@ fun BannerA(
                 Spacer(modifier = Modifier.weight(1f))
                 TextButton(
                     onClick = {
+                        EventLogger.logCampusClickEvent(
+                            label = "main_modal_close",
+                            value = bannerList[bannerIndex].title
+                        )
                         dismiss()
                     }
                 ) {
@@ -93,7 +100,8 @@ fun BannerA(
                 modifier = Modifier.height(maxImageHeight),
                 bannerList = bannerList,
                 dismiss = dismiss,
-                currentKoinVersion = currentKoinVersion
+                currentKoinVersion = currentKoinVersion,
+                onBannerIndexChange = onBannerIndexChange
             )
         }
     }
@@ -102,5 +110,5 @@ fun BannerA(
 @Preview
 @Composable
 fun BannerPreview() {
-    BannerA(persistentListOf(), 0)
+    BannerA(persistentListOf(), 0, 0)
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
@@ -15,8 +15,10 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,15 +38,15 @@ import kotlinx.collections.immutable.persistentListOf
 fun BannerA(
     bannerList: ImmutableList<LocalBanner>,
     currentKoinVersion: Int,
-    bannerIndex: Int,
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {},
-    dismissWithRefusal: () -> Unit = {},
-    onBannerIndexChange: (Int) -> Unit = {}
+    dismissWithRefusal: () -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth by remember { mutableStateOf(configuration.screenWidthDp.dp) }
     val maxImageHeight by remember { mutableStateOf(screenWidth / 4 * 3) }
+
+    var bannerIndex: Int by remember { mutableIntStateOf(0) }
 
     Box(
         modifier = modifier
@@ -105,7 +107,9 @@ fun BannerA(
                 bannerList = bannerList,
                 dismiss = dismiss,
                 currentKoinVersion = currentKoinVersion,
-                onBannerIndexChange = onBannerIndexChange
+                onBannerIndexChange = {
+                    bannerIndex = it
+                }
             )
         }
     }
@@ -114,5 +118,5 @@ fun BannerA(
 @Preview
 @Composable
 fun BannerPreview() {
-    BannerA(persistentListOf(), 0, 0)
+    BannerA(persistentListOf(), 0)
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
@@ -39,7 +39,7 @@ fun BannerB(
     currentKoinVersion: Int,
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {},
-    dismissWithRefusal: () -> Unit = {},
+    dismissWithRefusal: () -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth by remember { mutableStateOf(configuration.screenWidthDp.dp - 48.dp) } // minus horizontal padding

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
@@ -79,6 +79,10 @@ fun BannerB(
                     textStyle = KoinTheme.typography.medium15.copy(color = KoinTheme.colors.primary500),
                     shape = KoinTheme.shapes.small,
                     onClick = {
+                        EventLogger.logCampusClickEvent(
+                            label = "main_modal_hide_7d",
+                            value = bannerList[bannerIndex].title
+                        )
                         dismissWithRefusal()
                     }
                 )

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
@@ -12,8 +12,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -35,15 +37,15 @@ import kotlinx.collections.immutable.persistentListOf
 fun BannerB(
     bannerList: ImmutableList<LocalBanner>,
     currentKoinVersion: Int,
-    bannerIndex: Int,
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {},
     dismissWithRefusal: () -> Unit = {},
-    onBannerIndexChange: (Int) -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth by remember { mutableStateOf(configuration.screenWidthDp.dp - 48.dp) } // minus horizontal padding
     val maxImageHeight by remember { mutableStateOf(screenWidth / 4 * 3) }
+
+    var bannerIndex: Int by remember { mutableIntStateOf(0) }
 
     Box(
         modifier = modifier
@@ -62,7 +64,9 @@ fun BannerB(
                 bannerList = bannerList,
                 dismiss = dismiss,
                 currentKoinVersion = currentKoinVersion,
-                onBannerIndexChange = onBannerIndexChange
+                onBannerIndexChange = {
+                    bannerIndex = it
+                }
             )
 
             Row(
@@ -115,8 +119,7 @@ fun BannerBPreview() {
     KoinTheme {
         BannerB(
             bannerList = persistentListOf(),
-            currentKoinVersion = 0,
-            bannerIndex = 0,
+            currentKoinVersion = 0
         )
     }
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.button.OutlinedBoxButton
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
@@ -34,9 +35,11 @@ import kotlinx.collections.immutable.persistentListOf
 fun BannerB(
     bannerList: ImmutableList<LocalBanner>,
     currentKoinVersion: Int,
+    bannerIndex: Int,
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {},
-    dismissWithRefusal: () -> Unit = {}
+    dismissWithRefusal: () -> Unit = {},
+    onBannerIndexChange: (Int) -> Unit = {}
 ) {
     val configuration = LocalConfiguration.current
     val screenWidth by remember { mutableStateOf(configuration.screenWidthDp.dp - 48.dp) } // minus horizontal padding
@@ -58,7 +61,8 @@ fun BannerB(
                 modifier = Modifier.height(maxImageHeight),
                 bannerList = bannerList,
                 dismiss = dismiss,
-                currentKoinVersion = currentKoinVersion
+                currentKoinVersion = currentKoinVersion,
+                onBannerIndexChange = onBannerIndexChange
             )
 
             Row(
@@ -89,6 +93,10 @@ fun BannerB(
                     textStyle = KoinTheme.typography.medium15.copy(color = KoinTheme.colors.neutral0),
                     shape = KoinTheme.shapes.small,
                     onClick = {
+                        EventLogger.logCampusClickEvent(
+                            label = "main_modal_close",
+                            value = bannerList[bannerIndex].title
+                        )
                         dismiss()
                     }
                 )
@@ -103,7 +111,8 @@ fun BannerBPreview() {
     KoinTheme {
         BannerB(
             bannerList = persistentListOf(),
-            currentKoinVersion = 0
+            currentKoinVersion = 0,
+            bannerIndex = 0,
         )
     }
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -118,6 +118,11 @@ private fun BannerContent(
     val context = LocalContext.current
     SubcomposeAsyncImage(
         modifier = modifier.fillMaxSize().noRippleClickable {
+            EventLogger.logClickEvent(
+                action = EventAction.CAMPUS,
+                label = "main_modal",
+                value = banner.title
+            )
             if (banner.redirectLink == null) return@noRippleClickable
             if (banner.version > currentKoinVersion) { // If the banner link requires a higher version of the app
                 ToastUtil.getInstance().makeShort(R.string.banner_require_new_version)

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -47,7 +47,8 @@ fun BannerImage(
     bannerList: ImmutableList<LocalBanner>,
     currentKoinVersion: Int,
     modifier: Modifier = Modifier,
-    dismiss: () -> Unit = {}
+    dismiss: () -> Unit = {},
+    onBannerIndexChange: (Int) -> Unit = {}
 ) {
     val pagerState = rememberPagerState(
         initialPage = (Int.MAX_VALUE / 2) - (Int.MAX_VALUE / 2) % bannerList.size
@@ -72,6 +73,7 @@ fun BannerImage(
             state = pagerState
         ) { page ->
             val realPage = page % bannerList.size
+            onBannerIndexChange(realPage)
             BannerContent(
                 banner = bannerList[realPage],
                 dismiss = dismiss,

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.unit.dp
 import androidx.core.net.toUri
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
+import `in`.koreatech.koin.core.analytics.EventAction
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.toast.ToastUtil
@@ -108,6 +110,11 @@ private fun BannerContent(
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {}
 ) {
+    EventLogger.logEntryEvent(
+        action = EventAction.CAMPUS,
+        label = "main_modal_entry",
+        value = banner.title
+    )
     val context = LocalContext.current
     SubcomposeAsyncImage(
         modifier = modifier.fillMaxSize().noRippleClickable {

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -112,11 +112,6 @@ private fun BannerContent(
     modifier: Modifier = Modifier,
     dismiss: () -> Unit = {}
 ) {
-    EventLogger.logEntryEvent(
-        action = EventAction.CAMPUS,
-        label = "main_modal_entry",
-        value = banner.title
-    )
     val context = LocalContext.current
     SubcomposeAsyncImage(
         modifier = modifier.fillMaxSize().noRippleClickable {

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
@@ -17,6 +17,7 @@ data class BannerState(
 
 data class LocalBanner(
     val id: Int = 0,
+    val title: String = "",
     val imageUrl: String = "",
     val redirectLink: String? = null,
     val version: Int = 0
@@ -24,6 +25,7 @@ data class LocalBanner(
 
 fun Banner.toLocalBanner() = LocalBanner(
     id = id,
+    title = title,
     imageUrl = imageUrl,
     redirectLink = redirectLink,
     version = if (version.isNullOrEmpty()) {

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
@@ -12,7 +12,6 @@ data class BannerState(
     val bannerList: ImmutableList<LocalBanner> = persistentListOf(),
     val bannerCategory: ImmutableList<BannerCategory> = persistentListOf(),
     val isLoading: Boolean = true,
-    val currentBannerIndex: Int = 0, // Need for logging
     val currentVersionCode: Int = 0
 )
 

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/model/BannerState.kt
@@ -12,6 +12,7 @@ data class BannerState(
     val bannerList: ImmutableList<LocalBanner> = persistentListOf(),
     val bannerCategory: ImmutableList<BannerCategory> = persistentListOf(),
     val isLoading: Boolean = true,
+    val currentBannerIndex: Int = 0, // Need for logging
     val currentVersionCode: Int = 0
 )
 

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -76,7 +76,7 @@ class BannerActivity : ComponentActivity() {
                                         dismissWithRefusal = {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
-                                        },
+                                        }
                                     )
                                 }
 
@@ -95,7 +95,7 @@ class BannerActivity : ComponentActivity() {
                                         dismissWithRefusal = {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
-                                        },
+                                        }
                                     )
                                 }
                             }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -64,7 +64,6 @@ class BannerActivity : ComponentActivity() {
                                     BannerA(
                                         bannerList = uiState.bannerList,
                                         currentKoinVersion = uiState.currentVersionCode,
-                                        bannerIndex = uiState.currentBannerIndex,
                                         dismiss = {
                                             finishActivity()
                                         },
@@ -72,9 +71,6 @@ class BannerActivity : ComponentActivity() {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
                                         },
-                                        onBannerIndexChange = {
-                                            viewModel.setBannerIndex(it)
-                                        }
                                     )
                                 }
 
@@ -87,7 +83,6 @@ class BannerActivity : ComponentActivity() {
                                     BannerB(
                                         bannerList = uiState.bannerList,
                                         currentKoinVersion = uiState.currentVersionCode,
-                                        bannerIndex = uiState.currentBannerIndex,
                                         dismiss = {
                                             finishActivity()
                                         },
@@ -95,9 +90,6 @@ class BannerActivity : ComponentActivity() {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
                                         },
-                                        onBannerIndexChange = {
-                                            viewModel.setBannerIndex(it)
-                                        }
                                     )
                                 }
                             }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -64,12 +64,16 @@ class BannerActivity : ComponentActivity() {
                                     BannerA(
                                         bannerList = uiState.bannerList,
                                         currentKoinVersion = uiState.currentVersionCode,
+                                        bannerIndex = uiState.currentBannerIndex,
                                         dismiss = {
                                             finishActivity()
                                         },
                                         dismissWithRefusal = {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
+                                        },
+                                        onBannerIndexChange = {
+                                            viewModel.setBannerIndex(it)
                                         }
                                     )
                                 }
@@ -83,12 +87,16 @@ class BannerActivity : ComponentActivity() {
                                     BannerB(
                                         bannerList = uiState.bannerList,
                                         currentKoinVersion = uiState.currentVersionCode,
+                                        bannerIndex = uiState.currentBannerIndex,
                                         dismiss = {
                                             finishActivity()
                                         },
                                         dismissWithRefusal = {
                                             viewModel.setBannerRefusal()
                                             finishActivity()
+                                        },
+                                        onBannerIndexChange = {
+                                            viewModel.setBannerIndex(it)
                                         }
                                     )
                                 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerActivity.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.abtest.ExperimentGroup
+import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithDarkStatusBar
@@ -44,6 +45,11 @@ class BannerActivity : ComponentActivity() {
                         finishActivity()
                         return@KoinTheme
                     }
+                    EventLogger.logEntryEvent(
+                        action = EventAction.CAMPUS,
+                        label = "main_modal_entry",
+                        value = uiState.bannerList[0].title
+                    )
                     Scaffold(
                         modifier = Modifier.fillMaxSize(),
                         containerColor = Color.Transparent,

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
@@ -74,12 +74,6 @@ class BannerViewModel @Inject constructor(
         saveBannerRefusalUseCase()
     }
 
-    fun setBannerIndex(index: Int) {
-        _bannerState.value = _bannerState.value.copy(
-            currentBannerIndex = index
-        )
-    }
-
     companion object {
         const val MAIN_BANNER_CATEGORY = 1
     }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/ui/BannerViewModel.kt
@@ -74,6 +74,12 @@ class BannerViewModel @Inject constructor(
         saveBannerRefusalUseCase()
     }
 
+    fun setBannerIndex(index: Int) {
+        _bannerState.value = _bannerState.value.copy(
+            currentBannerIndex = index
+        )
+    }
+
     companion object {
         const val MAIN_BANNER_CATEGORY = 1
     }


### PR DESCRIPTION
## 개요
* 배너 누락된 로깅을 추가했습니다. #614 

## 작업 내용
* 배너 누락된 로깅을 추가했습니다.
* BannerA 및 BannerB Composable에 로깅을 위해 bannerIndex 변수를 추가했습니다.
* 상태 호이스팅해서 뷰모델로 빼버리면 계속 Recomposable이 일어나서 일단 이렇게 작업했습니다. 더 좋은 방법이 있으면 바로 고치겠습니다.
* EventLogger에 logEntryEvent를 추가했습니다.