### PR TITLE
Feature/#668 add auto release adder

### DIFF
--- a/.github/scripts/auto_release_adder.kts
+++ b/.github/scripts/auto_release_adder.kts
@@ -1,0 +1,29 @@
+import java.io.File
+
+val NO_VERSION_DATA = "NO_VERSION"
+val NO_BODY_DATA = "NO_BODY"
+
+fun searchReleaseVersion(prBody: String): String {
+    val versionRegex = Regex("v\\d+\\.\\d+\\.\\d+")
+    return versionRegex.find(prBody)?.value ?: NO_VERSION_DATA
+}
+
+fun searchReleaseBody(prBody: String): String {
+    var bodyRegex = Regex("# 변경 사항\\s*([\\s\\S]*)")
+    return bodyRegex.find(prBody)?.groups?.get(1)?.value?.replace("\r\n","\\n") ?: NO_BODY_DATA
+}
+
+fun restoreOutput(releaseVersion: String, releaseBody: String) {
+    val outputPath = System.getenv("GITHUB_OUTPUT")
+    File(outputPath).appendText("release_version=${releaseVersion}\n")
+    File(outputPath).appendText("release_body=${releaseBody}\n")
+}
+
+fun main() {
+    val prBody = args.firstOrNull() ?: NO_BODY_DATA
+    var version = searchReleaseVersion(prBody = prBody)
+    var body = searchReleaseBody(prBody = prBody)
+    restoreOutput(releaseVersion = version, releaseBody = body)
+}
+
+main()

--- a/.github/workflows/auto_release_adder.yml
+++ b/.github/workflows/auto_release_adder.yml
@@ -1,0 +1,53 @@
+name: "Auto Release adder"
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - production
+
+jobs:
+  auto-release-adder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout The PR
+        uses: actions/checkout@v4
+
+      - name: Create Release Body
+        id: create_release_body
+        run: kotlinc -script .github/scripts/auto_release_adder.kts "${{ github.event.pull_request.body }}"
+
+      - name: Create Release
+        if: ${{ steps.create_release_body.outputs.release_version != 'NO_VERSION' && steps.create_release_body.outputs.release_body != 'NO_BODY' }}
+        run: |
+          tag="${{ steps.create_release_body.outputs.release_version }}"
+          title="$tag"
+          body="${{ steps.create_release_body.outputs.release_body }}"
+          echo "Version: $tag"
+          echo "Body: $body"
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/releases \
+            -d "{
+              \"tag_name\": \"$tag\",
+              \"target_commitish\": \"production\",
+              \"name\": \"$title\",
+              \"body\": \"$body\",
+              \"draft\": false,
+              \"prerelease\": false,
+              \"generate_release_notes\": false
+            }"
+
+      - name: Show Fail Log
+        if: ${{ steps.create_release_body.outputs.release_version == 'NO_VERSION' || steps.create_release_body.outputs.release_body == 'NO_BODY' }}
+        run: |
+           if [ "${{ steps.create_release_body.outputs.release_version }}" == "NO_VERSION" ]; then
+            echo "Fail: Could not found the version code "
+           fi
+           if [ "${{ steps.create_release_body.outputs.release_body }}" == "NO_BODY" ]; then
+            echo "Fail: Could not found the body"
+           fi
+           exit 1
+


### PR DESCRIPTION
## 개요
Release note 를 자동으로 작성해주는 github action 을 만들었습니다.
- 코틀린 스크립트를 사용했습니다.
- #668 
### 주의 : 자동 기능을 사용하기 위해서는  지정된 양식대로 작성하셔야 작동합니다.


## 기능 설명
### 1. 양식에 맞춰 production 에 merge 되는 PR 을 작성합니다.

<img src="https://github.com/user-attachments/assets/9f9f660f-a5cf-484c-9071-50cfc3cf16af" width="80%">

* 현재 양식 사진
<img src="https://github.com/user-attachments/assets/ce00196c-4cbc-448d-8ea3-8f3ac8fab8e7" width="70%">

* 코드 (빠르게 노션에 문서 추가하겠습니다.
```
# 개요 - 선택
(버전코드 - 필수)
# 변경 사항 - 필수
(내용 - 선택)
```
###  2. merge 시 auto-release-adder 가 작동합니다.

<img src="https://github.com/user-attachments/assets/61319a07-00e9-4a57-aac0-5b89669cd8b8" width="40%">

### 3. release node 가 생성됩니다.

<img src="https://github.com/user-attachments/assets/459d67c1-b2f2-449b-aa18-2d7d6c1940ef" width="70%">

### (예외상황) 잘못된 양식일 경우
* 잘못된 양식 사진 (필수인 "버전코드"와 "# 변경사항" 제거 시)
<img src="https://github.com/user-attachments/assets/eeb9f376-159e-440d-8b20-92fb4308c3e9" width="80%">

* 상황에 맞는 오류 코드를 보여줍니다. (release note 는 생성되지 않습니다.)
<img src="https://github.com/user-attachments/assets/41dc7379-46e1-4827-b7b8-6ecd2a7b5923" width="40%">
