### PR TITLE
[User][Fix] 회원가입 일부 잘못된 상태 확인 수정

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -28,7 +28,7 @@ fun String.toColorForHtml(color: String) = "<font color = '#${color.substring(3)
 
 fun String.isNameFormat(): Boolean = this.matches(Regex("""^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$"""))
 
-fun String.isUserIdFormat(): Boolean = this.matches(Regex("""^[a-z0-9_.-]+${'$'}"""))
+fun String.isUserIdFormat(): Boolean = this.matches(Regex("""^[a-z0-9_.-]+${'$'}""")) && this.length in 5..13
 
 fun String.isNicknameFormat(): Boolean = this.matches(Regex("""^[ㄱ-ㅎ가-힣a-zA-Z0-9]+${'$'}"""))
 

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.feature.signup.ui.userinfo.general
 
 import android.os.Parcelable
+import `in`.koreatech.koin.domain.util.ext.isValidGeneralEmail
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -29,8 +30,14 @@ val SignUpGeneralState.currentStep: SignUpGeneralStep
         SignUpGeneralStep.INITIAL
     }
 
+private val SignUpGeneralState.isEmailValid
+    get() = (email.isNotEmpty() && email.isValidGeneralEmail()) || email.isEmpty()
+
+private val SignUpGeneralState.isNicknameValid
+    get() = (nickname.isNotEmpty() && isNicknameAvailable == true) || nickname.isEmpty()
+
 val SignUpGeneralState.isEnabled
-    get() = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && isUserIdAvailable == true
+    get() = isNicknameValid && isEmailValid && isPasswordValid && isPasswordEqual && isUserIdAvailable == true
 
 enum class SignUpGeneralStep {
     INITIAL,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -340,7 +340,7 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
                 modifier = Modifier.widthIn(min = 86.dp),
                 text = stringResource(R.string.sign_up_user_info_nickname_check_duplicate),
                 textStyle = KoinTheme.typography.regular10,
-                enabled = nickname.isNotEmpty() && nickname.isNicknameFormat(),
+                enabled = nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable != true,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
                     checkNicknameDuplicate()

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -35,9 +35,6 @@ val SignUpStudentState.currentStep: SignUpStudentStep
         SignUpStudentStep.INITIAL
     }
 
-private val SignUpStudentState.isEmailValid
-    get() = (email.isNotEmpty() && isNicknameAvailable == true) || email.isEmpty()
-
 private val SignUpStudentState.isNicknameValid
     get() = (nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable == true) || nickname.isEmpty()
 
@@ -45,7 +42,7 @@ private val SignUpStudentState.isStudentNumberValid
     get() = studentNumber.isNotEmpty() && studentNumber.isValidStudentId
 
 val SignUpStudentState.isEnabled
-    get() = isNicknameValid && isEmailValid && isPasswordValid && isPasswordEqual && department.isNotEmpty() && isStudentNumberValid && isUserIdAvailable == true
+    get() = isNicknameValid  && isPasswordValid && isPasswordEqual && department.isNotEmpty() && isStudentNumberValid && isUserIdAvailable == true
 
 enum class SignUpStudentStep {
     INITIAL,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -42,7 +42,7 @@ private val SignUpStudentState.isStudentNumberValid
     get() = studentNumber.isNotEmpty() && studentNumber.isValidStudentId
 
 val SignUpStudentState.isEnabled
-    get() = isNicknameValid  && isPasswordValid && isPasswordEqual && department.isNotEmpty() && isStudentNumberValid && isUserIdAvailable == true
+    get() = isNicknameValid && isPasswordValid && isPasswordEqual && department.isNotEmpty() && isStudentNumberValid && isUserIdAvailable == true
 
 enum class SignUpStudentStep {
     INITIAL,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -1,6 +1,8 @@
 package `in`.koreatech.koin.feature.signup.ui.userinfo.student
 
 import android.os.Parcelable
+import `in`.koreatech.koin.domain.util.ext.isNicknameFormat
+import `in`.koreatech.koin.domain.util.ext.isValidStudentId
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -33,8 +35,17 @@ val SignUpStudentState.currentStep: SignUpStudentStep
         SignUpStudentStep.INITIAL
     }
 
+private val SignUpStudentState.isEmailValid
+    get() = (email.isNotEmpty() && isNicknameAvailable == true) || email.isEmpty()
+
+private val SignUpStudentState.isNicknameValid
+    get() = (nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable == true) || nickname.isEmpty()
+
+private val SignUpStudentState.isStudentNumberValid
+    get() = studentNumber.isNotEmpty() && studentNumber.isValidStudentId
+
 val SignUpStudentState.isEnabled
-    get() = (nickname.isNotEmpty() && isNicknameAvailable == true || nickname.isEmpty()) && isPasswordValid && isPasswordEqual && department.isNotEmpty() && studentNumber.isNotEmpty() && isUserIdAvailable == true
+    get() = isNicknameValid && isEmailValid && isPasswordValid && isPasswordEqual && department.isNotEmpty() && isStudentNumberValid && isUserIdAvailable == true
 
 enum class SignUpStudentStep {
     INITIAL,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -413,7 +413,7 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
                 modifier = Modifier.widthIn(min = 86.dp),
                 text = stringResource(R.string.sign_up_user_info_nickname_check_duplicate),
                 textStyle = KoinTheme.typography.regular10,
-                enabled = nickname.isNotEmpty() && nickname.isNicknameFormat(),
+                enabled = nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable != true,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
                     checkNicknameDuplicate()

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -39,11 +39,11 @@
     <string name="sign_up_user_type_general">외부인</string>
 
     <string name="sign_up_user_info_id_title">사용하실 아이디를 입력해 주세요.</string>
-    <string name="sign_up_user_info_id_hint">최대 13자리까지 입력 가능합니다.</string>
+    <string name="sign_up_user_info_id_hint">5~13자리로 입력해 주세요.</string>
     <string name="sign_up_user_info_id_check_duplicate">중복 확인</string>
     <string name="sign_up_user_info_id_duplicate">이미 사용 중인 아이디입니다.</string>
     <string name="sign_up_user_info_id_available">사용 가능한 아이디입니다.</string>
-    <string name="sign_up_user_info_id_wrong_format">올바른 아이디 양식이 아닙니다. 다시 입력해 주세요.</string>
+    <string name="sign_up_user_info_id_wrong_format">영소문자, 숫자, _, -, . 로만 조합된 문자열만 입력 가능합니다.</string>
     <string name="sign_up_user_info_nickname_hint">닉네임은 변경 가능합니다. (선택)</string>
     <string name="sign_up_user_info_nickname_check_duplicate">중복 확인</string>
     <string name="sign_up_user_info_nickname_duplicate">중복된 닉네임입니다. 다시 입력해 주세요.</string>


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 일부 잘못된 상태 확인 수정

## 작업 내용
* 변경된 아이디 조건에 맞게 수정했습니다.
* 아이디 조건 오류 메시지를 수정했습니다.
* 일부 상태를 확장 프로퍼티를 사용하도록 수정했습니다. 가독성 향상을 위함입니다.
* 닉네임 중복 검증 통과 후 중복 확인 버튼이 비활성화 되지 않는 문제를 수정했습니다.