### PR TITLE
[User][Feature] 회원가입 학생 정보 입력 화면 구현

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -109,6 +109,7 @@ class SignupRepositoryImpl @Inject constructor(
         } catch (e: HttpException) {
             when (e.code()) {
                 409 -> SignupContinuationState.PhoneNumberDuplicated
+                400 -> SignupContinuationState.CheckPhoneNumberFormat
                 else -> SignupContinuationState.Failed(
                     message = e.getErrorResponse().message ?: "",
                     throwable = e

--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -109,7 +109,6 @@ class SignupRepositoryImpl @Inject constructor(
         } catch (e: HttpException) {
             when (e.code()) {
                 409 -> SignupContinuationState.PhoneNumberDuplicated
-                400 -> SignupContinuationState.CheckPhoneNumberFormat
                 else -> SignupContinuationState.Failed(
                     message = e.getErrorResponse().message ?: "",
                     throwable = e

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -7,10 +7,14 @@ fun String.toSHA256() = PasswordUtil().generateSHA256(this)
 
 val String.isValidStudentId: Boolean
     get() {
-        if (this.trim().length != 10) {
+        // Korean student number is 10 digit
+        // Foreign student number is 8 or 9 digit
+        if (this.trim().length !in 8..10) {
             return false
         }
 
+        // First 4 digits are year.
+        // Check if the year is between 1992 and current year
         val year: Int = this.trim().substring(0..3).toInt()
         return year in 1992..Calendar.getInstance().get(Calendar.YEAR)
     }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/Constant.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/Constant.kt
@@ -1,4 +1,19 @@
 package `in`.koreatech.koin.feature.signup
 
+import kotlinx.collections.immutable.persistentListOf
+
 const val SIGN_UP_PHONE_NUMBER_MAX_LENGTH = 11
 const val SIGN_UP_VERIFICATION_CODE_MAX_LENGTH = 6
+
+val departmentStringList = persistentListOf(
+    "건축공학부",
+    "고용서비스정책학과",
+    "기계공학부",
+    "디자인공학부",
+    "메카트로닉스공학부",
+    "산업경영학부",
+    "전기전자통신공학부",
+    "컴퓨터공학부",
+    "화학생명공학부",
+    "에너지신소재공학부"
+)

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/navigation/SignUpNavigation.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/navigation/SignUpNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import `in`.koreatech.koin.feature.signup.ui.term.SignUpTermScreen
 import `in`.koreatech.koin.feature.signup.ui.userinfo.general.SignUpGeneralUserInfo
+import `in`.koreatech.koin.feature.signup.ui.userinfo.student.SignUpStudentUserInfo
 import `in`.koreatech.koin.feature.signup.ui.usertype.SignUpUserType
 import `in`.koreatech.koin.feature.signup.ui.verification.SignUpVerification
 
@@ -68,6 +69,9 @@ fun NavGraphBuilder.koinSignUpGraph(
             navArgument(GENDER) { type = NavType.StringType }
         )
     ) {
+        SignUpStudentUserInfo {
+            navController.navigate(SignUpNavType.SignUpComplete.route)
+        }
     }
 
     composable(

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
@@ -23,6 +23,9 @@ data class SignUpGeneralState(
     val isSignUpSuccess: Boolean = false
 ) : Parcelable
 
+val SignUpGeneralState.isEnabled
+    get() = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && isUserIdAvailable == true
+
 enum class SignUpGeneralStep {
     INITIAL,
     NICK_NANE_AND_EMAIL

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
@@ -28,5 +28,5 @@ val SignUpGeneralState.isEnabled
 
 enum class SignUpGeneralStep {
     INITIAL,
-    NICKNANE_AND_EMAIL
+    NICKNAME_AND_EMAIL
 }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -47,7 +47,6 @@ fun SignUpGeneralUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
-    val enabled by viewModel.enabled.collectAsState(false)
 
     viewModel.collectSideEffect {
         handleSideEffect(
@@ -69,7 +68,7 @@ fun SignUpGeneralUserInfo(
         isPasswordValid = uiState.isPasswordValid,
         isPasswordEqual = uiState.isPasswordEqual,
         email = uiState.email,
-        enabled = enabled,
+        enabled = uiState.isEnabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
         checkNicknameDuplicate = { viewModel.checkNicknameDuplicate() },

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -147,7 +147,7 @@ fun SignUpGeneralUserInfoImpl(
                 onShowPasswordChange = { onShowPasswordChange(it) }
             )
 
-            if (step == SignUpGeneralStep.NICKNANE_AND_EMAIL) {
+            if (step == SignUpGeneralStep.NICKNAME_AND_EMAIL) {
                 Spacer(modifier = Modifier.height(32.dp))
 
                 SignUpGeneralUserInfoNickNameEmailStep(
@@ -383,7 +383,7 @@ private fun handleSideEffect(
 fun SignUpGeneralUserInfoPreview() {
     KoinTheme {
         SignUpGeneralUserInfoImpl(
-            step = SignUpGeneralStep.NICKNANE_AND_EMAIL,
+            step = SignUpGeneralStep.NICKNAME_AND_EMAIL,
             userId = "userid",
             isUserIdAvailable = true,
             isUserIdValid = true,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +47,7 @@ fun SignUpGeneralUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
+    val enabled by viewModel.enabled.collectAsState(false)
 
     viewModel.collectSideEffect {
         handleSideEffect(
@@ -67,6 +69,7 @@ fun SignUpGeneralUserInfo(
         isPasswordValid = uiState.isPasswordValid,
         isPasswordEqual = uiState.isPasswordEqual,
         email = uiState.email,
+        enabled = enabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
         checkNicknameDuplicate = { viewModel.checkNicknameDuplicate() },
@@ -94,6 +97,7 @@ fun SignUpGeneralUserInfoImpl(
     isPasswordValid: Boolean,
     isPasswordEqual: Boolean,
     email: String,
+    enabled: Boolean,
     modifier: Modifier = Modifier,
     onNicknameChange: (String) -> Unit = {},
     checkNicknameDuplicate: () -> Unit = {},
@@ -165,7 +169,7 @@ fun SignUpGeneralUserInfoImpl(
         FilledButton(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(R.string.sign_up_next),
-            enabled = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && isUserIdAvailable == true,
+            enabled = enabled,
             contentPadding = PaddingValues(12.dp),
             onClick = {
                 onSignUpButtonClick()
@@ -391,7 +395,8 @@ fun SignUpGeneralUserInfoPreview() {
             showPassword = false,
             isPasswordValid = true,
             isPasswordEqual = true,
-            email = "test@test.com"
+            email = "test@test.com",
+            enabled = true
         )
     }
 }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -13,7 +13,6 @@ import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
 import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
 import javax.inject.Inject
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -37,12 +36,6 @@ class SignUpGeneralViewModel @Inject constructor(
         checkNotNull(gender)
 
         setInitData(phoneNumber, name, gender)
-    }
-
-    val enabled = container.stateFlow.map {
-        with(it) {
-            (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && isUserIdAvailable == true
-        }
     }
 
     private fun setInitData(phoneNumber: String, name: String, gender: String) {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -125,7 +125,7 @@ class SignUpGeneralViewModel @Inject constructor(
         intent {
             if (state.isPasswordValid && state.isPasswordEqual) {
                 reduce {
-                    state.copy(step = SignUpGeneralStep.NICKNANE_AND_EMAIL)
+                    state.copy(step = SignUpGeneralStep.NICKNAME_AND_EMAIL)
                 }
             } else {
                 reduce {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -13,6 +13,7 @@ import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
 import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
 import javax.inject.Inject
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -36,6 +37,12 @@ class SignUpGeneralViewModel @Inject constructor(
         checkNotNull(gender)
 
         setInitData(phoneNumber, name, gender)
+    }
+
+    val enabled = container.stateFlow.map {
+        with(it) {
+            (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && isUserIdAvailable == true
+        }
     }
 
     private fun setInitData(phoneNumber: String, name: String, gender: String) {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentSideEffect.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentSideEffect.kt
@@ -1,0 +1,6 @@
+package `in`.koreatech.koin.feature.signup.ui.userinfo.student
+
+sealed class SignUpStudentSideEffect {
+    data object SignUpSuccess : SignUpStudentSideEffect()
+    data object SignUpFailure : SignUpStudentSideEffect()
+}

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -32,5 +32,5 @@ val SignUpStudentState.isEnabled
 
 enum class SignUpStudentStep {
     INITIAL,
-    NICKNANE_AND_EMAIL
+    NICKNAME_AND_EMAIL
 }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -1,0 +1,33 @@
+package `in`.koreatech.koin.feature.signup.ui.userinfo.student
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SignUpStudentState(
+    val step: SignUpStudentStep = SignUpStudentStep.INITIAL,
+    val phoneNumber: String = "",
+    val name: String = "",
+    val gender: String = "",
+    val userId: String = "",
+    val isUserIdAvailable: Boolean? = null,
+    val isUserIdValid: Boolean = false,
+    val password: String = "",
+    val passwordConfirm: String = "",
+    val isPasswordValid: Boolean = false,
+    val isPasswordEqual: Boolean = false,
+    val showPassword: Boolean = false,
+    val department: String = "",
+    val studentNumber: String = "",
+    val isDropdownExpanded: Boolean = false,
+    val isDepartmentSelected: Boolean = false,
+    val nickname: String = "",
+    val isNicknameAvailable: Boolean? = null,
+    val email: String = "",
+    val isSignUpSuccess: Boolean = false
+) : Parcelable
+
+enum class SignUpStudentStep {
+    INITIAL,
+    NICK_NANE_AND_EMAIL
+}

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -27,6 +27,9 @@ data class SignUpStudentState(
     val isSignUpSuccess: Boolean = false
 ) : Parcelable
 
+val SignUpStudentState.isEnabled
+    get() = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true
+
 enum class SignUpStudentStep {
     INITIAL,
     NICKNANE_AND_EMAIL

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -29,5 +29,5 @@ data class SignUpStudentState(
 
 enum class SignUpStudentStep {
     INITIAL,
-    NICK_NANE_AND_EMAIL
+    NICKNANE_AND_EMAIL
 }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +49,7 @@ fun SignUpStudentUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
+    val enabled by viewModel.enabled.collectAsState(false)
 
     viewModel.collectSideEffect {
         handleSideEffect(
@@ -73,6 +75,7 @@ fun SignUpStudentUserInfo(
         isDropdownExpanded = uiState.isDropdownExpanded,
         isDepartmentSelected = uiState.isDepartmentSelected,
         email = uiState.email,
+        enabled = enabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
         checkNicknameDuplicate = { viewModel.checkNicknameDuplicate() },
@@ -107,6 +110,7 @@ fun SignUpStudentUserInfoImpl(
     isDropdownExpanded: Boolean,
     isDepartmentSelected: Boolean,
     email: String,
+    enabled: Boolean,
     modifier: Modifier = Modifier,
     onNicknameChange: (String) -> Unit = {},
     checkNicknameDuplicate: () -> Unit = {},
@@ -190,7 +194,7 @@ fun SignUpStudentUserInfoImpl(
         FilledButton(
             modifier = Modifier.fillMaxWidth(),
             text = stringResource(R.string.sign_up_next),
-            enabled = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true,
+            enabled = enabled,
             contentPadding = PaddingValues(12.dp),
             onClick = {
                 onSignUpButtonClick()
@@ -472,7 +476,8 @@ fun SignUpStudentUserInfoPreview() {
             department = "컴퓨터공학과",
             studentNumber = "2000000000",
             isDropdownExpanded = false,
-            isDepartmentSelected = false
+            isDepartmentSelected = false,
+            enabled = true
         )
     }
 }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -165,7 +165,7 @@ fun SignUpStudentUserInfoImpl(
                 onShowPasswordChange = { onShowPasswordChange(it) }
             )
 
-            if (step == SignUpStudentStep.NICKNANE_AND_EMAIL) {
+            if (step == SignUpStudentStep.NICKNAME_AND_EMAIL) {
                 Spacer(modifier = Modifier.height(32.dp))
 
                 SignUpStudentUserInfoNickNameEmailStep(
@@ -469,7 +469,7 @@ private fun handleSideEffect(
 fun SignUpStudentUserInfoPreview() {
     KoinTheme {
         SignUpStudentUserInfoImpl(
-            step = SignUpStudentStep.NICKNANE_AND_EMAIL,
+            step = SignUpStudentStep.NICKNAME_AND_EMAIL,
             userId = "userId",
             isUserIdAvailable = true,
             isUserIdValid = true,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -30,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.domain.util.ext.isNicknameFormat
+import `in`.koreatech.koin.domain.util.ext.isValidStudentId
 import `in`.koreatech.koin.feature.signup.R
 import `in`.koreatech.koin.feature.signup.component.KoinSignUpBasicTextField
 import `in`.koreatech.koin.feature.signup.component.KoinSignUpDropdown
@@ -363,6 +363,15 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
         value = studentNumber,
         onValueChange = { onStudentNumberChange(it) }
     )
+
+    if (studentNumber.isNotEmpty() && !studentNumber.isValidStudentId) {
+        Spacer(modifier = Modifier.height(8.dp))
+
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_student_number_wrong_format),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
 
     Spacer(modifier = Modifier.height(12.dp))
 

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -49,7 +49,6 @@ fun SignUpStudentUserInfo(
     navigateToNextScreen: () -> Unit
 ) {
     val uiState by viewModel.collectAsState()
-    val enabled by viewModel.enabled.collectAsState(false)
 
     viewModel.collectSideEffect {
         handleSideEffect(
@@ -75,7 +74,7 @@ fun SignUpStudentUserInfo(
         isDropdownExpanded = uiState.isDropdownExpanded,
         isDepartmentSelected = uiState.isDepartmentSelected,
         email = uiState.email,
-        enabled = enabled,
+        enabled = uiState.isEnabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
         checkNicknameDuplicate = { viewModel.checkNicknameDuplicate() },

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -162,7 +162,7 @@ fun SignUpStudentUserInfoImpl(
                 onShowPasswordChange = { onShowPasswordChange(it) }
             )
 
-            if (step == SignUpStudentStep.NICK_NANE_AND_EMAIL) {
+            if (step == SignUpStudentStep.NICKNANE_AND_EMAIL) {
                 Spacer(modifier = Modifier.height(32.dp))
 
                 SignUpStudentUserInfoNickNameEmailStep(
@@ -457,7 +457,7 @@ private fun handleSideEffect(
 fun SignUpStudentUserInfoPreview() {
     KoinTheme {
         SignUpStudentUserInfoImpl(
-            step = SignUpStudentStep.NICK_NANE_AND_EMAIL,
+            step = SignUpStudentStep.NICKNANE_AND_EMAIL,
             userId = "userId",
             isUserIdAvailable = true,
             isUserIdValid = true,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -1,0 +1,476 @@
+package `in`.koreatech.koin.feature.signup.ui.userinfo.student
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.domain.util.ext.isNicknameFormat
+import `in`.koreatech.koin.feature.signup.R
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpBasicTextField
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpDropdown
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpPasswordTextField
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpProgressHeader
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpProgressIndicator
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpTextFieldAlert
+import `in`.koreatech.koin.feature.signup.component.KoinSignUpTextFieldAlertState
+import `in`.koreatech.koin.feature.signup.departmentStringList
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun SignUpStudentUserInfo(
+    modifier: Modifier = Modifier,
+    viewModel: SignUpStudentViewModel = hiltViewModel(),
+    navigateToNextScreen: () -> Unit
+) {
+    val uiState by viewModel.collectAsState()
+
+    viewModel.collectSideEffect {
+        handleSideEffect(
+            sideEffect = it,
+            navigateToNextScreen = navigateToNextScreen
+        )
+    }
+
+    SignUpStudentUserInfoImpl(
+        step = uiState.step,
+        userId = uiState.userId,
+        isUserIdAvailable = uiState.isUserIdAvailable,
+        isUserIdValid = uiState.isUserIdValid,
+        nickname = uiState.nickname,
+        isNicknameAvailable = uiState.isNicknameAvailable,
+        password = uiState.password,
+        passwordConfirm = uiState.passwordConfirm,
+        showPassword = uiState.showPassword,
+        isPasswordValid = uiState.isPasswordValid,
+        isPasswordEqual = uiState.isPasswordEqual,
+        department = uiState.department,
+        studentNumber = uiState.studentNumber,
+        isDropdownExpanded = uiState.isDropdownExpanded,
+        isDepartmentSelected = uiState.isDepartmentSelected,
+        email = uiState.email,
+        modifier = modifier,
+        onNicknameChange = { viewModel.setNickname(it) },
+        checkNicknameDuplicate = { viewModel.checkNicknameDuplicate() },
+        onUserIdChange = { viewModel.setUserId(it) },
+        checkUserIdDuplicate = { viewModel.checkUserIdDuplicate() },
+        onPasswordChange = { viewModel.setPassword(it) },
+        onPasswordConfirmChange = { viewModel.setPasswordConfirm(it) },
+        onShowPasswordChange = { viewModel.setPasswordVisibility(it) },
+        onDropdownExpandChange = { viewModel.setDepartmentDropdownExpanded(it) },
+        onDepartmentSelected = { viewModel.setDepartment(it) },
+        onStudentNumberChange = { viewModel.setStudentNumber(it) },
+        onEmailChange = { viewModel.setEmail(it) },
+        onSignUpButtonClick = { viewModel.signUp() }
+    )
+}
+
+@Composable
+fun SignUpStudentUserInfoImpl(
+    step: SignUpStudentStep,
+    userId: String,
+    isUserIdAvailable: Boolean?,
+    isUserIdValid: Boolean,
+    nickname: String,
+    isNicknameAvailable: Boolean?,
+    password: String,
+    passwordConfirm: String,
+    showPassword: Boolean,
+    isPasswordValid: Boolean,
+    isPasswordEqual: Boolean,
+    department: String,
+    studentNumber: String,
+    isDropdownExpanded: Boolean,
+    isDepartmentSelected: Boolean,
+    email: String,
+    modifier: Modifier = Modifier,
+    onNicknameChange: (String) -> Unit = {},
+    checkNicknameDuplicate: () -> Unit = {},
+    onUserIdChange: (String) -> Unit = {},
+    checkUserIdDuplicate: () -> Unit = {},
+    onPasswordChange: (String) -> Unit = {},
+    onPasswordConfirmChange: (String) -> Unit = {},
+    onShowPasswordChange: (Boolean) -> Unit = {},
+    onDropdownExpandChange: (Boolean) -> Unit = {},
+    onDepartmentSelected: (String) -> Unit = {},
+    onStudentNumberChange: (String) -> Unit = {},
+    onEmailChange: (String) -> Unit = {},
+    onSignUpButtonClick: () -> Unit = {}
+) {
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
+            .verticalScroll(scrollState)
+            .padding(horizontal = 24.dp)
+    ) {
+        KoinSignUpProgressHeader(
+            text = stringResource(R.string.sign_up_user_info),
+            currentStep = 4,
+            maxStep = 4
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        KoinSignUpProgressIndicator(
+            currentStep = 4,
+            maxStep = 4
+        )
+
+        Spacer(modifier = Modifier.height(64.dp))
+
+        Column(modifier = Modifier.padding(horizontal = 8.dp)) {
+            SignUpStudentUserInfoInitialStep(
+                userId = userId,
+                isUserIdAvailable = isUserIdAvailable,
+                isUserIdValid = isUserIdValid,
+                password = password,
+                passwordConfirm = passwordConfirm,
+                showPassword = showPassword,
+                isPasswordValid = isPasswordValid,
+                isPasswordEqual = isPasswordEqual,
+                onUserIdChange = { onUserIdChange(it) },
+                checkUserIdAvailable = { checkUserIdDuplicate() },
+                onPasswordChange = { onPasswordChange(it) },
+                onPasswordConfirmChange = { onPasswordConfirmChange(it) },
+                onShowPasswordChange = { onShowPasswordChange(it) }
+            )
+
+            if (step == SignUpStudentStep.NICK_NANE_AND_EMAIL) {
+                Spacer(modifier = Modifier.height(32.dp))
+
+                SignUpStudentUserInfoNickNameEmailStep(
+                    nickname = nickname,
+                    isNicknameAvailable = isNicknameAvailable,
+                    email = email,
+                    department = department,
+                    isDepartmentSelected = isDepartmentSelected,
+                    isDropdownExpanded = isDropdownExpanded,
+                    studentNumber = studentNumber,
+                    onDropdownExpandChange = { onDropdownExpandChange(it) },
+                    onDepartmentSelected = { onDepartmentSelected(it) },
+                    onStudentNumberChange = { onStudentNumberChange(it) },
+                    checkNicknameDuplicate = { checkNicknameDuplicate() },
+                    onNicknameChange = { onNicknameChange(it) },
+                    onEmailChange = { onEmailChange(it) }
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        FilledButton(
+            modifier = Modifier.fillMaxWidth(),
+            text = stringResource(R.string.sign_up_next),
+            enabled = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true,
+            contentPadding = PaddingValues(12.dp),
+            onClick = {
+                onSignUpButtonClick()
+            }
+        )
+    }
+}
+
+@Composable
+private fun SignUpStudentUserInfoInitialStep(
+    userId: String,
+    isUserIdAvailable: Boolean?,
+    isUserIdValid: Boolean,
+    password: String,
+    passwordConfirm: String,
+    showPassword: Boolean,
+    isPasswordValid: Boolean,
+    isPasswordEqual: Boolean,
+    onUserIdChange: (String) -> Unit = {},
+    checkUserIdAvailable: () -> Unit = {},
+    onPasswordChange: (String) -> Unit = {},
+    onPasswordConfirmChange: (String) -> Unit = {},
+    onShowPasswordChange: (Boolean) -> Unit = {}
+) {
+    Text(
+        text = stringResource(R.string.sign_up_user_info_id_title),
+        style = KoinTheme.typography.medium16
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Max),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        KoinSignUpBasicTextField(
+            modifier = Modifier.weight(1f),
+            hint = stringResource(R.string.sign_up_user_info_id_hint),
+            value = userId,
+            onValueChange = {
+                onUserIdChange(it)
+            }
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+            FilledButton(
+                modifier = Modifier.widthIn(min = 86.dp),
+                text = stringResource(R.string.sign_up_user_info_id_check_duplicate),
+                textStyle = KoinTheme.typography.regular10,
+                enabled = userId.isNotEmpty() && isUserIdAvailable != true,
+                contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
+                onClick = {
+                    checkUserIdAvailable()
+                }
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (userId.isNotEmpty() && !isUserIdValid) {
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_id_wrong_format),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+
+    if (isUserIdAvailable != null) {
+        KoinSignUpTextFieldAlert(
+            text = if (isUserIdAvailable == true) stringResource(R.string.sign_up_user_info_id_available) else stringResource(R.string.sign_up_user_info_id_duplicate),
+            state = if (isUserIdAvailable == true) KoinSignUpTextFieldAlertState.Success else KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+
+    Spacer(modifier = Modifier.height(32.dp))
+
+    Text(
+        text = stringResource(R.string.sign_up_user_info_password_title),
+        style = KoinTheme.typography.medium16
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    KoinSignUpPasswordTextField(
+        modifier = Modifier.fillMaxWidth(),
+        hint = stringResource(R.string.sign_up_user_info_password_hint),
+        value = password,
+        onValueChange = { onPasswordChange(it) },
+        showPassword = showPassword,
+        onShowPasswordChange = { onShowPasswordChange(it) }
+    )
+
+    if (isPasswordValid) {
+        Spacer(modifier = Modifier.height(16.dp))
+
+        KoinSignUpPasswordTextField(
+            modifier = Modifier.fillMaxWidth(),
+            hint = stringResource(R.string.sign_up_user_info_password_confirm_hint),
+            value = passwordConfirm,
+            onValueChange = { onPasswordConfirmChange(it) },
+            showPassword = showPassword,
+            onShowPasswordChange = { onShowPasswordChange(it) }
+        )
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (password.isNotEmpty() && !isPasswordValid) {
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_password_not_valid),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+
+    if (passwordConfirm.isNotEmpty()) {
+        KoinSignUpTextFieldAlert(
+            text = if (isPasswordEqual) stringResource(R.string.sign_up_user_info_password_confirm_correct) else stringResource(R.string.sign_up_user_info_password_confirm_incorrect),
+            state = if (isPasswordEqual) KoinSignUpTextFieldAlertState.Success else KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+}
+
+@Composable
+private fun SignUpStudentUserInfoNickNameEmailStep(
+    nickname: String,
+    isNicknameAvailable: Boolean?,
+    email: String,
+    department: String,
+    isDepartmentSelected: Boolean,
+    isDropdownExpanded: Boolean,
+    studentNumber: String,
+    onDropdownExpandChange: (Boolean) -> Unit,
+    onDepartmentSelected: (String) -> Unit = {},
+    onStudentNumberChange: (String) -> Unit = {},
+    checkNicknameDuplicate: () -> Unit = {},
+    onNicknameChange: (String) -> Unit = {},
+    onEmailChange: (String) -> Unit = {}
+) {
+    Text(
+        text = stringResource(R.string.sign_up_user_info_department_and_student_number_title),
+        style = KoinTheme.typography.medium18
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    KoinSignUpDropdown(
+        text = department,
+        hint = stringResource(R.string.sign_up_user_info_department_hint),
+        isSelected = isDepartmentSelected,
+        isDropdownExpanded = isDropdownExpanded,
+        items = departmentStringList,
+        onDropdownExpandChange = onDropdownExpandChange,
+        onItemSelected = {
+            onDepartmentSelected(departmentStringList[it])
+        }
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    KoinSignUpBasicTextField(
+        modifier = Modifier.fillMaxWidth(),
+        hint = stringResource(R.string.sign_up_user_info_student_number_hint),
+        value = studentNumber,
+        onValueChange = { onStudentNumberChange(it) }
+    )
+
+    Spacer(modifier = Modifier.height(12.dp))
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(IntrinsicSize.Max),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        KoinSignUpBasicTextField(
+            modifier = Modifier.weight(1f),
+            hint = stringResource(R.string.sign_up_user_info_nickname_hint),
+            value = nickname,
+            onValueChange = {
+                onNicknameChange(it)
+            }
+        )
+
+        Spacer(modifier = Modifier.width(16.dp))
+
+        CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+            FilledButton(
+                modifier = Modifier.widthIn(min = 86.dp),
+                text = stringResource(R.string.sign_up_user_info_nickname_check_duplicate),
+                textStyle = KoinTheme.typography.regular10,
+                enabled = nickname.isNotEmpty() && nickname.isNicknameFormat(),
+                contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
+                onClick = {
+                    checkNicknameDuplicate()
+                }
+            )
+        }
+    }
+
+    Spacer(modifier = Modifier.height(8.dp))
+
+    if (nickname.isNotEmpty() && !nickname.isNicknameFormat()) {
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_nickname_wrong_format),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+
+    if (isNicknameAvailable != null) {
+        KoinSignUpTextFieldAlert(
+            text = if (isNicknameAvailable == true) stringResource(R.string.sign_up_user_info_nickname_available) else stringResource(R.string.sign_up_user_info_nickname_duplicate),
+            state = if (isNicknameAvailable == true) KoinSignUpTextFieldAlertState.Success else KoinSignUpTextFieldAlertState.Warning
+        )
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        KoinSignUpBasicTextField(
+            modifier = Modifier.weight(1f),
+            hint = stringResource(R.string.sign_up_user_info_email_hint),
+            value = email,
+            onValueChange = {
+                onEmailChange(it)
+            }
+        )
+
+        Spacer(modifier = Modifier.width(4.dp))
+
+        Text(
+            style = KoinTheme.typography.regular14,
+            color = KoinTheme.colors.neutral400,
+            text = stringResource(R.string.sign_up_user_info_email_koreatech_suffix)
+        )
+    }
+}
+
+private fun handleSideEffect(
+    sideEffect: SignUpStudentSideEffect,
+    navigateToNextScreen: () -> Unit
+) {
+    when (sideEffect) {
+        is SignUpStudentSideEffect.SignUpSuccess -> {
+            navigateToNextScreen()
+        }
+
+        is SignUpStudentSideEffect.SignUpFailure -> {
+            // TODO: Handle sign up failure
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SignUpStudentUserInfoPreview() {
+    KoinTheme {
+        SignUpStudentUserInfoImpl(
+            step = SignUpStudentStep.NICK_NANE_AND_EMAIL,
+            userId = "userId",
+            isUserIdAvailable = true,
+            isUserIdValid = true,
+            email = "email",
+            nickname = "nickname",
+            isNicknameAvailable = true,
+            password = "password",
+            passwordConfirm = "password",
+            showPassword = false,
+            isPasswordValid = true,
+            isPasswordEqual = true,
+            department = "컴퓨터공학과",
+            studentNumber = "2000000000",
+            isDropdownExpanded = false,
+            isDepartmentSelected = false
+        )
+    }
+}

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -394,9 +394,9 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
         }
     }
 
-    Spacer(modifier = Modifier.height(8.dp))
-
     if (nickname.isNotEmpty() && !nickname.isNicknameFormat()) {
+        Spacer(modifier = Modifier.height(8.dp))
+
         KoinSignUpTextFieldAlert(
             text = stringResource(R.string.sign_up_user_info_nickname_wrong_format),
             state = KoinSignUpTextFieldAlertState.Warning
@@ -404,13 +404,15 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
     }
 
     if (isNicknameAvailable != null) {
+        Spacer(modifier = Modifier.height(8.dp))
+
         KoinSignUpTextFieldAlert(
             text = if (isNicknameAvailable == true) stringResource(R.string.sign_up_user_info_nickname_available) else stringResource(R.string.sign_up_user_info_nickname_duplicate),
             state = if (isNicknameAvailable == true) KoinSignUpTextFieldAlertState.Success else KoinSignUpTextFieldAlertState.Warning
         )
     }
 
-    Spacer(modifier = Modifier.height(16.dp))
+    Spacer(modifier = Modifier.height(12.dp))
 
     Row(
         modifier = Modifier.fillMaxWidth(),

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -149,7 +149,7 @@ class SignUpStudentViewModel @Inject constructor(
         intent {
             if (state.isPasswordValid && state.isPasswordEqual) {
                 reduce {
-                    state.copy(step = SignUpStudentStep.NICK_NANE_AND_EMAIL)
+                    state.copy(step = SignUpStudentStep.NICKNANE_AND_EMAIL)
                 }
             } else {
                 reduce {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -74,7 +74,7 @@ class SignUpStudentViewModel @Inject constructor(
     fun setPassword(password: String) {
         blockingIntent {
             reduce {
-                state.copy(password = password, isPasswordValid = password.isValidPassword())
+                state.copy(password = password, isPasswordValid = password.isValidPassword(), isPasswordEqual = password == state.passwordConfirm)
             }
         }
         checkNextStep()

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -13,7 +13,6 @@ import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
 import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
 import javax.inject.Inject
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -37,12 +36,6 @@ class SignUpStudentViewModel @Inject constructor(
         checkNotNull(gender)
 
         setInitData(phoneNumber, name, gender)
-    }
-
-    val enabled = container.stateFlow.map {
-        with(it) {
-            (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true
-        }
     }
 
     private fun setInitData(phoneNumber: String, name: String, gender: String) {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -1,0 +1,180 @@
+package `in`.koreatech.koin.feature.signup.ui.userinfo.student
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
+import `in`.koreatech.koin.domain.usecase.signup.PostStudentRegisterUseCase
+import `in`.koreatech.koin.domain.util.ext.isValidPassword
+import `in`.koreatech.koin.feature.signup.navigation.GENDER
+import `in`.koreatech.koin.feature.signup.navigation.NAME
+import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+
+@HiltViewModel
+class SignUpStudentViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
+    private val postStudentRegisterUseCase: PostStudentRegisterUseCase
+) : ViewModel(), ContainerHost<SignUpStudentState, SignUpStudentSideEffect> {
+    override val container = container<SignUpStudentState, SignUpStudentSideEffect>(SignUpStudentState(), savedStateHandle) {
+        val phoneNumber = savedStateHandle.get<String>(PHONE_NUMBER)
+        val name = savedStateHandle.get<String>(NAME)
+        val gender = savedStateHandle.get<String>(GENDER)
+        checkNotNull(phoneNumber)
+        checkNotNull(name)
+        checkNotNull(gender)
+
+        setInitData(phoneNumber, name, gender)
+    }
+
+    private fun setInitData(phoneNumber: String, name: String, gender: String) {
+        intent {
+            reduce {
+                state.copy(phoneNumber = phoneNumber, name = name, gender = gender)
+            }
+        }
+    }
+
+    fun setUserId(userId: String) {
+        blockingIntent {
+            reduce {
+                state.copy(userId = userId, isUserIdValid = userId.isNotEmpty())
+            }
+        }
+    }
+
+    fun checkUserIdDuplicate() = viewModelScope.launch {
+        intent {
+            reduce {
+                state.copy(isUserIdAvailable = true)
+            }
+        }
+        checkNextStep()
+    }
+
+    fun setEmail(email: String) {
+        blockingIntent {
+            reduce {
+                state.copy(email = email)
+            }
+        }
+    }
+
+    fun setPassword(password: String) {
+        blockingIntent {
+            reduce {
+                state.copy(password = password, isPasswordValid = password.isValidPassword())
+            }
+        }
+        checkNextStep()
+    }
+
+    fun setPasswordConfirm(passwordConfirm: String) {
+        blockingIntent {
+            reduce {
+                state.copy(passwordConfirm = passwordConfirm, isPasswordEqual = state.password == passwordConfirm)
+            }
+        }
+        checkNextStep()
+    }
+
+    fun setPasswordVisibility(showPassword: Boolean) {
+        blockingIntent {
+            reduce {
+                state.copy(showPassword = showPassword)
+            }
+        }
+    }
+
+    fun setNickname(nickname: String) {
+        blockingIntent {
+            reduce {
+                state.copy(nickname = nickname)
+            }
+        }
+    }
+
+    fun checkNicknameDuplicate() = viewModelScope.launch {
+        intent {
+            checkNicknameDuplicateUseCase(state.nickname).let {
+                if (it is SignupContinuationState.AvailableNickname) {
+                    reduce {
+                        state.copy(isNicknameAvailable = true)
+                    }
+                } else {
+                    reduce {
+                        state.copy(isNicknameAvailable = false)
+                    }
+                }
+            }
+        }
+    }
+
+    fun setDepartmentDropdownExpanded(isExpanded: Boolean) {
+        blockingIntent {
+            reduce {
+                state.copy(isDropdownExpanded = isExpanded)
+            }
+        }
+    }
+
+    fun setDepartment(department: String) {
+        blockingIntent {
+            reduce {
+                state.copy(department = department, isDepartmentSelected = department.isNotEmpty())
+            }
+        }
+    }
+
+    fun setStudentNumber(studentNumber: String) {
+        blockingIntent {
+            reduce {
+                state.copy(studentNumber = studentNumber)
+            }
+        }
+    }
+
+    private fun checkNextStep() {
+        intent {
+            if (state.isPasswordValid && state.isPasswordEqual) {
+                reduce {
+                    state.copy(step = SignUpStudentStep.NICK_NANE_AND_EMAIL)
+                }
+            } else {
+                reduce {
+                    state.copy(step = SignUpStudentStep.INITIAL)
+                }
+            }
+        }
+    }
+
+    fun signUp() = viewModelScope.launch {
+        intent {
+            postStudentRegisterUseCase(
+                name = state.name,
+                phoneNumber = state.phoneNumber,
+                userId = state.userId,
+                password = state.password,
+                gender = state.gender,
+                email = state.email,
+                nickname = state.nickname,
+                studentNumber = state.studentNumber,
+                department = state.department
+            ).onSuccess {
+                postSideEffect(SignUpStudentSideEffect.SignUpSuccess)
+            }.onFailure {
+                postSideEffect(SignUpStudentSideEffect.SignUpFailure)
+            }
+        }
+    }
+}

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -13,6 +13,7 @@ import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
 import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
 import javax.inject.Inject
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -36,6 +37,12 @@ class SignUpStudentViewModel @Inject constructor(
         checkNotNull(gender)
 
         setInitData(phoneNumber, name, gender)
+    }
+
+    val enabled = container.stateFlow.map {
+        with(it) {
+            (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true
+        }
     }
 
     private fun setInitData(phoneNumber: String, name: String, gender: String) {

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostStudentRegisterUseCase
+import `in`.koreatech.koin.domain.util.ext.isUserIdFormat
 import `in`.koreatech.koin.domain.util.ext.isValidPassword
 import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
@@ -48,7 +49,7 @@ class SignUpStudentViewModel @Inject constructor(
     fun setUserId(userId: String) {
         blockingIntent {
             reduce {
-                state.copy(userId = userId, isUserIdValid = userId.isNotEmpty())
+                state.copy(userId = userId, isUserIdValid = userId.isUserIdFormat())
             }
         }
     }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -149,7 +149,7 @@ class SignUpStudentViewModel @Inject constructor(
         intent {
             if (state.isPasswordValid && state.isPasswordEqual) {
                 reduce {
-                    state.copy(step = SignUpStudentStep.NICKNANE_AND_EMAIL)
+                    state.copy(step = SignUpStudentStep.NICKNAME_AND_EMAIL)
                 }
             } else {
                 reduce {

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="sign_up_user_info_nickname_available">사용 가능한 닉네임입니다.</string>
     <string name="sign_up_user_info_nickname_wrong_format">한글, 영문 및 숫자 포함하여 10자 내로 입력해 주세요.</string>
     <string name="sign_up_user_info_email_hint">이메일을 입력해 주세요. (선택)</string>
+    <string name="sign_up_user_info_email_koreatech_suffix">\@koreatech.ac.kr</string>
     <string name="sign_up_user_info_password_title">사용하실 비밀번호를 입력해 주세요.</string>
     <string name="sign_up_user_info_password_hint">특수문자 포함 영어와 숫자 6~18자리로 입력해 주세요.</string>
     <string name="sign_up_user_info_password_not_valid">올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.</string>

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="sign_up_user_info_department_and_student_number_title">학부와 학번을 알려주세요.</string>
     <string name="sign_up_user_info_department_hint">학부를 선택해주세요.</string>
     <string name="sign_up_user_info_student_number_hint">학번을 입력해주세요.</string>
+    <string name="sign_up_user_info_student_number_wrong_format">올바른 학번 양식이 아닙니다. 다시 입력해 주세요.</string>
 
     <string name="sign_up_next">다음</string>
 </resources>


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 학생 정보 입력 화면 구현

## 작업 내용
* 회원가입 학생 정보 입력 화면을 구현했습니다.

## 사진
|초기 화면|아이디 입력|비밀번호 입력|비밀번호 보기 체크|학부 선택|
|----|----|----|----|----|
|![Screenshot_20250427-223929_코인D](https://github.com/user-attachments/assets/60675159-e3ac-4630-87dd-dcd4e140dd78)|![Screenshot_20250427-223937_코인D](https://github.com/user-attachments/assets/efb348b5-6986-463a-a681-5947146c3a32)|![Screenshot_20250427-224044_코인D](https://github.com/user-attachments/assets/4906efc2-c4a0-4d00-97c1-aca6ddfbfd62)|![Screenshot_20250427-224051_코인D](https://github.com/user-attachments/assets/0709d2f7-f27a-480d-9bd0-937ff9f37e21)|![Screenshot_20250427-224055_코인D](https://github.com/user-attachments/assets/be5d6213-f35e-4581-88fc-c3ea59be4fd5)|

## 추가적인 내용
* 마찬가지로 아이디 검증 API가 아직 나오지 않아서 나온 후 수정하겠습니다.
* #624 에 이어서 작업했기 때문에 c3c16af7b46da4cf217e22b0b2a911c79d2ad7b1 부터 보시면 됩니다.