### PR TITLE
[User][Fix] 키보드가 보일 때 Navigation bar padding이 사라지지 않던 문제 수정

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -41,7 +42,9 @@ class SignUpActivity : ComponentActivity() {
                     containerColor = KoinTheme.colors.neutral0
                 ) { contentPadding ->
                     NavHost(
-                        modifier = Modifier.padding(contentPadding),
+                        modifier = Modifier
+                            .padding(contentPadding)
+                            .consumeWindowInsets(contentPadding),
                         navController = navController,
                         enterTransition = {
                             EnterTransition.None


### PR DESCRIPTION
issue #592 

## 개요
* 키보드가 보일 때 Navigation bar padding이 사라지지 않던 문제 수정

## 작업 내용
* SignUpActivity에서 contentPadding을 consume 처리 했습니다.