### PR TITLE
리뷰어 지정 방식 개선

### DIFF
--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -87,7 +87,7 @@ fun pickRandomReviewer(prOwnerTeam: KoinTeam, developer: Developer) {
  * Pick a mentor.
  */
 fun pickMentor() {
-    val shouldAddMentor = Random.nextInt() % 4 == 0 // 25%
+    val shouldAddMentor = Random.nextInt() % 10 == 0 // 10%
     if (shouldAddMentor) {
         val mentor = Developer.entries.filter { it.isMentor }.random()
         exportMentor(mentor.githubName)

--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -39,6 +39,11 @@ val reviewerPair = listOf(
 )
 
 /**
+ * Regex to extract the team from the pull request title.
+ */
+val titleRegex = Regex("(?<=\\[)(user|campus|business)(?=\\])")
+
+/**
  * Export the reviewer name to GitHub Actions output.
  * @param name The name of the reviewer.
  */
@@ -69,11 +74,11 @@ fun pickPairedReviewer(developer: Developer) {
  * Pick a random reviewer from the other team members.
  * The developer and reviewer should not be in the same team.
  */
-fun pickRandomReviewer(developer: Developer) {
+fun pickRandomReviewer(prOwnerTeam: KoinTeam, developer: Developer) {
     val otherTeamDevelopers = Developer.entries
         .filter { it != developer }
         .filter { !it.isMentor }
-        .filter { it.team.intersect(developer.team).isEmpty() }
+        .filter { !it.team.contains(prOwnerTeam) }
     val randomReviewer = otherTeamDevelopers.random()
     exportReviewer(randomReviewer.githubName)
 }
@@ -89,7 +94,7 @@ fun pickMentor() {
     }
 }
 
-fun main() {
+fun main(args: Array<String>) {
     val githubActor = System.getenv("GITHUB_ACTOR")
     val developer = Developer.entries.firstOrNull { it.githubName == githubActor }
 
@@ -97,8 +102,21 @@ fun main() {
         return
     }
 
-    pickPairedReviewer(developer)
+    val team = titleRegex.find(args[0].lowercase())?.value.let {
+        when (it) {
+            "user" -> KoinTeam.USER
+            "campus" -> KoinTeam.CAMPUS
+            "business" -> KoinTeam.BUSINESS
+            else -> null
+        }
+    }
+
+    if (team == null) {
+        return
+    }
+
+    pickRandomReviewer(team, developer)
     pickMentor()
 }
 
-main()
+main(args)

--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -74,7 +74,7 @@ fun pickPairedReviewer(developer: Developer) {
  * Pick a random reviewer from the other team members.
  * The developer and reviewer should not be in the same team.
  */
-fun pickRandomReviewer(prOwnerTeam: KoinTeam, developer: Developer) {
+fun pickRandomReviewer(prOwnerTeam: KoinTeam?, developer: Developer) {
     val otherTeamDevelopers = Developer.entries
         .filter { it != developer }
         .filter { !it.isMentor }
@@ -109,10 +109,6 @@ fun main(args: Array<String>) {
             "business" -> KoinTeam.BUSINESS
             else -> null
         }
-    }
-
-    if (team == null) {
-        return
     }
 
     pickRandomReviewer(team, developer)

--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -1,7 +1,7 @@
 name: "Pick Reviewer"
 on:
   pull_request:
-    types: opened
+    types: [opened, ready_for_review]
 
 jobs:
   pick-reviewer:

--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Pick reviewer
         id: pick_reviewer
-        run: kotlinc -script ./.github/scripts/pick_reviewer.kts ${{ github.event.pull_request.title }}
+        run: kotlinc -script ./.github/scripts/pick_reviewer.kts "${{ github.event.pull_request.title }}"
 
       - name: Add Reviewer
         uses: madrapps/add-reviewers@v1

--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -12,7 +12,7 @@ jobs:
 
       - name: Pick reviewer
         id: pick_reviewer
-        run: kotlinc -script ./.github/scripts/pick_reviewer.kts
+        run: kotlinc -script ./.github/scripts/pick_reviewer.kts ${{ github.event.pull_request.title }}
 
       - name: Add Reviewer
         uses: madrapps/add-reviewers@v1


### PR DESCRIPTION
close #646 

## 개요
* 리뷰어 지정 방식 개선

## 작업 내용
* 멘토 확률을 10%로 하향했습니다.
* 리뷰어를 PR 제목의 팀이 아닌 팀 사람 중 랜덤으로 선택하도록 수정했습니다.
* PR 제목에 팀이 없으면 PR 작성자를 제외한 사람 중 랜덤으로 선택하도록 수정했습니다.
* PR이 Draft일 경우, 리뷰어를 지정하지 않도록 수정했습니다.