### PR TITLE
[User][Fix] 회원가입 이메일 닉네임이 공란일 경우, null로 요청하도록 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -139,8 +139,8 @@ class SignupRepositoryImpl @Inject constructor(
                     department = department,
                     studentNumber = studentNumber,
                     gender = gender,
-                    email = email,
-                    nickname = nickname
+                    email = email.ifBlank { null },
+                    nickname = nickname.ifBlank { null }
                 )
             )
             Result.success(Unit)
@@ -182,8 +182,8 @@ class SignupRepositoryImpl @Inject constructor(
                     userId = userId,
                     password = password,
                     gender = gender,
-                    email = email,
-                    nickname = nickname
+                    email = email.ifBlank { null },
+                    nickname = nickname.ifBlank { null }
                 )
             )
             Result.success(Unit)

--- a/data/src/main/java/in/koreatech/koin/data/request/user/GeneralInfoRequest.kt
+++ b/data/src/main/java/in/koreatech/koin/data/request/user/GeneralInfoRequest.kt
@@ -14,7 +14,7 @@ data class GeneralInfoRequest(
     @SerializedName("gender")
     val gender: String,
     @SerializedName("email")
-    val email: String,
+    val email: String?,
     @SerializedName("nickname")
-    val nickname: String
+    val nickname: String?
 )

--- a/data/src/main/java/in/koreatech/koin/data/request/user/StudentInfoRequestV2.kt
+++ b/data/src/main/java/in/koreatech/koin/data/request/user/StudentInfoRequestV2.kt
@@ -18,7 +18,7 @@ data class StudentInfoRequestV2(
     @SerializedName("gender")
     val gender: String,
     @SerializedName("email")
-    val email: String,
+    val email: String?,
     @SerializedName("nickname")
-    val nickname: String
+    val nickname: String?
 )


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 이메일 닉네임이 공란일 경우, null로 요청하도록 수정

## 작업 내용
* 이메일 및 닉네임이 공란일 경우, API 요청 시 null로 보내도록 수정했습니다.