### PR TITLE
[User][Fix] 회원가입 약관 동의 화면에서 액티비티가 종료되지 않는 문제 수정

### DIFF
--- a/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
+++ b/feature/signup/src/main/java/in/koreatech/koin/feature/signup/SignUpActivity.kt
@@ -35,7 +35,9 @@ class SignUpActivity : ComponentActivity() {
                         KoinTopAppBar(
                             title = stringResource(R.string.sign_up_title),
                             onNavigationIconClick = {
-                                navController.popBackStack()
+                                if (!navController.popBackStack()) {
+                                    finish()
+                                }
                             }
                         )
                     },


### PR DESCRIPTION
close #592 

## 개요
* 회원가입 약관 동의 화면에서 액티비티가 종료되지 않는 문제 수정

## 작업 내용
* backstack이 비어있을 경우, 액티비티를 종료하도록 수정했습니다.