### PR TITLE
[Campus][Fix] 메인 화면에서 채팅 목록 API 예외 처리 추가

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -56,7 +57,9 @@ class KoinNavigationDrawerViewModel @Inject constructor(
     fun getUnreadMessageCount() = viewModelScope.launch {
         if (userInfoFlow.value == User.Anonymous) return@launch
         var tempUnReadMessageCount = 0
-        getChatListUseCase().collectLatest { messages ->
+        getChatListUseCase().catch {
+            Timber.e("Failed to get chat list: ${it.message}")
+        }.collectLatest { messages ->
             messages.forEach { message ->
                 tempUnReadMessageCount += message.unReadMessageCount
             }


### PR DESCRIPTION
close #684 

## 개요
* 메인 화면에서 채팅 목록 API 예외 처리 추가

## 작업 내용
* 메인 화면에서 채팅 목록 API를 호출할 때 예외처리가 되지 않아 Intercepter에서 처리가 되어도 크래시가 발생하는 문제를 수정했습니다.