### PR TITLE
[Campus][Fix] 분실물 게시판이 정상적으로 새로고침 되지 않는 문제 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
@@ -80,6 +82,10 @@ fun LostAndFoundList(
                 }
             }
         )
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        viewModel.fetchLostAndFoundList()
     }
 
     val context = LocalContext.current


### PR DESCRIPTION
close #665 

## 개요
* 분실물 게시판이 정상적으로 새로고침 되지 않는 문제 수정

## 작업 내용
* 분실물 게시판에서 다른 화면으로 이동했다가 돌아왔을 때, 분실물 목록이 새로고침 되지 않는 문제를 수정했습니다.