### PR TITLE
[User][Feature] 회원가입 번호 인증 시 인증코드 입력란 비활성화

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpBasicTextField.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/component/KoinSignUpBasicTextField.kt
@@ -46,6 +46,8 @@ fun KoinSignUpBasicTextField(
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
     hint: String = "",
+    enabled: Boolean = true,
+    readOnly: Boolean = false,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     singleLine: Boolean = false,
@@ -64,6 +66,8 @@ fun KoinSignUpBasicTextField(
                 onValueChange(it.take(maxLength))
             }
         },
+        enabled = enabled,
+        readOnly = readOnly,
         keyboardOptions = keyboardOptions,
         keyboardActions = keyboardActions,
         textStyle = KoinTheme.typography.regular14.copy(
@@ -98,7 +102,7 @@ fun KoinSignUpBasicTextField(
                         innerTextField()
                     }
 
-                    if (showTrailingClearButton) {
+                    if (showTrailingClearButton && enabled && !readOnly) {
                         Image(
                             modifier = Modifier
                                 .size(20.dp)

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/verification/SignUpVerification.kt
@@ -335,7 +335,8 @@ fun SignUpVerificationCodeVerificationStep(
                     imeAction = ImeAction.Done
                 ),
                 onValueChange = { onVerificationCodeChange(it) },
-                hint = stringResource(R.string.sign_up_verification_code_field_hint)
+                hint = stringResource(R.string.sign_up_verification_code_field_hint),
+                enabled = verificationCodeState !is SignupContinuationState.SmsCodeIsValidated
             )
 
             if (verificationCodeState == null || verificationCodeState != SignupContinuationState.SmsCodeIsValidated) {


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 번호 인증 시 인증코드 입력란 비활성화

## 작업 내용
* KoinSignUpBasicTextField에 readOnly와 enabled 옵션을 추가했습니다.
* 번호 인증 시 인증코드 입력란을 비활성화 했습니다.