### PR TITLE
[User][Feature] 회원가입 API 성공/실패 여부를 Result로 반환하도록 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -127,7 +127,7 @@ class SignupRepositoryImpl @Inject constructor(
         gender: String,
         email: String,
         nickname: String
-    ): Boolean {
+    ): Result<Unit> {
         return try {
             userRemoteDataSource.postStudentRegister(
                 StudentInfoRequestV2(
@@ -142,9 +142,9 @@ class SignupRepositoryImpl @Inject constructor(
                     nickname = nickname
                 )
             )
-            true
+            Result.success(Unit)
         } catch (e: HttpException) {
-            false
+            Result.failure(e)
         }
     }
 
@@ -156,7 +156,7 @@ class SignupRepositoryImpl @Inject constructor(
         gender: String,
         email: String,
         nickname: String
-    ): Boolean {
+    ): Result<Unit> {
         return try {
             userRemoteDataSource.postGeneralRegister(
                 GeneralInfoRequest(
@@ -169,9 +169,9 @@ class SignupRepositoryImpl @Inject constructor(
                     nickname = nickname
                 )
             )
-            false
+            Result.success(Unit)
         } catch (e: HttpException) {
-            false
+            Result.failure(e)
         }
     }
 

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
@@ -44,7 +44,7 @@ interface SignupRepository {
         gender: String,
         email: String,
         nickname: String
-    ): Boolean
+    ): Result<Unit>
 
     suspend fun postGeneralRegister(
         name: String,
@@ -54,7 +54,7 @@ interface SignupRepository {
         gender: String,
         email: String,
         nickname: String
-    ): Boolean
+    ): Result<Unit>
 
     suspend fun requestSmsVerification(phoneNumber: String): SignupContinuationState
 

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/PostGeneralRegisterUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/PostGeneralRegisterUseCase.kt
@@ -14,8 +14,8 @@ class PostGeneralRegisterUseCase @Inject constructor(
         gender: String,
         email: String,
         nickname: String
-    ) {
-        signupRepository.postGeneralRegister(
+    ): Result<Unit> {
+        return signupRepository.postGeneralRegister(
             name = name,
             phoneNumber = phoneNumber,
             userId = userId,

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/PostStudentRegisterUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/PostStudentRegisterUseCase.kt
@@ -16,8 +16,8 @@ class PostStudentRegisterUseCase @Inject constructor(
         gender: String,
         email: String,
         nickname: String
-    ) {
-        signupRepository.postStudentRegister(
+    ): Result<Unit> {
+        return signupRepository.postStudentRegister(
             name = name,
             phoneNumber = phoneNumber,
             userId = userId,


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 API 성공/실패 여부를 Result로 반환하도록 수정

## 작업 내용
* 회원가입 API 성공 및 실패 여부를 Result로 반환하도록 수정했습니다.
* UseCase에 return이 누락되어서 추가했습니다