### PR TITLE
[Campus] 분실물 키워드 변경 시, 분실물 목록이 새로고침 되지 않는 문제 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -147,7 +147,7 @@ fun LostAndFoundList(
                     .consumeWindowInsets(contentPadding)
             ) {
                 LazyColumn(
-                    modifier = modifier,
+                    modifier = Modifier,
                     state = lazyListState
                 ) {
                     item {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -160,6 +160,7 @@ fun LostAndFoundList(
                             navigateToKeywordFragment = navigateToKeywordFragment
                         ) {
                             viewModel.selectKeyword(it)
+                            viewModel.changePage(1)
                         }
                         LostAndFoundDropdownGroup(
                             selectedType = uiState.selectedType,


### PR DESCRIPTION
close: #649 

## 개요
* 분실물 키워드 변경 시, 분실물 목록이 새로고침 되지 않는 문제 수정

## 작업 내용
* 분실물 키워드 변경 시, 분실물 복록이 새로고침 되지 않는 문제를 수정했습니다.
* 분실물 키워드 변경 시, 페이지를 1로 변경하도록 수정했습니다.