### PR TITLE
[User][Feature] 회원가입 아이디 중복 확인 API 연결

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/UserApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/UserApi.kt
@@ -66,6 +66,11 @@ interface UserApi {
         @Query("nickname") nickname: String
     )
 
+    @GET(URLConstant.USER.CHECKUSERID)
+    suspend fun checkUserId(
+        @Query("loginId") id: String
+    )
+
     @POST(URLConstant.USER.SMSSEND)
     suspend fun smsSend(
         @Body smsSendRequest: SmsSendRequest

--- a/data/src/main/java/in/koreatech/koin/data/constant/URLConstant.kt
+++ b/data/src/main/java/in/koreatech/koin/data/constant/URLConstant.kt
@@ -66,6 +66,7 @@ object URLConstant {
         const val PROFILEUPLOAD: String = "$USER/profile/upload"
         const val CHECKPHONE: String = "$USER/check/phone"
         const val CHECKNICKNAME_V2: String = "$USER/check/nickname"
+        const val CHECKUSERID: String = "$USER/check/id"
         const val SMSSEND: String = "$USER/verification/sms/send"
         const val SMSVERIFY: String = "$USER/verification/sms/verify"
         const val AUTH: String = "$USER/auth"

--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -109,6 +109,7 @@ class SignupRepositoryImpl @Inject constructor(
         } catch (e: HttpException) {
             when (e.code()) {
                 409 -> SignupContinuationState.PhoneNumberDuplicated
+                400 -> SignupContinuationState.CheckPhoneNumberFormat
                 else -> SignupContinuationState.Failed(
                     message = e.getErrorResponse().message ?: "",
                     throwable = e
@@ -145,6 +146,22 @@ class SignupRepositoryImpl @Inject constructor(
             Result.success(Unit)
         } catch (e: HttpException) {
             Result.failure(e)
+        }
+    }
+
+    override suspend fun isUserIdDuplicated(userId: String): SignupContinuationState {
+        return try {
+            userRemoteDataSource.checkUserId(userId)
+            SignupContinuationState.AvailableUserId
+        } catch (e: HttpException) {
+            when (e.code()) {
+                409 -> SignupContinuationState.UserIdDuplicated
+                400 -> SignupContinuationState.CheckUserIdFormat
+                else -> SignupContinuationState.Failed(
+                    message = e.getErrorResponse().message ?: "",
+                    throwable = e
+                )
+            }
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/UserRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/UserRemoteDataSource.kt
@@ -98,6 +98,10 @@ class UserRemoteDataSource(
         userApi.checkNicknameV2(nickname)
     }
 
+    suspend fun checkUserId(userId: String) {
+        userApi.checkUserId(userId)
+    }
+
     suspend fun postStudentRegister(studentInfoRequest: StudentInfoRequestV2) {
         userApi.postStudentRegister(studentInfoRequest)
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
@@ -34,6 +34,8 @@ interface SignupRepository {
 
     suspend fun isPhoneDuplicated(phone: String): SignupContinuationState
 
+    suspend fun isUserIdDuplicated(userId: String): SignupContinuationState
+
     suspend fun postStudentRegister(
         name: String,
         phoneNumber: String,

--- a/domain/src/main/java/in/koreatech/koin/domain/state/signup/SignupContinuationState.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/state/signup/SignupContinuationState.kt
@@ -33,6 +33,8 @@ sealed class SignupContinuationState {
 
     object CheckPhoneNumberFormat : SignupContinuationState() // 전화번호를 올바른 형식으로 작성했는지 확인
 
+    object CheckUserIdFormat : SignupContinuationState() // 아이디를 올바른 형식으로 작성했는지 확인
+
     object CompanyNumberIsNotValidate : SignupContinuationState()
 
     object SmsCodeIsValidated : SignupContinuationState()

--- a/domain/src/main/java/in/koreatech/koin/domain/state/signup/SignupContinuationState.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/state/signup/SignupContinuationState.kt
@@ -7,6 +7,8 @@ sealed class SignupContinuationState {
 
     object NicknameDuplicated : SignupContinuationState() // 닉네임 중복
 
+    object UserIdDuplicated : SignupContinuationState() // 아이디 중복
+
     object BusinessNumberDuplicated : SignupContinuationState() // 사업자 번호 중복
 
     object AvailablePhoneNumber : SignupContinuationState() // 전화번호 중복 확인으로 사용 가능
@@ -14,6 +16,8 @@ sealed class SignupContinuationState {
     object AvailableEmail : SignupContinuationState() // 이메일 중복 확인으로 사용 가능
 
     object AvailableNickname : SignupContinuationState() // 이메일 중복 확인으로 사용 가능
+
+    object AvailableUserId : SignupContinuationState() // 아이디 중복 확인으로 사용 가능
 
     object RequestedEmailValidation : SignupContinuationState()
 

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckUserIdDuplicateUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckUserIdDuplicateUseCase.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.domain.usecase.signup
+
+import `in`.koreatech.koin.domain.repository.SignupRepository
+import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import javax.inject.Inject
+
+class CheckUserIdDuplicateUseCase @Inject constructor(
+    private val signupRepository: SignupRepository,
+) {
+    suspend operator fun invoke(userId: String): SignupContinuationState {
+        return signupRepository.isUserIdDuplicated(userId)
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckUserIdDuplicateUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckUserIdDuplicateUseCase.kt
@@ -5,7 +5,7 @@ import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
 import javax.inject.Inject
 
 class CheckUserIdDuplicateUseCase @Inject constructor(
-    private val signupRepository: SignupRepository,
+    private val signupRepository: SignupRepository
 ) {
     suspend operator fun invoke(userId: String): SignupContinuationState {
         return signupRepository.isUserIdDuplicated(userId)

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
+import `in`.koreatech.koin.domain.usecase.signup.CheckUserIdDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostGeneralRegisterUseCase
 import `in`.koreatech.koin.domain.util.ext.isUserIdFormat
 import `in`.koreatech.koin.domain.util.ext.isValidPassword
@@ -20,12 +21,14 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 
 @HiltViewModel
 class SignUpGeneralViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
-    private val postGeneralRegisterUseCase: PostGeneralRegisterUseCase
+    private val postGeneralRegisterUseCase: PostGeneralRegisterUseCase,
+    private val checkUserIdDuplicateUseCase: CheckUserIdDuplicateUseCase
 ) : ViewModel(), ContainerHost<SignUpGeneralState, SignUpGeneralSideEffect> {
     override val container = container<SignUpGeneralState, SignUpGeneralSideEffect>(SignUpGeneralState(), savedStateHandle) {
         val phoneNumber = savedStateHandle.get<String>(PHONE_NUMBER)
@@ -106,8 +109,30 @@ class SignUpGeneralViewModel @Inject constructor(
 
     fun checkUserIdDuplicate() = viewModelScope.launch {
         intent {
-            reduce {
-                state.copy(isUserIdAvailable = true)
+            checkUserIdDuplicateUseCase(state.userId).let {
+                when (it) {
+                    is SignupContinuationState.AvailableUserId -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = true, isUserIdValid = true)
+                        }
+                    }
+
+                    is SignupContinuationState.UserIdDuplicated -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = false, isUserIdValid = true)
+                        }
+                    }
+
+                    is SignupContinuationState.CheckUserIdFormat -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = null, isUserIdValid = false)
+                        }
+                    }
+
+                    else -> {
+                        Timber.d(it.toString())
+                    }
+                }
             }
         }
         checkNextStep()

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -102,7 +102,7 @@ class SignUpGeneralViewModel @Inject constructor(
     fun setUserId(userId: String) {
         blockingIntent {
             reduce {
-                state.copy(userId = userId, isUserIdValid = userId.isUserIdFormat())
+                state.copy(userId = userId, isUserIdValid = userId.isUserIdFormat(), isUserIdAvailable = null)
             }
         }
     }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -52,7 +52,7 @@ class SignUpStudentViewModel @Inject constructor(
     fun setUserId(userId: String) {
         blockingIntent {
             reduce {
-                state.copy(userId = userId, isUserIdValid = userId.isUserIdFormat())
+                state.copy(userId = userId, isUserIdValid = userId.isUserIdFormat(), isUserIdAvailable = null)
             }
         }
     }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
+import `in`.koreatech.koin.domain.usecase.signup.CheckUserIdDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostStudentRegisterUseCase
 import `in`.koreatech.koin.domain.util.ext.isUserIdFormat
 import `in`.koreatech.koin.domain.util.ext.isValidPassword
@@ -20,12 +21,14 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 
 @HiltViewModel
 class SignUpStudentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
-    private val postStudentRegisterUseCase: PostStudentRegisterUseCase
+    private val postStudentRegisterUseCase: PostStudentRegisterUseCase,
+    private val checkUserIdDuplicateUseCase: CheckUserIdDuplicateUseCase
 ) : ViewModel(), ContainerHost<SignUpStudentState, SignUpStudentSideEffect> {
     override val container = container<SignUpStudentState, SignUpStudentSideEffect>(SignUpStudentState(), savedStateHandle) {
         val phoneNumber = savedStateHandle.get<String>(PHONE_NUMBER)
@@ -56,8 +59,30 @@ class SignUpStudentViewModel @Inject constructor(
 
     fun checkUserIdDuplicate() = viewModelScope.launch {
         intent {
-            reduce {
-                state.copy(isUserIdAvailable = true)
+            checkUserIdDuplicateUseCase(state.userId).let {
+                when (it) {
+                    is SignupContinuationState.AvailableUserId -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = true, isUserIdValid = true)
+                        }
+                    }
+
+                    is SignupContinuationState.UserIdDuplicated -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = false, isUserIdValid = true)
+                        }
+                    }
+
+                    is SignupContinuationState.CheckUserIdFormat -> {
+                        reduce {
+                            state.copy(isUserIdAvailable = null, isUserIdValid = false)
+                        }
+                    }
+
+                    else -> {
+                        Timber.d(it.toString())
+                    }
+                }
             }
         }
         checkNextStep()


### PR DESCRIPTION
issue #523 

## 개요
* 회원가입 아이디 중복 확인 API 연결

## 작업 내용
* 회원가입 시 아이디 중복 여부를 확인하는 API를 연결했습니다.
* 사용자가 아이디 입력 값을 변경할 시, isUserIdAvailable을 null로 설정하도록 수정했습니다.
* 휴대폰 번호 확인에서 400 처리가 빠져서 같이 처리했습니다.