### PR TITLE
[Campus][Fix] 배너 광고가 식단을 비롯한 다른 화면에 표시되던 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -151,7 +151,6 @@ class MainActivity : KoinNavigationDrawerTimeActivity() {
         initView()
         initDiningTooltip()
         initViewModel()
-        initBanner()
         handleIntent()
     }
 
@@ -414,7 +413,8 @@ class MainActivity : KoinNavigationDrawerTimeActivity() {
             }
 
             else -> {
-                // Do nothing
+                // Banner shouldn't popup on other page
+                initBanner()
             }
         }
     }


### PR DESCRIPTION
close #673 

## 개요
* 배너 광고가 식단을 비롯한 다른 화면에 표시되던 문제 수정

## 작업 내용
* SchemeType이 공란일 경우(알림으로 실행되어 다른화면으로 넘어가는 경우가 아닐 때)에만 배너 광고가 표시되도록 수정했습니다.