### PR TITLE
[Campus][Fix] 배너 이미지 좌측 하얀 줄 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -133,6 +134,7 @@ private fun BannerContent(
             }
             dismiss()
         },
+        contentScale = ContentScale.Crop,
         model = ImageRequest.Builder(LocalContext.current)
             .data(ImageUtil.getResizedImageUrl(banner.imageUrl, width = 400))
             .crossfade(true)


### PR DESCRIPTION
close #641 

## 개요
* 배너 이미지 좌측 하얀 줄 수정

## 작업 내용
* 이미지 content scale을 crop으로 수정했습니다.

## 추가적인 내용
* 광고 배너 이미지의 기본 사이즈는 4:3으로 고정이기 때문에, 컴포넌트 또한 동일하게 4:3 크기로 고정되어 있습니다.
* 다만, 컴포넌트 크기 계산에 약간의 오차가 발생할 경우, 이미지 뒤의 하얀색 배경이 보이는 것이 원인입니다.
* 이를 수정하기 위해 이미지를 컴포넌트 사이즈에 맞게 crop 처리했으며, 이미지 비율 및 컴포넌트 비율 모두 4:3이기 때문에, 약간의 오차를 제외하면 문제가 없을 것이라 생각했습니다.