### PR TITLE
[User][Fix] 사용자가 다른 플랫폼에서 탈퇴했을 경우, 앱 사용이 불가능하던 문제 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -79,10 +79,24 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getUserInfo(): User {
-        val userType = userRemoteDataSource.getUserType()
+        val userType = try {
+            userRemoteDataSource.getUserType()
+        } catch (e: HttpException) {
+            // If user withdraw on other platform, saved token is not valid
+            // and API returns error code
+            null
+        }
 
-        return userRemoteDataSource.getUserInfo().toUser(userType.userType).also {
-            userLocalDataSource.updateUserInfo(it)
+        return if (userType != null) {
+            userRemoteDataSource.getUserInfo().toUser(userType.userType).also {
+                userLocalDataSource.updateUserInfo(it)
+            }
+        } else {
+            userLocalDataSource.updateIsLogin(false)
+            tokenLocalDataSource.removeAccessToken()
+            tokenLocalDataSource.removeRefreshToken()
+            userLocalDataSource.updateUserInfo(User.Anonymous)
+            User.Anonymous
         }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/di/network/AuthAuthenticator.kt
+++ b/koin/src/main/java/in/koreatech/koin/di/network/AuthAuthenticator.kt
@@ -43,7 +43,12 @@ class AuthAuthenticator @Inject constructor(
                 return@withLock null
             }
 
-            val currentRefreshToken = tokenLocalDataSource.getRefreshToken() ?: ""
+            val currentRefreshToken = tokenLocalDataSource.getRefreshToken()
+
+            if (currentRefreshToken == null) {
+                goToLoginActivity()
+                return@withLock null
+            }
 
             val newResponse =
                 runCatching {

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
@@ -67,6 +67,7 @@ class SplashActivity : ActivityBase() {
 
     private fun initView() {
         splashViewModel.checkUpdate()
+        splashViewModel.fetchUserInfo()
         firebasePerformanceUtil.start()
         SystemBarsUtils(this).apply {
             setImmersiveMode(window)

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/viewmodel/SplashViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/viewmodel/SplashViewModel.kt
@@ -10,16 +10,19 @@ import `in`.koreatech.koin.core.viewmodel.SingleLiveEvent
 import `in`.koreatech.koin.domain.model.version.Version
 import `in`.koreatech.koin.domain.state.version.VersionUpdatePriority
 import `in`.koreatech.koin.domain.usecase.token.IsTokenSavedInDeviceUseCase
+import `in`.koreatech.koin.domain.usecase.user.GetUserInfoUseCase
 import `in`.koreatech.koin.domain.usecase.version.GetVersionInformationUseCase
 import `in`.koreatech.koin.domain.usecase.version.UpdateLatestVersionUseCase
 import `in`.koreatech.koin.ui.splash.state.TokenState
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val getVersionInformationUseCase: GetVersionInformationUseCase,
     private val updateLatestVersionUseCase: UpdateLatestVersionUseCase,
-    private val isTokenSavedInDeviceUseCase: IsTokenSavedInDeviceUseCase
+    private val isTokenSavedInDeviceUseCase: IsTokenSavedInDeviceUseCase,
+    private val getUserInfoUseCase: GetUserInfoUseCase
 ) : BaseViewModel() {
     private val _version = MutableLiveData<Version>()
     val version: LiveData<Version> get() = _version
@@ -53,6 +56,10 @@ class SplashViewModel @Inject constructor(
                 _tokenState.value = TokenState.Invalid
             }
         }
+    }
+
+    fun fetchUserInfo() = viewModelScope.launch {
+        getUserInfoUseCase()
     }
 
     private fun isVersionPriorityNone(priority: VersionUpdatePriority): Boolean {


### PR DESCRIPTION
close #675 

## 개요
* 사용자가 다른 플랫폼에서 탈퇴했을 경우, 앱 사용이 불가능하던 문제 수정

## 작업 내용
* /user/auth 요청 시 HttpExcption이 발생할 경우, 로그아웃 처리하도록 수정했습니다.
* refreshToken이 null일 경우, 토큰을 갱신하지 않도록 수정했습니다.
* Splash에서 사용자 계정이 존재하는 지 확인하도록 수정했습니다.

## 추가적인 내용
* 토큰 만료 시, 401 코드가 서버에서 내려오는데 어차피 Intercepter에서 먼저 처리하는 것으로 알고 있어서 별도의 분기처리는 하지 않았습니다.
* 혹시 잘못 알고 있다면 알려주세요!