### PR TITLE
[Campus][Fix] 로그아웃 시 드로어에서 채팅 아이콘이 사라지지 않는 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -374,6 +374,7 @@ abstract class KoinNavigationDrawerActivity :
                                     getString(R.string.navigation_hello_message_anonymous)
                                 loginOrLogoutTextView.text = getString(R.string.navigation_item_login)
                                 chatMenuIcon.visibility = View.GONE
+                                unReadMessageCountTextView.visibility = View.GONE
                             }
 
                             is User.Student -> {

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -373,6 +373,7 @@ abstract class KoinNavigationDrawerActivity :
                                 helloMessageTextView.text =
                                     getString(R.string.navigation_hello_message_anonymous)
                                 loginOrLogoutTextView.text = getString(R.string.navigation_item_login)
+                                chatMenuIcon.visibility = View.GONE
                             }
 
                             is User.Student -> {


### PR DESCRIPTION
close #653 

## 개요
* 로그아웃 시 드로어에서 채팅 아이콘이 사라지지 않는 문제 수정

## 작업 내용
* 사용자가 Anonymous일 경우, 채팅 아이콘이 숨겨지지 않던 문제를 수정했습니다.
* 사용자가 Anonymous일 경우, 읽지 않은 채팅 숫자가 숨겨지지 않던 문제를 수정했습니다.