### PR TITLE
[User][Fix] Dropdown 컴포넌트 크기 고정 및 키보드 처리

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpDropdown.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpDropdown.kt
@@ -121,6 +121,7 @@ fun KoinSignUpDropdown(
          */
         ExposedDropdownMenu(
             modifier = Modifier
+                .height(180.dp) // Set a fixed height for the dropdown menu
                 .wrapContentSize(),
             expanded = isDropdownExpanded,
             onDismissRequest = { onDropdownExpandChange(false) },

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpDropdown.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpDropdown.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.CornerSize
@@ -26,6 +27,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -58,95 +60,102 @@ fun KoinSignUpDropdown(
     modifier: Modifier = Modifier,
     onDropdownExpandChange: (Boolean) -> Unit = {},
     onItemSelected: (Int) -> Unit = {}
-) = ExposedDropdownMenuBox(
-    expanded = isDropdownExpanded,
-    onExpandedChange = onDropdownExpandChange,
-    modifier = modifier
 ) {
-    val rotateDegree: Float by animateFloatAsState(
-        targetValue = if (isDropdownExpanded) 180f else 0f,
-        label = "degree"
-    )
+    val focusManager = LocalFocusManager.current
 
-    val dropdownCorner: Dp by animateDpAsState(
-        targetValue = if (isDropdownExpanded) 0.dp else 14.dp
-    )
-
-    val dropdownShape = KoinTheme.shapes.large.copy(
-        bottomStart = CornerSize(dropdownCorner),
-        bottomEnd = CornerSize(dropdownCorner)
-    )
-
-    Row(
-        modifier = Modifier
-            .shadow(
-                elevation = 9.dp,
-                shape = dropdownShape
-            )
-            .background(
-                color = KoinTheme.colors.neutral0,
-                shape = dropdownShape
-            )
-            .padding(vertical = 8.dp, horizontal = 12.dp)
-            .menuAnchor(MenuAnchorType.PrimaryNotEditable),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            text = if (isSelected) text else hint,
-            style = KoinTheme.typography.regular14,
-            color = if (isSelected) Color.Unspecified else KoinTheme.colors.neutral400,
-            maxLines = 1
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Icon(
-            modifier = Modifier.rotate(rotateDegree),
-            painter = painterResource(id = R.drawable.ic_arrow_down),
-            tint = KoinTheme.colors.neutral400,
-            contentDescription = ""
-        )
-    }
-
-    /**
-     * Vertical padding of DropdownMenu is hardcoded to 8.dp by google.
-     * So, we will leave vertical padding value to 0.dp
-     * @see [androidx.compose.material3.DropdownMenu]
-     */
-    ExposedDropdownMenu(
-        modifier = Modifier
-            .wrapContentSize(),
+    ExposedDropdownMenuBox(
         expanded = isDropdownExpanded,
-        onDismissRequest = { onDropdownExpandChange(false) },
-        containerColor = KoinTheme.colors.neutral0,
-        shape = KoinTheme.shapes.large.copy(
-            topEnd = CornerSize(0.dp),
-            topStart = CornerSize(0.dp)
-        )
+        onExpandedChange = {
+            focusManager.clearFocus()
+            onDropdownExpandChange(it)
+        },
+        modifier = modifier
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .clip(KoinTheme.shapes.large)
-        ) {
-            Column {
-                items.forEachIndexed { index, it ->
-                    Text(
-                        text = it,
-                        style = KoinTheme.typography.medium14,
-                        modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .noRippleClickable {
-                                onItemSelected(index)
-                                onDropdownExpandChange(false)
-                            }
-                            .padding(vertical = 8.dp, horizontal = 12.dp),
-                        maxLines = 1
-                    )
+        val rotateDegree: Float by animateFloatAsState(
+            targetValue = if (isDropdownExpanded) 180f else 0f,
+            label = "degree"
+        )
 
-                    if (index != items.size - 1) {
-                        HorizontalDivider(
-                            color = KoinTheme.colors.neutral200
+        val dropdownCorner: Dp by animateDpAsState(
+            targetValue = if (isDropdownExpanded) 0.dp else 14.dp
+        )
+
+        val dropdownShape = KoinTheme.shapes.large.copy(
+            bottomStart = CornerSize(dropdownCorner),
+            bottomEnd = CornerSize(dropdownCorner)
+        )
+
+        Row(
+            modifier = Modifier
+                .shadow(
+                    elevation = 9.dp,
+                    shape = dropdownShape
+                )
+                .background(
+                    color = KoinTheme.colors.neutral0,
+                    shape = dropdownShape
+                )
+                .padding(vertical = 8.dp, horizontal = 12.dp)
+                .menuAnchor(MenuAnchorType.PrimaryNotEditable),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = if (isSelected) text else hint,
+                style = KoinTheme.typography.regular14,
+                color = if (isSelected) Color.Unspecified else KoinTheme.colors.neutral400,
+                maxLines = 1
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            Icon(
+                modifier = Modifier.rotate(rotateDegree),
+                painter = painterResource(id = R.drawable.ic_arrow_down),
+                tint = KoinTheme.colors.neutral400,
+                contentDescription = ""
+            )
+        }
+
+        /**
+         * Vertical padding of DropdownMenu is hardcoded to 8.dp by google.
+         * So, we will leave vertical padding value to 0.dp
+         * @see [androidx.compose.material3.DropdownMenu]
+         */
+        ExposedDropdownMenu(
+            modifier = Modifier
+                .wrapContentSize(),
+            expanded = isDropdownExpanded,
+            onDismissRequest = { onDropdownExpandChange(false) },
+            containerColor = KoinTheme.colors.neutral0,
+            shape = KoinTheme.shapes.large.copy(
+                topEnd = CornerSize(0.dp),
+                topStart = CornerSize(0.dp)
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(KoinTheme.shapes.large)
+            ) {
+                Column {
+                    items.forEachIndexed { index, it ->
+                        Text(
+                            text = it,
+                            style = KoinTheme.typography.medium14,
+                            modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .noRippleClickable {
+                                    onItemSelected(index)
+                                    onDropdownExpandChange(false)
+                                }
+                                .padding(vertical = 8.dp, horizontal = 12.dp),
+                            maxLines = 1
                         )
+
+                        if (index != items.size - 1) {
+                            HorizontalDivider(
+                                color = KoinTheme.colors.neutral200
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
issue: #592 

## 개요
* Dropdown 컴포넌트 크기 고정 및 키보드 처리

## 작업 내용
* Dropdown menu의 크기를 180.dp로 고정했습니다.
* Dropdown 클릭 시, 키보드가 숨겨지도록 수정했습니다.

## 추가적인 내용
* 본 PR은 Compose Dropdown에서 dropdown menu가 열리는 방향을 정할 수 없고, 어느 방향으로 열렸는지 알 수 없기 때문에 최대한 아래 방향으로 열리도록 하기 위한 PR입니다.
* 키보드가 열려있을 경우, 아래로 열리는게 거의 불가능하기 때문에, dropdown을 클릭할 경우, 키보드를 숨겨 아래로 열리도록 유도했습니다.