### PR TITLE
[User][Fix] 회원가입 TextField 동작 수정

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpPasswordTextField.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpPasswordTextField.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
@@ -45,6 +46,8 @@ fun KoinSignUpPasswordTextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     hint: String = "",
+    keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = false,
     maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
     maxLength: Int = Int.MAX_VALUE,
@@ -61,9 +64,10 @@ fun KoinSignUpPasswordTextField(
                 onValueChange(it.take(maxLength))
             }
         },
-        keyboardOptions = KeyboardOptions.Default.copy(
+        keyboardOptions = keyboardOptions.copy(
             keyboardType = KeyboardType.Password
         ),
+        keyboardActions = keyboardActions,
         textStyle = KoinTheme.typography.regular14.copy(
             lineHeightStyle = null // Remove line height
         ),

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
@@ -23,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -213,7 +215,10 @@ private fun SignUpGeneralUserInfoInitialStep(
             onValueChange = {
                 onUserIdChange(it)
             },
-            showTrailingClearButton = false
+            showTrailingClearButton = false,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -263,7 +268,10 @@ private fun SignUpGeneralUserInfoInitialStep(
         value = password,
         onValueChange = { onPasswordChange(it) },
         showPassword = showPassword,
-        onShowPasswordChange = { onShowPasswordChange(it) }
+        onShowPasswordChange = { onShowPasswordChange(it) },
+        keyboardOptions = KeyboardOptions(
+            imeAction = ImeAction.Next
+        )
     )
 
     if (isPasswordValid) {
@@ -275,7 +283,10 @@ private fun SignUpGeneralUserInfoInitialStep(
             value = passwordConfirm,
             onValueChange = { onPasswordConfirmChange(it) },
             showPassword = showPassword,
-            onShowPasswordChange = { onShowPasswordChange(it) }
+            onShowPasswordChange = { onShowPasswordChange(it) },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
     }
 
@@ -317,7 +328,10 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
             value = nickname,
             onValueChange = {
                 onNicknameChange(it)
-            }
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -360,7 +374,10 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
         value = email,
         onValueChange = {
             onEmailChange(it)
-        }
+        },
+        keyboardOptions = KeyboardOptions(
+            imeAction = ImeAction.Done
+        )
     )
 }
 

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
@@ -22,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -238,7 +240,10 @@ private fun SignUpStudentUserInfoInitialStep(
             onValueChange = {
                 onUserIdChange(it)
             },
-            showTrailingClearButton = false
+            showTrailingClearButton = false,
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -288,7 +293,10 @@ private fun SignUpStudentUserInfoInitialStep(
         value = password,
         onValueChange = { onPasswordChange(it) },
         showPassword = showPassword,
-        onShowPasswordChange = { onShowPasswordChange(it) }
+        onShowPasswordChange = { onShowPasswordChange(it) },
+        keyboardOptions = KeyboardOptions(
+            imeAction = ImeAction.Next
+        )
     )
 
     if (isPasswordValid) {
@@ -300,7 +308,10 @@ private fun SignUpStudentUserInfoInitialStep(
             value = passwordConfirm,
             onValueChange = { onPasswordConfirmChange(it) },
             showPassword = showPassword,
-            onShowPasswordChange = { onShowPasswordChange(it) }
+            onShowPasswordChange = { onShowPasswordChange(it) },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
     }
 
@@ -362,7 +373,10 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
         modifier = Modifier.fillMaxWidth(),
         hint = stringResource(R.string.sign_up_user_info_student_number_hint),
         value = studentNumber,
-        onValueChange = { onStudentNumberChange(it) }
+        onValueChange = { onStudentNumberChange(it) },
+        keyboardOptions = KeyboardOptions(
+            imeAction = ImeAction.Next
+        )
     )
 
     if (studentNumber.isNotEmpty() && !studentNumber.isValidStudentId) {
@@ -388,7 +402,10 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
             value = nickname,
             onValueChange = {
                 onNicknameChange(it)
-            }
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
 
         Spacer(modifier = Modifier.width(16.dp))
@@ -437,7 +454,10 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
             value = email,
             onValueChange = {
                 onEmailChange(it)
-            }
+            },
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Done
+            )
         )
 
         Spacer(modifier = Modifier.width(4.dp))

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -199,7 +200,10 @@ private fun SignUpVerificationInitialStep(
             modifier = Modifier.fillMaxWidth(),
             value = name,
             onValueChange = { onNameChange(it) },
-            hint = stringResource(R.string.sign_up_name_field_hint)
+            hint = stringResource(R.string.sign_up_name_field_hint),
+            keyboardOptions = KeyboardOptions(
+                imeAction = ImeAction.Next
+            )
         )
 
         Spacer(modifier = Modifier.height(16.dp))
@@ -246,7 +250,8 @@ fun SignUpVerificationPhoneNumberStep(
             value = phoneNumber,
             maxLength = SIGN_UP_PHONE_NUMBER_MAX_LENGTH,
             keyboardOptions = KeyboardOptions(
-                keyboardType = KeyboardType.Number
+                keyboardType = KeyboardType.Number,
+                imeAction = ImeAction.Done
             ),
             onValueChange = { onPhoneNumberChange(it) },
             hint = stringResource(R.string.sign_up_phone_number_field_hint)
@@ -314,7 +319,8 @@ fun SignUpVerificationCodeVerificationStep(
                 value = verificationCode,
                 maxLength = SIGN_UP_VERIFICATION_CODE_MAX_LENGTH,
                 keyboardOptions = KeyboardOptions(
-                    keyboardType = KeyboardType.Number
+                    keyboardType = KeyboardType.Number,
+                    imeAction = ImeAction.Done
                 ),
                 onValueChange = { onVerificationCodeChange(it) },
                 hint = stringResource(R.string.sign_up_verification_code_field_hint)

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
@@ -21,9 +21,13 @@ import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
@@ -302,6 +306,12 @@ fun SignUpVerificationCodeVerificationStep(
     onVerificationCodeChange: (String) -> Unit = {},
     checkVerificationCode: () -> Unit = {}
 ) {
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
     Spacer(modifier = Modifier.height(24.dp))
 
     Row(
@@ -315,7 +325,9 @@ fun SignUpVerificationCodeVerificationStep(
             contentAlignment = Alignment.CenterEnd
         ) {
             KoinSignUpBasicTextField(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester),
                 value = verificationCode,
                 maxLength = SIGN_UP_VERIFICATION_CODE_MAX_LENGTH,
                 keyboardOptions = KeyboardOptions(


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 TextField 동작 수정

## 작업 내용
* KoinSignUpPasswordTextField에 KeyboardOption과 KeyboardAction을 추가했습니다.
* 다음 Textfield가 존재할 경우, 키보드에 다음 버튼이 표시되도록 수정했습니다.
* 마지막 TextField일 경우, 완료 버튼이 표시되도록 수정했습니다.
* 전화번호 인증번호 발송 후, 인증번호 입력 TextField로 focus를 이동시키도록 수정했습니다.