### PR TITLE
[User][Feature] 회원가입 이메일 중복 체크 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -165,6 +165,22 @@ class SignupRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun isEmailDuplicated(email: String): SignupContinuationState {
+        return try {
+            userRemoteDataSource.checkEmail(email)
+            SignupContinuationState.AvailableEmail
+        } catch (e: HttpException) {
+            when (e.code()) {
+                409 -> SignupContinuationState.EmailDuplicated
+                400 -> SignupContinuationState.EmailIsNotValidate
+                else -> SignupContinuationState.Failed(
+                    message = e.getErrorResponse().message ?: "",
+                    throwable = e
+                )
+            }
+        }
+    }
+
     override suspend fun postGeneralRegister(
         name: String,
         phoneNumber: String,

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/SignupRepository.kt
@@ -36,6 +36,8 @@ interface SignupRepository {
 
     suspend fun isLoginIdDuplicated(loginId: String): SignupContinuationState
 
+    suspend fun isEmailDuplicated(email: String): SignupContinuationState
+
     suspend fun postStudentRegister(
         name: String,
         phoneNumber: String,

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
@@ -30,7 +30,7 @@ interface UserRepository {
 
     suspend fun isUsernameDuplicated(nickname: String): Boolean
 
-    suspend fun isUserEmailDuplicated(email: String): Boolean
+    suspend fun isUserEmailDuplicated(email: String): Boolean // TODO: Remove after new sign up release
 
     suspend fun updateUser(user: User)
 

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckEmailDuplicateUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckEmailDuplicateUseCase.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.domain.usecase.signup
+
+import `in`.koreatech.koin.domain.repository.SignupRepository
+import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import javax.inject.Inject
+
+class CheckEmailDuplicateUseCase @Inject constructor(
+    private val signupRepository: SignupRepository
+) {
+    suspend operator fun invoke(email: String): SignupContinuationState {
+        return signupRepository.isEmailDuplicated(email)
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckEmailValidationUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/signup/CheckEmailValidationUseCase.kt
@@ -17,3 +17,4 @@ class CheckEmailValidationUseCase @Inject constructor(
         }
     }
 }
+// TODO: Remove after new sign up release

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/Constant.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/Constant.kt
@@ -6,6 +6,8 @@ const val SIGN_UP_PHONE_NUMBER_MAX_LENGTH = 11
 const val SIGN_UP_VERIFICATION_CODE_MAX_LENGTH = 6
 const val SIGN_UP_NICKNAME_MAX_LENGTH = 10
 
+const val KOREATECH_EMAIL_DOMAIN = "koreatech.ac.kr"
+
 val departmentStringList = persistentListOf(
     "건축공학부",
     "고용서비스정책학과",

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralState.kt
@@ -20,6 +20,7 @@ data class SignUpGeneralState(
     val nickname: String = "",
     val isNicknameAvailable: Boolean? = null,
     val email: String = "",
+    val isEmailAvailable: Boolean? = null,
     val isSignUpSuccess: Boolean = false
 ) : Parcelable
 

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralUserInfo.kt
@@ -72,6 +72,7 @@ fun SignUpGeneralUserInfo(
         isPasswordValid = uiState.isPasswordValid,
         isPasswordEqual = uiState.isPasswordEqual,
         email = uiState.email,
+        isEmailAvailable = uiState.isEmailAvailable,
         enabled = uiState.isEnabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
@@ -100,6 +101,7 @@ fun SignUpGeneralUserInfoImpl(
     isPasswordValid: Boolean,
     isPasswordEqual: Boolean,
     email: String,
+    isEmailAvailable: Boolean?,
     enabled: Boolean,
     modifier: Modifier = Modifier,
     onNicknameChange: (String) -> Unit = {},
@@ -158,6 +160,7 @@ fun SignUpGeneralUserInfoImpl(
                     nickname = nickname,
                     isNicknameAvailable = isNicknameAvailable,
                     email = email,
+                    isEmailAvailable = isEmailAvailable,
                     checkNicknameDuplicate = { checkNicknameDuplicate() },
                     onNicknameChange = { onNicknameChange(it) },
                     onEmailChange = { onEmailChange(it) }
@@ -310,6 +313,7 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
     nickname: String,
     isNicknameAvailable: Boolean?,
     email: String,
+    isEmailAvailable: Boolean?,
     checkNicknameDuplicate: () -> Unit = {},
     onNicknameChange: (String) -> Unit = {},
     onEmailChange: (String) -> Unit = {}
@@ -383,6 +387,13 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
             state = KoinSignUpTextFieldAlertState.Warning
         )
     }
+
+    if (email.isNotEmpty() && isEmailAvailable == false) {
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_email_duplicate),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
 }
 
 private fun handleSideEffect(
@@ -417,6 +428,7 @@ fun SignUpGeneralUserInfoPreview() {
             isPasswordValid = true,
             isPasswordEqual = true,
             email = "test@test.com",
+            isEmailAvailable = false,
             enabled = true
         )
     }

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/general/SignUpGeneralViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import `in`.koreatech.koin.domain.usecase.signup.CheckEmailDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckLoginIdDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostGeneralRegisterUseCase
@@ -28,7 +29,8 @@ class SignUpGeneralViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
     private val postGeneralRegisterUseCase: PostGeneralRegisterUseCase,
-    private val checkLoginIdDuplicateUseCase: CheckLoginIdDuplicateUseCase
+    private val checkLoginIdDuplicateUseCase: CheckLoginIdDuplicateUseCase,
+    private val checkEmailDuplicateUseCase: CheckEmailDuplicateUseCase
 ) : ViewModel(), ContainerHost<SignUpGeneralState, SignUpGeneralSideEffect> {
     override val container = container<SignUpGeneralState, SignUpGeneralSideEffect>(SignUpGeneralState(), savedStateHandle) {
         val phoneNumber = savedStateHandle.get<String>(PHONE_NUMBER)
@@ -143,8 +145,35 @@ class SignUpGeneralViewModel @Inject constructor(
         }
     }
 
-    fun signUp() = viewModelScope.launch {
+    private fun checkEmailDuplicate() = viewModelScope.launch {
         intent {
+            if (state.email == "") return@intent
+            checkEmailDuplicateUseCase(state.email).let {
+                reduce {
+                    when (it) {
+                        is SignupContinuationState.AvailableEmail -> {
+                            state.copy(isEmailAvailable = true)
+                        }
+
+                        is SignupContinuationState.EmailDuplicated -> {
+                            state.copy(isEmailAvailable = false)
+                        }
+
+                        else -> {
+                            // We check email validation with regex.
+                            // So, Don't check email validation from API response.
+                            state.copy(isEmailAvailable = null)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun signUp() = viewModelScope.launch {
+        checkEmailDuplicate()
+        intent {
+            if (state.isEmailAvailable == false) return@intent
             postGeneralRegisterUseCase(
                 name = state.name,
                 phoneNumber = state.phoneNumber,

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentState.kt
@@ -25,6 +25,7 @@ data class SignUpStudentState(
     val nickname: String = "",
     val isNicknameAvailable: Boolean? = null,
     val email: String = "",
+    val isEmailAvailable: Boolean? = null,
     val isSignUpSuccess: Boolean = false
 ) : Parcelable
 

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentUserInfo.kt
@@ -77,6 +77,7 @@ fun SignUpStudentUserInfo(
         isDropdownExpanded = uiState.isDropdownExpanded,
         isDepartmentSelected = uiState.isDepartmentSelected,
         email = uiState.email,
+        isEmailAvailable = uiState.isEmailAvailable,
         enabled = uiState.isEnabled,
         modifier = modifier,
         onNicknameChange = { viewModel.setNickname(it) },
@@ -112,6 +113,7 @@ fun SignUpStudentUserInfoImpl(
     isDropdownExpanded: Boolean,
     isDepartmentSelected: Boolean,
     email: String,
+    isEmailAvailable: Boolean?,
     enabled: Boolean,
     modifier: Modifier = Modifier,
     onNicknameChange: (String) -> Unit = {},
@@ -175,6 +177,7 @@ fun SignUpStudentUserInfoImpl(
                     nickname = nickname,
                     isNicknameAvailable = isNicknameAvailable,
                     email = email,
+                    isEmailAvailable = isEmailAvailable,
                     department = department,
                     isDepartmentSelected = isDepartmentSelected,
                     isDropdownExpanded = isDropdownExpanded,
@@ -334,6 +337,7 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
     nickname: String,
     isNicknameAvailable: Boolean?,
     email: String,
+    isEmailAvailable: Boolean?,
     department: String,
     isDepartmentSelected: Boolean,
     isDropdownExpanded: Boolean,
@@ -464,6 +468,13 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
             text = stringResource(R.string.sign_up_user_info_email_koreatech_suffix)
         )
     }
+
+    if (email.isNotEmpty() && isEmailAvailable == false) {
+        KoinSignUpTextFieldAlert(
+            text = stringResource(R.string.sign_up_user_info_email_duplicate),
+            state = KoinSignUpTextFieldAlertState.Warning
+        )
+    }
 }
 
 private fun handleSideEffect(
@@ -491,6 +502,7 @@ fun SignUpStudentUserInfoPreview() {
             isLoginIdAvailable = true,
             isLoginIdValid = true,
             email = "email",
+            isEmailAvailable = true,
             nickname = "nickname",
             isNicknameAvailable = true,
             password = "password",

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -172,7 +172,7 @@ class SignUpStudentViewModel @Inject constructor(
     private fun checkEmailDuplicate() = viewModelScope.launch {
         intent {
             if (state.email == "") return@intent
-            checkEmailDuplicateUseCase(state.email).let {
+            checkEmailDuplicateUseCase("${state.email}@koreatech.ac.kr").let {
                 reduce {
                     when (it) {
                         is SignupContinuationState.AvailableEmail -> {
@@ -204,7 +204,7 @@ class SignUpStudentViewModel @Inject constructor(
                 loginId = state.loginId,
                 password = state.password,
                 gender = state.gender,
-                email = state.email,
+                email = "${state.email}@koreatech.ac.kr",
                 nickname = state.nickname,
                 studentNumber = state.studentNumber,
                 department = state.department

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -11,6 +11,7 @@ import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostStudentRegisterUseCase
 import `in`.koreatech.koin.domain.util.ext.isLoginIdFormat
 import `in`.koreatech.koin.domain.util.ext.isValidPassword
+import `in`.koreatech.koin.feature.signup.KOREATECH_EMAIL_DOMAIN
 import `in`.koreatech.koin.feature.signup.navigation.GENDER
 import `in`.koreatech.koin.feature.signup.navigation.NAME
 import `in`.koreatech.koin.feature.signup.navigation.PHONE_NUMBER
@@ -172,7 +173,7 @@ class SignUpStudentViewModel @Inject constructor(
     private fun checkEmailDuplicate() = viewModelScope.launch {
         intent {
             if (state.email == "") return@intent
-            checkEmailDuplicateUseCase("${state.email}@koreatech.ac.kr").let {
+            checkEmailDuplicateUseCase("${state.email}@$KOREATECH_EMAIL_DOMAIN").let {
                 reduce {
                     when (it) {
                         is SignupContinuationState.AvailableEmail -> {
@@ -204,7 +205,7 @@ class SignUpStudentViewModel @Inject constructor(
                 loginId = state.loginId,
                 password = state.password,
                 gender = state.gender,
-                email = "${state.email}@koreatech.ac.kr",
+                email = "${state.email}@$KOREATECH_EMAIL_DOMAIN",
                 nickname = state.nickname,
                 studentNumber = state.studentNumber,
                 department = state.department

--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/ui/userinfo/student/SignUpStudentViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import `in`.koreatech.koin.domain.usecase.signup.CheckEmailDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckLoginIdDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckNicknameDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.PostStudentRegisterUseCase
@@ -28,7 +29,8 @@ class SignUpStudentViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val checkNicknameDuplicateUseCase: CheckNicknameDuplicateUseCase,
     private val postStudentRegisterUseCase: PostStudentRegisterUseCase,
-    private val checkLoginIdDuplicateUseCase: CheckLoginIdDuplicateUseCase
+    private val checkLoginIdDuplicateUseCase: CheckLoginIdDuplicateUseCase,
+    private val checkEmailDuplicateUseCase: CheckEmailDuplicateUseCase
 ) : ViewModel(), ContainerHost<SignUpStudentState, SignUpStudentSideEffect> {
     override val container = container<SignUpStudentState, SignUpStudentSideEffect>(SignUpStudentState(), savedStateHandle) {
         val phoneNumber = savedStateHandle.get<String>(PHONE_NUMBER)
@@ -167,8 +169,35 @@ class SignUpStudentViewModel @Inject constructor(
         }
     }
 
-    fun signUp() = viewModelScope.launch {
+    private fun checkEmailDuplicate() = viewModelScope.launch {
         intent {
+            if (state.email == "") return@intent
+            checkEmailDuplicateUseCase(state.email).let {
+                reduce {
+                    when (it) {
+                        is SignupContinuationState.AvailableEmail -> {
+                            state.copy(isEmailAvailable = true)
+                        }
+
+                        is SignupContinuationState.EmailDuplicated -> {
+                            state.copy(isEmailAvailable = false)
+                        }
+
+                        else -> {
+                            // We check email validation with regex.
+                            // So, Don't check email validation from API response.
+                            state.copy(isEmailAvailable = null)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun signUp() = viewModelScope.launch {
+        checkEmailDuplicate()
+        intent {
+            if (state.isEmailAvailable == false) return@intent
             postStudentRegisterUseCase(
                 name = state.name,
                 phoneNumber = state.phoneNumber,

--- a/feature/signup/src/main/res/values/strings.xml
+++ b/feature/signup/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="sign_up_user_info_email_hint">이메일을 입력해 주세요. (선택)</string>
     <string name="sign_up_user_info_email_koreatech_suffix">\@koreatech.ac.kr</string>
     <string name="sign_up_user_info_email_wrong_format">올바른 이메일 형식이 아닙니다.</string>
+    <string name="sign_up_user_info_email_duplicate">이미 사용 중인 이메일입니다.</string>
     <string name="sign_up_user_info_password_title">사용하실 비밀번호를 입력해 주세요.</string>
     <string name="sign_up_user_info_password_hint">특수문자 포함 영어와 숫자 6~18자리로 입력해 주세요.</string>
     <string name="sign_up_user_info_password_not_valid">올바른 비밀번호 양식이 아닙니다. 다시 입력해 주세요.</string>


### PR DESCRIPTION
issue: #592 

## 개요
* 회원가입 이메일 중복 체크 추가

## 작업 내용
* 이메일 중복 체크를 추가했습니다.
* 이메일 중복 체크 UseCase를 추가했습니다. 기존의 UseCase와 반환값이 달라 분리했습니다.
* 누락된 @koreatech.ac.kr suffix를 추가했습니다.
* 추후 개발 완료 시점에서 사용하지 않는 UseCase 삭제를 위해 TODO를 추가했습니다.