### PR TITLE
[User][Fix] 다크 모드 시 회원가입 화면 상단바 색상이 올바르지 않은 문제 수정

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.signup
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.consumeWindowInsets
@@ -17,6 +16,7 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
 import `in`.koreatech.koin.feature.signup.navigation.SignUpNavType
 import `in`.koreatech.koin.feature.signup.navigation.koinSignUpGraph
 
@@ -25,7 +25,7 @@ class SignUpActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdgeWithLightStatusBar()
         setContent {
             KoinTheme {
                 val navController = rememberNavController()


### PR DESCRIPTION
issue: #592 

## 개요
* 다크 모드 시 회원가입 화면 상단바 색상이 올바르지 않은 문제 수정

## 작업 내용
* enableEdgeToEdgeWithLightStatusBar()를 사용하여 다크모드 시 상단바 색상이 올바르지 않은 문제를 수정했습니다.