### PR TITLE
[Campus][Fix] 배너 수동 스크롤 시 시간이 초기화되지 않는 문제 수정

### DIFF
--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -13,8 +13,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,8 +39,7 @@ import `in`.koreatech.koin.feature.banner.model.LocalBanner
 import `in`.koreatech.koin.feature.banner.util.ImageUtil
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
 
 @Composable
 fun BannerImage(
@@ -54,16 +52,17 @@ fun BannerImage(
     val pagerState = rememberPagerState(
         initialPage = (Int.MAX_VALUE / 2) - (Int.MAX_VALUE / 2) % bannerList.size
     ) { Int.MAX_VALUE }
+    val coroutineScope = rememberCoroutineScope()
 
-    LaunchedEffect(Unit) {
-        snapshotFlow { pagerState.isScrollInProgress }
-            .filter { it == false }
-            .collectLatest {
-                if (bannerList.size > 1) {
-                    delay(BANNER_AUTO_SCROLL_MILLISECONDS)
+    LaunchedEffect(key1 = pagerState.currentPage, key2 = pagerState.isScrollInProgress) {
+        launch {
+            delay(BANNER_AUTO_SCROLL_MILLISECONDS)
+            coroutineScope.launch {
+                if (!pagerState.isScrollInProgress) {
                     pagerState.animateScrollToPage(pagerState.currentPage + 1)
                 }
             }
+        }
     }
 
     Box(
@@ -115,25 +114,27 @@ private fun BannerContent(
 ) {
     val context = LocalContext.current
     SubcomposeAsyncImage(
-        modifier = modifier.fillMaxSize().noRippleClickable {
-            EventLogger.logClickEvent(
-                action = EventAction.CAMPUS,
-                label = "main_modal",
-                value = banner.title
-            )
-            if (banner.redirectLink == null) return@noRippleClickable
-            if (banner.version > currentKoinVersion) { // If the banner link requires a higher version of the app
-                ToastUtil.getInstance().makeShort(R.string.banner_require_new_version)
-                val intent = Intent(Intent.ACTION_VIEW, KOIN_PLAYSTORE_URL.toUri())
-                context.startActivity(intent)
-            } else {
-                if (banner.redirectLink.isNotEmpty()) {
-                    val intent = Intent(Intent.ACTION_VIEW, banner.redirectLink.toUri())
+        modifier = modifier
+            .fillMaxSize()
+            .noRippleClickable {
+                EventLogger.logClickEvent(
+                    action = EventAction.CAMPUS,
+                    label = "main_modal",
+                    value = banner.title
+                )
+                if (banner.redirectLink == null) return@noRippleClickable
+                if (banner.version > currentKoinVersion) { // If the banner link requires a higher version of the app
+                    ToastUtil.getInstance().makeShort(R.string.banner_require_new_version)
+                    val intent = Intent(Intent.ACTION_VIEW, KOIN_PLAYSTORE_URL.toUri())
                     context.startActivity(intent)
+                } else {
+                    if (banner.redirectLink.isNotEmpty()) {
+                        val intent = Intent(Intent.ACTION_VIEW, banner.redirectLink.toUri())
+                        context.startActivity(intent)
+                    }
                 }
-            }
-            dismiss()
-        },
+                dismiss()
+            },
         contentScale = ContentScale.Crop,
         model = ImageRequest.Builder(LocalContext.current)
             .data(ImageUtil.getResizedImageUrl(banner.imageUrl, width = 400))


### PR DESCRIPTION
close #661 

## 개요
* 배너 수동 스크롤 시 시간이 초기화되지 않는 문제 수정

## 작업 내용
* 배너를 수동으로 스크롤 할 경우, 시간을 처음부터 다시 계산하도록 수정

## 추가적인 내용
* 뭔가 수정사항이 많아 보이는데 단순히 코드 포맷팅이 달라진겁니다!