### PR TITLE
[User][Fix] 시간표 강의 시간이 넘칠 경우, 강의 추가/삭제 버튼이 사라지던 문제 수정

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/LectureBox.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/LectureBox.kt
@@ -81,7 +81,7 @@ fun LectureBox(
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Column(
-            modifier = Modifier
+            modifier = Modifier.weight(1f)
         ) {
             Text(
                 text = lecture.name,

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/LectureBox.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/LectureBox.kt
@@ -3,13 +3,14 @@ package `in`.koreatech.koin.feature.timetable.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectable
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -29,8 +30,10 @@ import `in`.koreatech.koin.domain.model.timetable.response.Lecture
 import `in`.koreatech.koin.feature.timetable.R
 import `in`.koreatech.koin.feature.timetable.model.TimetableEvent
 import `in`.koreatech.koin.feature.timetable.model.dummyLecture
+import `in`.koreatech.koin.feature.timetable.utils.toLectureTime
 import `in`.koreatech.koin.feature.timetable.utils.toTimetableEvents
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LectureBox(
     position: Int,
@@ -94,19 +97,13 @@ fun LectureBox(
                 color = KoinTheme.colors.neutral800
             )
 
-            Row {
-                events.forEachIndexed { index, event ->
+            FlowRow {
+                events.forEach {
                     Text(
-                        text = event.dayOfWeekToKorean(),
+                        text = it.toLectureTime(),
                         style = KoinTheme.typography.regular12,
                         color = KoinTheme.colors.neutral800
                     )
-                    Text(
-                        text = "${event.formatClassTimeCode().first} ~ ${event.formatClassTimeCode().second}",
-                        style = KoinTheme.typography.regular12,
-                        color = KoinTheme.colors.neutral800
-                    )
-                    Spacer(modifier = Modifier.width(6.dp))
                 }
             }
             Text(

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/utils/Extensions.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/utils/Extensions.kt
@@ -100,6 +100,8 @@ fun List<TimetableEvent>.formatTimeRange(): Int {
     }
 }
 
+fun TimetableEvent.toLectureTime(): String = "${dayOfWeekToKorean()}${formatClassTimeCode().first} ~ ${formatClassTimeCode().second} "
+
 // TODO::UseCase 에서 변환하는게 좋아보이네
 fun String.toSemesterModel(): SemesterModel =
     SemesterModel(


### PR DESCRIPTION
close #692 

## 개요
* 시간표 강의 시간이 넘칠 경우, 강의 추가/삭제 버튼이 사라지던 문제 수정

## 작업 내용
* 강의 시간이 넘칠 경우, 두 줄로 출력되도록 수정했습니다.
* 강의 시간으로 변환하는 확장함수를 추가했습니다.
* 강의 시간이 넘칠 경우, 추가 버튼이 사라지던 문제를 수정했습니다.

## 사진
|전|후|
|--|--|
|![image](https://github.com/user-attachments/assets/da6ceb43-b3ab-4e8c-abb2-35cfcd26e4fb)|![image](https://github.com/user-attachments/assets/2f583ad8-0a74-4331-9362-47cc8f685501)|
