### PR TITLE
[Campus][feature] 동아리 detail snackbar 생성

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
@@ -25,12 +25,20 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.FloatingActionButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -42,6 +50,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -53,6 +62,7 @@ import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.feature.club.BuildConfig
 import `in`.koreatech.koin.feature.club.R
 import `in`.koreatech.koin.feature.club.intent.detail.ClubDetailIntent
 import `in`.koreatech.koin.feature.club.type.DetailIntroType.DETAIL_CATEGORY
@@ -95,6 +105,7 @@ fun ClubDetail(
 
     val context = LocalContext.current
 
+    val snackbarHostState = remember { SnackbarHostState() }
     val scrollStates = remember { mutableStateMapOf<Int, Int>() }
     val listState = rememberLazyListState()
 
@@ -134,6 +145,42 @@ fun ClubDetail(
                     contentDescription = "up"
                 )
             }
+        },
+        snackbarHost = {
+            SnackbarHost(
+                hostState = snackbarHostState,
+                snackbar = { data ->
+                    Snackbar(
+                        modifier = Modifier
+                            .padding(horizontal = 24.dp),
+                        content = {
+                            Text(
+                                text = data.visuals.message,
+                                style = KoinTheme.typography.regular12,
+                                color = KoinTheme.colors.neutral0
+                            )
+                        },
+                        action = {
+                            data.visuals.actionLabel?.let { label ->
+                                Box(
+                                    modifier = Modifier
+                                        .padding(end = 12.dp)
+                                        .clickable { data.performAction() }
+                                ) {
+                                    Text(
+                                        text = label,
+                                        style = KoinTheme.typography.regular12,
+                                        color = KoinTheme.colors.info700
+                                    )
+                                }
+                            }
+                        },
+                        containerColor = Color(0xCC041A44),
+                        contentColor = KoinTheme.colors.neutral0,
+                        shape = RoundedCornerShape(8.dp)
+                    )
+                }
+            )
         }
     ) { contentPadding ->
 
@@ -318,8 +365,27 @@ fun ClubDetail(
                 ) { page ->
                     when (tabList[page]) {
                         DetailTabType.DETAIL_INTRO.strResId -> {
+                            val snackbarMessage = stringResource(R.string.detail_snackbar_detail_intro_text)
+                            val snackbarActionLabel = stringResource(R.string.detail_snackbar_detail_intro_button)
                             ClubDetailIntro(
-                                onFixIntroClick = { },
+                                onFixIntroClick = {
+                                    scope.launch {
+                                        val result = snackbarHostState.showSnackbar(
+                                            message =  snackbarMessage,
+                                            actionLabel = snackbarActionLabel,
+                                            duration = SnackbarDuration.Short
+                                        )
+                                        if (result == SnackbarResult.ActionPerformed) {
+                                            var intent: Intent
+                                            if (BuildConfig.DEBUG){
+                                                intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://stage.koreatech.in/"))
+                                            }else {
+                                                intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://koreatech.in/"))
+                                            }
+                                            context.startActivity(intent)
+                                        }
+                                    }
+                                },
                                 isManager = state.clubDetails?.manager ?: false,
                                 userId = state.userId
                             )

--- a/feature/club/src/main/res/values/strings.xml
+++ b/feature/club/src/main/res/values/strings.xml
@@ -23,4 +23,6 @@
     <string name="detail_dialog_login_positive">로그인하기</string>
     <string name="detail_dialog_login_title">로그인이 필요한 기능입니다.</string>
     <string name="detail_dialog_login_description">로그인 하시겠어요?</string>
+    <string name="detail_snackbar_detail_intro_text">앱에서는 수정 기능이 준비 중입니다.\n브라우저에서 계속 진행해 주세요.</string>
+    <string name="detail_snackbar_detail_intro_button">브라우저로 연결</string>
 </resources>


### PR DESCRIPTION
issue #688 

## 개요
* 동아리 detail snackbar 생성

## 작업 내용
* 동아리 detail 에 상세 소개 수정 버튼 클릭 시 snackbar 가 나오며 브라우저로 이동합니다. 

| snackbar (브라우저 이동 시 현재는 koin stage 웹사이트로 이동) |
| :--: |
|  <img src = https://github.com/user-attachments/assets/62bdc75f-47d1-4ae9-94b0-6b1746124975  width=40%>  |

## 추가적인 내용
* figma 정의에서는 폰트 사이즈가 14 인데 실제 14 적용시 글자가 줄넘김이 망가집니다.
  결국 사진에서는 폰트 사이즈를 12 로 줄여서 시연하였고 이는 design 팀과 이야기 해봐야할 거 같습니다.
  
* snackbar 위치는 현재 floationg 버튼 위에 있습니다.
