### PR TITLE
[User][Fix] 회원가입 회원 유형 선택 화면 중앙 정렬

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/usertype/SignUpUserType.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/usertype/SignUpUserType.kt
@@ -46,7 +46,7 @@ fun SignUpUserType(
             maxStep = 4
         )
 
-        Spacer(modifier = Modifier.height(100.dp))
+        Spacer(modifier = Modifier.weight(1f))
 
         Image(
             modifier = Modifier.width(96.dp),
@@ -77,6 +77,8 @@ fun SignUpUserType(
             colors = FilledButtonColors.Primary,
             onClick = { navigateToGeneralScreen() }
         )
+
+        Spacer(modifier = Modifier.weight(1f))
     }
 }
 


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 회원 유형 선택 화면 중앙 정렬

## 작업 내용
* 회원가입 회원 유형 선택 화면을 중앙 정렬로 수정했습니다.

|수정 전|수정 후|
|----|----|
|![Screenshot_20250429-234951_코인D](https://github.com/user-attachments/assets/ebfc5c3c-149d-4d89-96ce-f23a148f947e)|![Screenshot_20250429-234700_코인D](https://github.com/user-attachments/assets/70be2d2d-b4fc-4463-acf7-3556747947e7)|