### PR TITLE
[Campus][Fix] 버스 화면에서 네비게이션 바가 겹치던 문제 수정

### DIFF
--- a/feature/bus/src/main/java/in/koreatech/bus/navigation/BusSearchNavigation.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/navigation/BusSearchNavigation.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.bus.navigation
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,7 +30,7 @@ fun BusSearchNavigation(
 ) {
     val context = LocalContext.current
     NavHost(
-        modifier = modifier.background(defaultOutsideColor),
+        modifier = modifier.safeDrawingPadding().background(defaultOutsideColor),
         navController = navController,
         startDestination = Routes.BusSearch,
         enterTransition = {

--- a/feature/bus/src/main/java/in/koreatech/bus/navigation/BusTimetableNavigation.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/navigation/BusTimetableNavigation.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.bus.navigation
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -27,7 +28,7 @@ fun BusTimetableNavigation(
     val context = LocalContext.current
 
     NavHost(
-        modifier = modifier.background(defaultOutsideColor),
+        modifier = modifier.safeDrawingPadding().background(defaultOutsideColor),
         navController = navController,
         startDestination = Routes.BusTimetable,
         enterTransition = {


### PR DESCRIPTION
close #616 

## 개요
* 버스 화면에서 네비게이션 바가 겹치던 문제 수정

## 작업 내용
* 버스 화면에 safeDrawingPadding()을 적용했습니다.