### PR TITLE
[Koin Project][feature] 자동 PR 라벨 추가 git action 추가

### DIFF
--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   auto_pr_label_adder:
+    if: github.base_ref != 'production'
     runs-on: ubuntu-latest
     steps:
       - name: Check Team and Job From PR

--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -16,7 +16,6 @@ jobs:
           NO_VALUE="no value"
           
           declare -A TEAM_MAP
-          declare -A JOB_MAP
 
           # Team 별 REGEX
           CAMPUS_REGEX="\[[cC][aA][mM][pP][uU][sS]\]"
@@ -35,26 +34,6 @@ jobs:
           TEAM_MAP["$BUSINESS_REGEX"]="$BUSINESS_TAG"
           TEAM_MAP["$USER_REGEX"]="$USER_TAG"
           TEAM_MAP["$KOIN_PROJECT_REGEX"]="$KOIN_PROJECT_TAG"
-
-          # 작업별 REGEX (fix 와 bug 는 동일합니다)
-          FEATURE_REGEX="\[[fF][eE][aA][tT][uU][rR][eE]\]"
-          BUG_REGEX="\[[bB][uU][gG]\]"
-          FIX_REGEX="\[[fF][iI][xX]\]"
-          REFECTOR_REGEX="\[[rR][eE][fF][eE][cC][tT][oO][rR]\]"
-          CHORE_REGEX="\[[cC][hH][oO][rR][eE]\]"
-
-          # 작업별 TAG
-          FEATURE_TAG="feature"
-          FIX_TAG="fix"
-          REFECTOR_TAG="refactor"
-          CHORE_TAG="chore"
-
-          # 작업별 REGEX, TAG 연관 배열
-          JOB_MAP["$FEATURE_REGEX"]="$FEATURE_TAG"
-          JOB_MAP["$BUG_REGEX"]="$FIX_TAG"
-          JOB_MAP["$FIX_REGEX"]="$FIX_TAG"
-          JOB_MAP["$REFECTOR_REGEX"]="$REFECTOR_TAG"
-          JOB_MAP["$CHORE_REGEX"]="$CHORE_TAG"
 
           # 정규식 검사
           check_by_regex() {
@@ -76,26 +55,10 @@ jobs:
             echo "$NO_VALUE"
             return 0
           }
-          # 작업 순차 검색
-          job_check() {
-            local title=$1
-            for regex in "${!JOB_MAP[@]}"; do
-              if check_by_regex "$title" "$regex"; then
-                echo "${JOB_MAP[$regex]}"
-                return 0
-              fi
-            done
-            echo "$NO_VALUE"
-            return 0
-          }
 
           # Team 검사, 결과 저장
           TEAM_RESULT=$(team_check "$PR_TITLE")
           echo "team=$TEAM_RESULT" >> $GITHUB_OUTPUT
-
-          # 작업 검사, 결과 저장 (미사용)
-          # JOB_RESULT=$(job_check "$PR_TITLE")
-          # echo "job=$JOB_RESULT" >> $GITHUB_OUTPUT
 
       - name: Check Error
         run: |

--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -45,15 +45,14 @@ jobs:
 
           # 작업별 TAG
           FEATURE_TAG="feature"
-          BUG_TAG="bug"
-
+          FIX_TAG="fix"
           REFECTOR_TAG="refactor"
           CHORE_TAG="chore"
 
           # 작업별 REGEX, TAG 연관 배열
           JOB_MAP["$FEATURE_REGEX"]="$FEATURE_TAG"
-          JOB_MAP["$BUG_REGEX"]="$BUG_TAG"
-          JOB_MAP["$FIX_REGEX"]="$BUG_TAG"
+          JOB_MAP["$BUG_REGEX"]="$FIX_TAG"
+          JOB_MAP["$FIX_REGEX"]="$FIX_TAG"
           JOB_MAP["$REFECTOR_REGEX"]="$REFECTOR_TAG"
           JOB_MAP["$CHORE_REGEX"]="$CHORE_TAG"
 
@@ -94,9 +93,9 @@ jobs:
           TEAM_RESULT=$(team_check "$PR_TITLE")
           echo "team=$TEAM_RESULT" >> $GITHUB_OUTPUT
 
-          # 작업 검사, 결과 저장
-          JOB_RESULT=$(job_check "$PR_TITLE")
-          echo "job=$JOB_RESULT" >> $GITHUB_OUTPUT
+          # 작업 검사, 결과 저장 (미사용)
+          # JOB_RESULT=$(job_check "$PR_TITLE")
+          # echo "job=$JOB_RESULT" >> $GITHUB_OUTPUT
 
       - name: Check Error
         run: |
@@ -105,10 +104,10 @@ jobs:
           if [[ "$TEAM_LABEL" == "$NO_VALUE" ]]; then
             echo "No Team code like \"[Campus]\""
           fi
-          JOB_LABEL="${{ steps.check_need_label.outputs.job }}"
-          if [[ "$JOB_LABEL" == "$NO_VALUE" ]]; then
-            echo "No JOB code like \"[fix]\""
-          fi
+          # JOB_LABEL="${{ steps.check_need_label.outputs.job }}"
+          # if [[ "$JOB_LABEL" == "$NO_VALUE" ]]; then
+          #   echo "No JOB code like \"[fix]\""
+          # fi
           if [[ "$TEAM_LABEL" == "$NO_VALUE" || "$JOB_LABEL" == "$NO_VALUE" ]]; then
             exit 1
           fi
@@ -118,10 +117,9 @@ jobs:
         with:
           script: |
             const team_label = '${{ steps.check_need_label.outputs.team }}';
-            const job_label = '${{ steps.check_need_label.outputs.job }}';
             github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              labels: [team_label, job_label]
+              labels: [team_label]
             });

--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -1,0 +1,126 @@
+name: "Auto PR Label Adder"
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  auto_pr_label_adder:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Team and Job From PR
+        id: check_need_label
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+
+          NO_VALUE="no value"
+          
+          declare -A TEAM_MAP
+          declare -A JOB_MAP
+
+          # Team 별 REGEX
+          CAMPUS_REGEX="\[[cC][aA][mM][pP][uU][sS]\]"
+          BUSINESS_REGEX="\[[bB][uU][sS][iI][nN][eE][sS][sS]\]"
+          USER_REGEX="\[[uU][sS][eE][rR]\]"
+          KOIN_PROJECT_REGEX="\[[kK][oO][iI][nN][[:space:]][pP][rR][oO][jJ][eE][cC][tT]\]"
+
+          # Team 별 TAG
+          CAMPUS_TAG="campus"
+          BUSINESS_TAG="business"
+          USER_TAG="user"
+          KOIN_PROJECT_TAG="koin project"
+
+          # Team 별 REGEX, TAG 연관 배열
+          TEAM_MAP["$CAMPUS_REGEX"]="$CAMPUS_TAG"
+          TEAM_MAP["$BUSINESS_REGEX"]="$BUSINESS_TAG"
+          TEAM_MAP["$USER_REGEX"]="$USER_TAG"
+          TEAM_MAP["$KOIN_PROJECT_REGEX"]="$KOIN_PROJECT_TAG"
+
+          # 작업별 REGEX (fix 와 bug 는 동일합니다)
+          FEATURE_REGEX="\[[fF][eE][aA][tT][uU][rR][eE]\]"
+          BUG_REGEX="\[[bB][uU][gG]\]"
+          FIX_REGEX="\[[fF][iI][xX]\]"
+          REFECTOR_REGEX="\[[rR][eE][fF][eE][cC][tT][oO][rR]\]"
+          CHORE_REGEX="\[[cC][hH][oO][rR][eE]\]"
+
+          # 작업별 TAG
+          FEATURE_TAG="feature"
+          BUG_TAG="bug"
+
+          REFECTOR_TAG="refactor"
+          CHORE_TAG="chore"
+
+          # 작업별 REGEX, TAG 연관 배열
+          JOB_MAP["$FEATURE_REGEX"]="$FEATURE_TAG"
+          JOB_MAP["$BUG_REGEX"]="$BUG_TAG"
+          JOB_MAP["$FIX_REGEX"]="$BUG_TAG"
+          JOB_MAP["$REFECTOR_REGEX"]="$REFECTOR_TAG"
+          JOB_MAP["$CHORE_REGEX"]="$CHORE_TAG"
+
+          # 정규식 검사
+          check_by_regex() {
+            local string=$1
+            local regex=$2
+            [[ "$string" =~ $regex ]]
+            return $?
+          }
+
+          # 팀 순차 검색
+          team_check() {
+            local title=$1
+            for regex in "${!TEAM_MAP[@]}"; do
+              if check_by_regex "$title" "$regex"; then
+                echo "${TEAM_MAP[$regex]}"
+                return 0
+              fi
+            done
+            echo "$NO_VALUE"
+            return 0
+          }
+          # 작업 순차 검색
+          job_check() {
+            local title=$1
+            for regex in "${!JOB_MAP[@]}"; do
+              if check_by_regex "$title" "$regex"; then
+                echo "${JOB_MAP[$regex]}"
+                return 0
+              fi
+            done
+            echo "$NO_VALUE"
+            return 0
+          }
+
+          # Team 검사, 결과 저장
+          TEAM_RESULT=$(team_check "$PR_TITLE")
+          echo "team=$TEAM_RESULT" >> $GITHUB_OUTPUT
+
+          # 작업 검사, 결과 저장
+          JOB_RESULT=$(job_check "$PR_TITLE")
+          echo "job=$JOB_RESULT" >> $GITHUB_OUTPUT
+
+      - name: Check Error
+        run: |
+          NO_VALUE="no value"
+          TEAM_LABEL="${{ steps.check_need_label.outputs.team }}"
+          if [[ "$TEAM_LABEL" == "$NO_VALUE" ]]; then
+            echo "No Team code like \"[Campus]\""
+          fi
+          JOB_LABEL="${{ steps.check_need_label.outputs.job }}"
+          if [[ "$JOB_LABEL" == "$NO_VALUE" ]]; then
+            echo "No JOB code like \"[fix]\""
+          fi
+          if [[ "$TEAM_LABEL" == "$NO_VALUE" || "$JOB_LABEL" == "$NO_VALUE" ]]; then
+            exit 1
+          fi
+
+      - name: Add Label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const team_label = '${{ steps.check_need_label.outputs.team }}';
+            const job_label = '${{ steps.check_need_label.outputs.job }}';
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: [team_label, job_label]
+            });

--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -103,12 +103,6 @@ jobs:
           TEAM_LABEL="${{ steps.check_need_label.outputs.team }}"
           if [[ "$TEAM_LABEL" == "$NO_VALUE" ]]; then
             echo "No Team code like \"[Campus]\""
-          fi
-          # JOB_LABEL="${{ steps.check_need_label.outputs.job }}"
-          # if [[ "$JOB_LABEL" == "$NO_VALUE" ]]; then
-          #   echo "No JOB code like \"[fix]\""
-          # fi
-          if [[ "$TEAM_LABEL" == "$NO_VALUE" || "$JOB_LABEL" == "$NO_VALUE" ]]; then
             exit 1
           fi
 

--- a/.github/workflows/auto_release_adder.yml
+++ b/.github/workflows/auto_release_adder.yml
@@ -57,13 +57,13 @@ jobs:
           
           # 작업별 TITLE (작성용)
           FEATURE_TITLE="### 신규 기능 개발 \\n"
-          BUG_TITLE="### 버그 수정 \\n"
+          FIX_TITLE="### 버그 수정 \\n"
           REFECTOR_TITLE="### 리팩토링 \\n"
           CHORE_TITLE="### 자잘한 작업 \\n"
           
           # 작업별 TAG (감지용)
           FEATURE_TAG="feature"
-          BUG_TAG="bug"
+          FIX_TAG="fix"
           REFECTOR_TAG="refactor"
           CHORE_TAG="chore"
           
@@ -90,7 +90,7 @@ jobs:
           add_team_body() {
             local team_tag=$1
             local team_title=$2
-            local team_body="$(fetch_prs "$team_tag" "$FEATURE_TAG" "$FEATURE_TITLE")$(fetch_prs "$team_tag" "$BUG_TAG" "$BUG_TITLE")$(fetch_prs "$team_tag" "$REFECTOR_TAG" "$REFECTOR_TITLE")$(fetch_prs "$team_tag" "$CHORE_TAG" "$CHORE_TITLE")"
+            local team_body="$(fetch_prs "$team_tag" "$FEATURE_TAG" "$FEATURE_TITLE")$(fetch_prs "$team_tag" "$FIX_TAG" "$FIX_TITLE")$(fetch_prs "$team_tag" "$REFECTOR_TAG" "$REFECTOR_TITLE")$(fetch_prs "$team_tag" "$CHORE_TAG" "$CHORE_TITLE")"
             # 내용이 없으면 작성 안함
             if [ -n "$team_body" ]; then
               BODY="$BODY$team_title$team_body\\n"


### PR DESCRIPTION
close/issue: #694

## 개요
Auto PR Label Adder :
자동 PR 라벨 추가 git action 추가

## 작업 내용
* 자동으로 생성, 수정된 PR 을 탐지해 label 을 추가하는 git action 개발

### 탐지 범위

대소문자 제한X
- [Campus] - OK
- [CAMPUS] - OK
- [caMPus] - OK

Koin Project 에 한하여 띄워쓰기 가능
- [KoinProject] - OK
- [Koin Project] - OK

## 스크린샷
| 제목이 형식에 맞으면 라벨 추가 |
|-----|
|<img src= https://github.com/user-attachments/assets/29d42626-4290-4e8e-9e79-8b5845667121 width="80%">|
| 하단 |
|<img src= https://github.com/user-attachments/assets/4947a141-e39b-4930-b93e-33d70cd38ba7 width="80%">|

| 제목이 형식에 맞지 않으면 merge 불가|
|-----|
|<img src= https://github.com/user-attachments/assets/a31c3666-d8f9-4628-a9ac-ac09a3fee735 width="80%">|
| actions > Auto PR Label Adder 혹은 viewDetails 로 화면을 넘어가 log 확인 가능|
|<img src= https://github.com/user-attachments/assets/78c5d0b3-29b8-4541-a200-ca5898c4b0bd width="80%">|
## 추가적인 내용 (선택)
- [x] Release PR 은 title 양식이 없어서 merge 가 잠기는 오류 해결 - production 에 날리는 PR 은 검사X
- [x] pr-labeler 와 라벨 부여가 중복되는 문제 (작동은 정상 작동) 해결 - job 라벨 기능 비활성화
## 논의 사항
1. PR 제목을 [Campus] 로 설정 > campus 라벨이 생김
2. PR 제목을 [Business] 로 변경 > business 라벨이 생김
3. 결과적으로  campus 와 business 가 모두 존재하는 혼종 PR 이 생김
-> 대응을 해야할까요..?
