### PR TITLE
[Campus][Refactor] 분실물 게시판 검색 API 변경

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.api
 
+import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundResponse
 import `in`.koreatech.koin.data.response.article.ArticlePaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleResponse
@@ -58,6 +59,19 @@ interface ArticleApi {
     suspend fun fetchMostSearchedKeywords(
         @Query("count") count: Int
     ): KeywordsResponse
+
+    /**
+     * 검색된 분실물 게시글 목록과 페이지 정보를 가져옴
+     * @param query 검색어
+     * @param page 페이지 번호
+     * @param limit 페이지 당 게시글 수
+     */
+    @GET("articles/lost-item/search")
+    suspend fun fetchSearchedLostAndFoundArticles(
+        @Query("query") query: String,
+        @Query("page") page: Int,
+        @Query("limit") limit: Int
+    ): ArticleLostAndFoundPaginationResponse
 
     /**
      * 분실물 게시글 조회

--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -61,6 +61,18 @@ interface ArticleApi {
     ): KeywordsResponse
 
     /**
+     * 분실물 게시글 목록과 페이지 정보를 가져옴
+     * @param page 페이지 번호
+     * @param limit 페이지 당 게시글 수
+     */
+    @GET("articles/lost-item")
+    suspend fun fetchArticleLostAndFoundPagination(
+        @Query("page") page: Int,
+        @Query("limit") limit: Int,
+        @Query("type") type: String?
+    ): ArticleLostAndFoundPaginationResponse
+
+    /**
      * 검색된 분실물 게시글 목록과 페이지 정보를 가져옴
      * @param query 검색어
      * @param page 페이지 번호

--- a/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
@@ -4,7 +4,6 @@ import `in`.koreatech.koin.data.request.article.ArticleKeywordRequest
 import `in`.koreatech.koin.data.request.article.ArticleLostAndFoundReportRequest
 import `in`.koreatech.koin.data.request.article.ArticleLostAndFoundRequest
 import `in`.koreatech.koin.data.response.article.ArticleKeywordWrapperResponse
-import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundResponse
 import `in`.koreatech.koin.data.response.article.KeywordsResponse
 import retrofit2.Response
@@ -13,7 +12,6 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.Path
-import retrofit2.http.Query
 
 interface ArticleAuthApi {
     @GET("articles/keyword/me")
@@ -31,18 +29,6 @@ interface ArticleAuthApi {
     suspend fun deleteKeyword(
         @Path("id") keywordId: Int
     ): Response<Unit>
-
-    /**
-     * 분실물 게시글 목록과 페이지 정보를 가져옴
-     * @param page 페이지 번호
-     * @param limit 페이지 당 게시글 수
-     */
-    @GET("articles/lost-item")
-    suspend fun fetchArticleLostAndFoundPagination(
-        @Query("page") page: Int,
-        @Query("limit") limit: Int,
-        @Query("type") type: String?
-    ): ArticleLostAndFoundPaginationResponse
 
     @POST("articles/lost-item")
     suspend fun uploadArticleLostAndFound(

--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -239,6 +239,15 @@ class ArticleRepositoryImpl @Inject constructor(
         }
     }
 
+    override fun fetchSearchedLostAndFoundArticles(query: String, page: Int, limit: Int): Flow<ArticleLostAndFoundPagination> {
+        return flow {
+            emit(
+                articleRemoteDataSource.fetchSearchedLostAndFoundArticles(query, page, limit)
+                    .toArticleLostAndFoundPagination()
+            )
+        }
+    }
+
     override fun fetchArticleLostAndFound(articleId: Int): Flow<ArticleLostAndFound> {
         return flow {
             emit(

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -85,7 +85,7 @@ class ArticleRemoteDataSource @Inject constructor(
         limit: Int,
         type: String?
     ): ArticleLostAndFoundPaginationResponse {
-        return articleAuthApi.fetchArticleLostAndFoundPagination(page, limit, type)
+        return articleApi.fetchArticleLostAndFoundPagination(page, limit, type)
     }
 
     suspend fun fetchSearchedLostAndFoundArticles(

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -88,6 +88,14 @@ class ArticleRemoteDataSource @Inject constructor(
         return articleAuthApi.fetchArticleLostAndFoundPagination(page, limit, type)
     }
 
+    suspend fun fetchSearchedLostAndFoundArticles(
+        query: String,
+        page: Int,
+        limit: Int
+    ): ArticleLostAndFoundPaginationResponse {
+        return articleApi.fetchSearchedLostAndFoundArticles(query, page, limit)
+    }
+
     suspend fun fetchArticleLostAndFound(articleId: Int): ArticleLostAndFoundResponse {
         return articleApi.fetchArticleLostAndFound(articleId)
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
@@ -68,6 +68,12 @@ interface ArticleRepository {
         type: String?
     ): Flow<ArticleLostAndFoundPagination>
 
+    fun fetchSearchedLostAndFoundArticles(
+        query: String,
+        page: Int,
+        limit: Int
+    ): Flow<ArticleLostAndFoundPagination>
+
     fun fetchArticleLostAndFound(articleId: Int): Flow<ArticleLostAndFound>
 
     suspend fun uploadArticleLostAndFound(articleLostAndFoundList: List<ArticleLostAndFoundUpload>): Result<ArticleLostAndFound>

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/article/lostandfound/FetchSearchedLostAndFoundArticlesUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/article/lostandfound/FetchSearchedLostAndFoundArticlesUseCase.kt
@@ -1,0 +1,16 @@
+package `in`.koreatech.koin.domain.usecase.article.lostandfound
+
+import `in`.koreatech.koin.domain.model.article.ArticleLostAndFoundPagination
+import `in`.koreatech.koin.domain.repository.ArticleRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class FetchSearchedLostAndFoundArticlesUseCase @Inject constructor(
+    private val articleRepository: ArticleRepository
+) {
+    operator fun invoke(
+        query: String,
+        page: Int,
+        limit: Int
+    ): Flow<ArticleLostAndFoundPagination> = articleRepository.fetchSearchedLostAndFoundArticles(query, page, limit)
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFoundViewModel.kt
@@ -6,11 +6,9 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.article.FetchMyKeywordUseCase
-import `in`.koreatech.koin.domain.usecase.article.FetchSearchedArticlesUseCase
 import `in`.koreatech.koin.domain.usecase.article.lostandfound.FetchLostAndFoundArticlePaginationUseCase
-import `in`.koreatech.koin.domain.usecase.article.lostandfound.FetchLostAndFoundArticleUseCase
+import `in`.koreatech.koin.domain.usecase.article.lostandfound.FetchSearchedLostAndFoundArticlesUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
-import `in`.koreatech.koin.feature.lostandfound.enums.ArticleBoardType
 import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import javax.inject.Inject
 import kotlinx.coroutines.flow.catch
@@ -26,8 +24,7 @@ import timber.log.Timber
 @HiltViewModel
 class LostAndFoundViewModel @Inject constructor(
     private val fetchLostAndFoundArticlePaginationUseCase: FetchLostAndFoundArticlePaginationUseCase,
-    private val fetchSearchedArticlesUseCase: FetchSearchedArticlesUseCase,
-    private val fetchLostAndFoundArticleUseCase: FetchLostAndFoundArticleUseCase,
+    private val fetchSearchedLostAndFoundArticlesUseCase: FetchSearchedLostAndFoundArticlesUseCase,
     private val fetchMyKeywordUseCase: FetchMyKeywordUseCase,
     private val getUserStatusUseCase: GetUserStatusUseCase,
     savedStateHandle: SavedStateHandle
@@ -71,40 +68,19 @@ class LostAndFoundViewModel @Inject constructor(
                         }
                     }
                 } else {
-                    fetchSearchedArticlesUseCase(
+                    fetchSearchedLostAndFoundArticlesUseCase(
                         state.selectedKeyword,
-                        ArticleBoardType.LOSTANDFOUND.id,
                         state.currentPage,
                         ARTICLES_PER_PAGE
                     ).collectLatest {
                         reduce {
                             state.copy(
-                                lostAndFoundList = it.articleHeaders.map { it.toLostAndFoundItemState() },
+                                lostAndFoundList = it.articleLostAndFoundHeader.map { it.toLostAndFoundItemState() },
                                 currentCount = it.currentCount,
                                 totalCount = it.totalCount,
                                 currentPage = it.currentPage,
                                 totalPage = it.totalPage
                             )
-                        }
-
-                        // Fetch content by id because our search API doesn't return content value
-                        state.lostAndFoundList.forEachIndexed { index, lostAndFoundItemState ->
-                            fetchLostAndFoundArticleUseCase(lostAndFoundItemState.id).collect {
-                                reduce {
-                                    state.copy(
-                                        lostAndFoundList =
-                                        state.lostAndFoundList.mapIndexed { i, item ->
-                                            if (i == index) {
-                                                return@mapIndexed item.copy(
-                                                    content = it.content ?: ""
-                                                )
-                                            } else {
-                                                item
-                                            }
-                                        }
-                                    )
-                                }
-                            }
                         }
                     }
 


### PR DESCRIPTION
close #663 

## 개요
* 분실물 게시판 검색 API 변경

## 작업 내용
* 분실물 게시판 검색을 articles/lost-item/search API를 사용하도록 수정했습니다.
* 분실물 게시글 조회 API에 auth token을 담아서 보내던 문제를 수정했습니다.