### PR TITLE
[Campus][feature] 동아리 Detail 에 manager empowerment 기능 추가

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/type/DetailTextFieldErrorCode.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/type/DetailTextFieldErrorCode.kt
@@ -1,0 +1,10 @@
+package `in`.koreatech.koin.feature.club.type
+
+import `in`.koreatech.koin.feature.club.R
+
+enum class DetailTextFieldErrorCode(
+    val strResId: Int
+) {
+    EMPTY_ERROR(R.string.detail_textfield_error_empty),
+    NON_USERID_ERROR(R.string.detail_textfield_error_non_user_id)
+}

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
@@ -217,14 +217,15 @@ fun ClubDetail(
                 }
             )
         }
-        //TODO 불편한 변수 선언 뺄 방법 생각하기 : constFile > SideEffect > 출력 ?
+        // TODO 불편한 변수 선언 뺄 방법 생각하기 : constFile > SideEffect > 출력 ?
         val empowermentSucessMessage = stringResource(R.string.detail_snackbar_empowerment_success)
         viewModel.collectSideEffect { sideEffect ->
             when (sideEffect) {
                 is ClubDetailSideEffect.ShowEmpowermentSnackBar -> {
                     snackbarHostState.showSnackbar(
                         message = empowermentSucessMessage,
-                        duration = SnackbarDuration.Short)
+                        duration = SnackbarDuration.Short
+                    )
                 }
             }
         }
@@ -331,8 +332,8 @@ fun ClubDetail(
                         modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        //TODO 인스타, googleForm, 오픈채팅은 양식 검증 후 Uri 반환 필요
-                        //TODO 전화번호 반환값에 양식 변환 필요
+                        // TODO 인스타, googleForm, 오픈채팅은 양식 검증 후 Uri 반환 필요
+                        // TODO 전화번호 반환값에 양식 변환 필요
                         detailList.forEach { intro ->
                             Row {
                                 Text(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetail.kt
@@ -71,12 +71,14 @@ import `in`.koreatech.koin.feature.club.type.DetailTabType
 import `in`.koreatech.koin.feature.club.ui.detail.component.dialog.DetailDialog
 import `in`.koreatech.koin.feature.club.ui.detail.component.dialog.DetailLoginDialog
 import `in`.koreatech.koin.feature.club.ui.detail.component.dialog.content.DetailDialogAddQnaContent
+import `in`.koreatech.koin.feature.club.ui.detail.component.dialog.content.DetailDialogEmpowermentContent
 import `in`.koreatech.koin.feature.club.ui.detail.component.snackbar.DetailSnackBar
 import `in`.koreatech.koin.feature.club.ui.detail.component.tabrow.DetailTabRow
 import `in`.koreatech.koin.feature.club.ui.detail.intro.ClubDetailIntro
 import `in`.koreatech.koin.feature.club.ui.detail.qna.ClubDetailQna
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
@@ -175,22 +177,56 @@ fun ClubDetail(
                 modifier = Modifier,
                 title = stringResource(R.string.detail_add_qna_button),
                 onPositive = {
-                    if (addQnaText.isNotEmpty()) {
-                        viewModel.dismissAddQnaDialog()
-                        viewModel.addClubQna(
-                            parentId = null,
-                            content = addQnaText
-                        )
-                    }
+                    viewModel.addClubQna(
+                        parentId = null,
+                        content = addQnaText
+                    )
                 },
                 onNegative = { viewModel.dismissAddQnaDialog() },
                 content = {
                     DetailDialogAddQnaContent(
                         text = addQnaText,
-                        onValueChange = { addQnaText = it }
+                        onValueChange = { addQnaText = it },
+                        isError = state.textFieldErrorResId != null,
+                        errorMessage = state.textFieldErrorResId?.let { stringResource(it) } ?: ""
                     )
                 }
             )
+        }
+
+        if (state.showEmpowermentDialog) {
+            var newManagerText by remember { mutableStateOf("") }
+            DetailDialog(
+                modifier = Modifier,
+                title = stringResource(R.string.detail_dialog_empowerment_title),
+                onPositive = {
+                    viewModel.setManagerEmpowerment(
+                        newUserId = newManagerText
+                    )
+                },
+                onNegative = { viewModel.dismissEmpowermentDialog() },
+                content = {
+                    DetailDialogEmpowermentContent(
+                        clubName = state.clubDetails?.name ?: "",
+                        managerId = state.userId ?: -1,
+                        text = newManagerText,
+                        onValueChange = { newManagerText = it },
+                        isError = state.textFieldErrorResId != null,
+                        errorMessage = state.textFieldErrorResId?.let { stringResource(it) } ?: ""
+                    )
+                }
+            )
+        }
+        //TODO 불편한 변수 선언 뺄 방법 생각하기 : constFile > SideEffect > 출력 ?
+        val empowermentSucessMessage = stringResource(R.string.detail_snackbar_empowerment_success)
+        viewModel.collectSideEffect { sideEffect ->
+            when (sideEffect) {
+                is ClubDetailSideEffect.ShowEmpowermentSnackBar -> {
+                    snackbarHostState.showSnackbar(
+                        message = empowermentSucessMessage,
+                        duration = SnackbarDuration.Short)
+                }
+            }
         }
 
         LazyColumn(
@@ -251,7 +287,7 @@ fun ClubDetail(
                                     .padding(end = 8.dp)
                             )
                             Image(
-                                painter = if (state.clubDetails?.isLiked ?: false) painterResource(id = R.drawable.icon_like_true) else painterResource(id = R.drawable.icon_like_false),
+                                painter = if (state.clubDetails?.isLiked == true) painterResource(id = R.drawable.icon_like_true) else painterResource(id = R.drawable.icon_like_false),
                                 contentDescription = "",
                                 modifier = Modifier
                                     .size(24.dp)
@@ -276,13 +312,13 @@ fun ClubDetail(
                                 ) {
                                     FilledButton(
                                         text = stringResource(R.string.detail_fix_button),
-                                        onClick = {},
+                                        onClick = {}, // 동아리 정보 수정 버튼 클릭
                                         contentPadding = PaddingValues(horizontal = 11.dp, vertical = 5.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     FilledButton(
                                         text = stringResource(R.string.detail_empowerment_button),
-                                        onClick = {},
+                                        onClick = { viewModel.showEmpowermentDialog() },
                                         contentPadding = PaddingValues(horizontal = 9.dp, vertical = 5.dp)
                                     )
                                 }
@@ -295,6 +331,8 @@ fun ClubDetail(
                         modifier = Modifier.fillMaxWidth(),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
+                        //TODO 인스타, googleForm, 오픈채팅은 양식 검증 후 Uri 반환 필요
+                        //TODO 전화번호 반환값에 양식 변환 필요
                         detailList.forEach { intro ->
                             Row {
                                 Text(
@@ -396,7 +434,7 @@ fun ClubDetail(
                                     viewModel.deleteClubQna(qnaId)
                                 },
                                 onAddAnswerClick = { qnaId, content ->
-                                    viewModel.addClubQna(qnaId, content)
+                                    viewModel.addClubQnaAnswer(qnaId, content)
                                 }
                             )
                         }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailSideEffect.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailSideEffect.kt
@@ -1,3 +1,5 @@
 package `in`.koreatech.koin.feature.club.ui.detail
 
-sealed class ClubDetailSideEffect
+sealed class ClubDetailSideEffect {
+    object ShowEmpowermentSnackBar: ClubDetailSideEffect()
+}

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailSideEffect.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailSideEffect.kt
@@ -1,5 +1,5 @@
 package `in`.koreatech.koin.feature.club.ui.detail
 
 sealed class ClubDetailSideEffect {
-    object ShowEmpowermentSnackBar: ClubDetailSideEffect()
+    object ShowEmpowermentSnackBar : ClubDetailSideEffect()
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailState.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailState.kt
@@ -9,5 +9,7 @@ data class ClubDetailState(
     val clubDetails: ClubDetails? = null,
     val clubQnasInfo: ClubQnasInfo? = null,
     val showLoginDialog: Boolean = false,
-    val showAddQnaDialog: Boolean = false
+    val showAddQnaDialog: Boolean = false,
+    val showEmpowermentDialog: Boolean = false,
+    val textFieldErrorResId: Int? = null
 )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailViewModel.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.club.ui.detail
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,12 +15,15 @@ import `in`.koreatech.koin.domain.usecase.club.PostClubQnaUseCase
 import `in`.koreatech.koin.domain.usecase.club.SetClubEmpowermentUseCase
 import `in`.koreatech.koin.domain.usecase.club.SetClubLikeUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
+import `in`.koreatech.koin.feature.club.type.DetailTextFieldErrorCode.NON_USERID_ERROR
+import `in`.koreatech.koin.feature.club.type.DetailTextFieldErrorCode.EMPTY_ERROR
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
@@ -38,7 +42,7 @@ class ClubDetailViewModel @Inject constructor(
         initialState = ClubDetailState()
     )
 
-    private var selectedClubId = 1 // 연결 이전 hard Coding
+    private var selectedClubId = 1 // 선택한 Clud 의 id 값
 
     private val userInfoFlow: StateFlow<User> =
         getUserStatusUseCase()
@@ -88,11 +92,32 @@ class ClubDetailViewModel @Inject constructor(
         reduce { state.copy(showAddQnaDialog = true) }
     }
     fun dismissAddQnaDialog() = intent {
-        reduce { state.copy(showAddQnaDialog = false) }
+        reduce { state.copy(showAddQnaDialog = false, textFieldErrorResId = null) }
     }
 
     fun addClubQna(
         parentId: Int?,
+        content: String
+    ) = intent {
+        if (state.isLoading) return@intent
+        reduce { state.copy(isLoading = true) }
+        if(content.isEmpty()) {
+            reduce { state.copy(isLoading = false, textFieldErrorResId = EMPTY_ERROR.strResId) }
+            return@intent
+        }
+        state.clubDetails?.let {
+            postClubQnaUseCase(
+                clubId = selectedClubId,
+                parentId = parentId,
+                content = content
+            )
+        }
+        val clubQnasInfo = loadClubQnas()
+        reduce { state.copy(isLoading = false, clubQnasInfo = clubQnasInfo,showAddQnaDialog = false, textFieldErrorResId = null) }
+    }
+
+    fun addClubQnaAnswer(
+        parentId: Int,
         content: String
     ) = intent {
         if (state.isLoading) return@intent
@@ -142,5 +167,38 @@ class ClubDetailViewModel @Inject constructor(
         }
         val clubDetails = loadClubDetails()
         reduce { state.copy(isLoading = false, clubDetails = clubDetails) }
+    }
+
+    fun showEmpowermentDialog() = intent {
+        reduce { state.copy(showEmpowermentDialog = true) }
+    }
+    fun dismissEmpowermentDialog() = intent {
+        reduce { state.copy(showEmpowermentDialog = false, textFieldErrorResId = null) }
+    }
+
+    //TODO result 오류처리 로직에 맞게 개선 필요
+    fun setManagerEmpowerment(newUserId: String) = intent {
+        if (state.isLoading) return@intent
+        reduce { state.copy(isLoading = true) }
+        if(newUserId.isEmpty()) {
+            reduce { state.copy(isLoading = false, textFieldErrorResId = EMPTY_ERROR.strResId) }
+            return@intent
+        }
+        setClubEmpowermentUseCase(
+            clubId = selectedClubId,
+            changedManagerId = newUserId
+        ).onFailure { e ->
+            if(e is retrofit2.HttpException) {
+                if (e.code() == 404) {
+                    reduce { state.copy(textFieldErrorResId = NON_USERID_ERROR.strResId) }
+                }
+            }
+            reduce { state.copy(isLoading = false) }
+            return@intent
+        }
+        val clubDetails = loadClubDetails()
+        val clubQnasInfo = loadClubQnas()
+        reduce { state.copy(isLoading = false, clubDetails = clubDetails, clubQnasInfo = clubQnasInfo, showEmpowermentDialog = false, textFieldErrorResId = null) }
+        postSideEffect(ClubDetailSideEffect.ShowEmpowermentSnackBar)
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/ClubDetailViewModel.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.feature.club.ui.detail
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,8 +14,8 @@ import `in`.koreatech.koin.domain.usecase.club.PostClubQnaUseCase
 import `in`.koreatech.koin.domain.usecase.club.SetClubEmpowermentUseCase
 import `in`.koreatech.koin.domain.usecase.club.SetClubLikeUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
-import `in`.koreatech.koin.feature.club.type.DetailTextFieldErrorCode.NON_USERID_ERROR
 import `in`.koreatech.koin.feature.club.type.DetailTextFieldErrorCode.EMPTY_ERROR
+import `in`.koreatech.koin.feature.club.type.DetailTextFieldErrorCode.NON_USERID_ERROR
 import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -101,7 +100,7 @@ class ClubDetailViewModel @Inject constructor(
     ) = intent {
         if (state.isLoading) return@intent
         reduce { state.copy(isLoading = true) }
-        if(content.isEmpty()) {
+        if (content.isEmpty()) {
             reduce { state.copy(isLoading = false, textFieldErrorResId = EMPTY_ERROR.strResId) }
             return@intent
         }
@@ -113,7 +112,7 @@ class ClubDetailViewModel @Inject constructor(
             )
         }
         val clubQnasInfo = loadClubQnas()
-        reduce { state.copy(isLoading = false, clubQnasInfo = clubQnasInfo,showAddQnaDialog = false, textFieldErrorResId = null) }
+        reduce { state.copy(isLoading = false, clubQnasInfo = clubQnasInfo, showAddQnaDialog = false, textFieldErrorResId = null) }
     }
 
     fun addClubQnaAnswer(
@@ -176,11 +175,11 @@ class ClubDetailViewModel @Inject constructor(
         reduce { state.copy(showEmpowermentDialog = false, textFieldErrorResId = null) }
     }
 
-    //TODO result 오류처리 로직에 맞게 개선 필요
+    // TODO result 오류처리 로직에 맞게 개선 필요
     fun setManagerEmpowerment(newUserId: String) = intent {
         if (state.isLoading) return@intent
         reduce { state.copy(isLoading = true) }
-        if(newUserId.isEmpty()) {
+        if (newUserId.isEmpty()) {
             reduce { state.copy(isLoading = false, textFieldErrorResId = EMPTY_ERROR.strResId) }
             return@intent
         }
@@ -188,7 +187,7 @@ class ClubDetailViewModel @Inject constructor(
             clubId = selectedClubId,
             changedManagerId = newUserId
         ).onFailure { e ->
-            if(e is retrofit2.HttpException) {
+            if (e is retrofit2.HttpException) {
                 if (e.code() == 404) {
                     reduce { state.copy(textFieldErrorResId = NON_USERID_ERROR.strResId) }
                 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogAddQnaContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogAddQnaContent.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,7 +19,9 @@ import `in`.koreatech.koin.feature.club.ui.detail.component.textfield.DetailQnaT
 fun DetailDialogAddQnaContent(
     modifier: Modifier = Modifier,
     text: String = "",
-    onValueChange: (String) -> Unit
+    isError: Boolean = false,
+    errorMessage: String = "",
+    onValueChange: (String) -> Unit = {}
 ) {
     Column(
         modifier = modifier,
@@ -31,7 +34,10 @@ fun DetailDialogAddQnaContent(
             textStyle = KoinTheme.typography.regular12,
             onValueChange = onValueChange,
             isSendIconVisible = false,
-            onSendClick = {},
+            isError = isError,
+            errorMessage = errorMessage,
+            errorIconModifier = Modifier.size(14.dp),
+            errorTextStyle = KoinTheme.typography.regular12,
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp)
         )
         Text(
@@ -49,7 +55,19 @@ fun DetailDialogAddQnaContentPreView() {
         modifier = Modifier
             .background(
                 color = KoinTheme.colors.neutral0
+            )
+    )
+}
+
+@Preview
+@Composable
+fun DetailDialogAddQnaContentErrorPreView() {
+    DetailDialogAddQnaContent(
+        modifier = Modifier
+            .background(
+                color = KoinTheme.colors.neutral0
             ),
-        onValueChange = {}
+        isError = true,
+        errorMessage = "필수 입력란입니다."
     )
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogEmpowermentContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogEmpowermentContent.kt
@@ -62,7 +62,7 @@ fun DetailDialogEmpowermentContent(
             )
         }
         Row(
-            verticalAlignment = if(isError) Alignment.Top else Alignment.CenterVertically
+            verticalAlignment = if (isError) Alignment.Top else Alignment.CenterVertically
         ) {
             Text(
                 text = stringResource(R.string.detail_dialog_empowerment_new_id),

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogEmpowermentContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/dialog/content/DetailDialogEmpowermentContent.kt
@@ -1,0 +1,114 @@
+package `in`.koreatech.koin.feature.club.ui.detail.component.dialog.content
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.feature.club.R
+import `in`.koreatech.koin.feature.club.ui.detail.component.textfield.DetailQnaTextField
+
+@Composable
+fun DetailDialogEmpowermentContent(
+    clubName: String,
+    managerId: Int,
+    modifier: Modifier = Modifier,
+    text: String = "",
+    isError: Boolean = false,
+    errorMessage: String = "",
+    onValueChange: (String) -> Unit = {}
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement
+            .spacedBy(8.dp)
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.detail_dialog_empowerment_club_name),
+                style = KoinTheme.typography.medium18,
+                color = KoinTheme.colors.neutral800
+            )
+            Text(
+                text = clubName,
+                style = KoinTheme.typography.medium18,
+                color = KoinTheme.colors.neutral800
+            )
+        }
+        Row(
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.detail_dialog_empowerment_old_id),
+                style = KoinTheme.typography.medium16,
+                color = KoinTheme.colors.neutral800
+            )
+            Text(
+                text = managerId.toString(),
+                style = KoinTheme.typography.medium16,
+                color = KoinTheme.colors.neutral800
+            )
+        }
+        Row(
+            verticalAlignment = if(isError) Alignment.Top else Alignment.CenterVertically
+        ) {
+            Text(
+                text = stringResource(R.string.detail_dialog_empowerment_new_id),
+                style = KoinTheme.typography.medium16,
+                color = KoinTheme.colors.neutral800
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            DetailQnaTextField(
+                value = text,
+                hint = stringResource(R.string.detail_dialog_empowerment_hint),
+                textStyle = KoinTheme.typography.regular14,
+                hintColor = KoinTheme.colors.neutral700,
+                onValueChange = onValueChange,
+                isSendIconVisible = false,
+                isError = isError,
+                errorMessage = errorMessage,
+                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 7.dp)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+fun DetailDialogEmpowermentContentPreView() {
+    DetailDialogEmpowermentContent(
+        clubName = "bcsd",
+        managerId = 6488,
+        modifier = Modifier
+            .background(
+                color = KoinTheme.colors.neutral0
+            )
+    )
+}
+
+@Preview
+@Composable
+fun DetailDialogEmpowermentContentErrorPreView() {
+    DetailDialogEmpowermentContent(
+        clubName = "bcsd",
+        managerId = 6488,
+        modifier = Modifier
+            .background(
+                color = KoinTheme.colors.neutral0
+            ),
+        isError = true,
+        errorMessage = "필수 입력란입니다."
+    )
+}

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/qnabox/DetailQnaBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/qnabox/DetailQnaBox.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ButtonColors
@@ -26,6 +27,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.club.R
@@ -48,6 +50,7 @@ fun DetailQnaBox(
     answerQnaId: Int? = null,
     answerText: String? = null
 ) {
+    var isError by remember { mutableStateOf(false) }
     var showDeleteQnaDialog by remember { mutableStateOf(Pair(false, -1)) }
     if (showDeleteQnaDialog.first) {
         DetailDialog(
@@ -126,6 +129,7 @@ fun DetailQnaBox(
                 Row(
                     modifier = Modifier
                         .fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start)
                 ) {
                     Image(
@@ -133,7 +137,7 @@ fun DetailQnaBox(
                         contentDescription = "QuestionDelete",
                         modifier = Modifier
                             .size(24.dp)
-                            .align(Alignment.CenterVertically)
+                            .offset { IntOffset(x = 0, y = if(isError) -(13.dp.roundToPx()) else 0) }
                     )
                     if (answerText.isNullOrEmpty() || answerQnaId == null) {
                         DetailQnaTextField(
@@ -144,8 +148,14 @@ fun DetailQnaBox(
                             onSendClick = {
                                 if (addAnswerText.isNotEmpty()) {
                                     onAddAnswerClick(qnaId, addAnswerText)
+                                    isError = false
                                 }
-                            }
+                                else {
+                                    isError = true
+                                }
+                            },
+                            isError = isError,
+                            errorMessage = stringResource(R.string.detail_textfield_error_empty)
                         )
                     } else {
                         Text(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/qnabox/DetailQnaBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/qnabox/DetailQnaBox.kt
@@ -137,7 +137,7 @@ fun DetailQnaBox(
                         contentDescription = "QuestionDelete",
                         modifier = Modifier
                             .size(24.dp)
-                            .offset { IntOffset(x = 0, y = if(isError) -(13.dp.roundToPx()) else 0) }
+                            .offset { IntOffset(x = 0, y = if (isError) -(13.dp.roundToPx()) else 0) }
                     )
                     if (answerText.isNullOrEmpty() || answerQnaId == null) {
                         DetailQnaTextField(
@@ -149,8 +149,7 @@ fun DetailQnaBox(
                                 if (addAnswerText.isNotEmpty()) {
                                     onAddAnswerClick(qnaId, addAnswerText)
                                     isError = false
-                                }
-                                else {
+                                } else {
                                     isError = true
                                 }
                             },

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/component/textfield/DetailQnaTextField.kt
@@ -6,17 +6,21 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -34,52 +38,85 @@ fun DetailQnaTextField(
     textStyle: TextStyle = KoinTheme.typography.regular14,
     textFieldColor: Color = KoinTheme.colors.primary500,
     hint: String = stringResource(R.string.detail_qna_text_field_hint),
+    hintColor: Color = KoinTheme.colors.neutral600,
     isSendIconVisible: Boolean = true,
+    sendIcon: Painter = painterResource(id = R.drawable.icon_qna_send),
+    sendIconModifier: Modifier = Modifier,
+    isError: Boolean = false,
+    errorColor: Color = KoinTheme.colors.sub500,
+    errorMessage: String = "",
+    errorTextStyle: TextStyle = KoinTheme.typography.regular14,
+    errorIcon: Painter = painterResource(id = R.drawable.icon_exclamation),
+    errorIconModifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(horizontal = 10.dp, vertical = 7.dp)
 ) {
-    BasicTextField(
-        modifier = Modifier,
-        value = value,
-        textStyle = textStyle,
-        onValueChange = { onValueChange(it) },
-        decorationBox = { innerTextField ->
-            Row(
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-                modifier = modifier
-                    .fillMaxWidth()
-                    .border(
-                        width = 1.dp,
-                        color = textFieldColor,
-                        shape = KoinTheme.shapes.extraSmall
-                    )
-                    .background(KoinTheme.colors.neutral100)
-                    .padding(contentPadding)
-            ) {
-                Box(
-                    modifier = Modifier.weight(1f)
+    Column(
+        verticalArrangement = Arrangement
+            .spacedBy(4.dp)
+    ) {
+        BasicTextField(
+            modifier = Modifier,
+            value = value,
+            textStyle = textStyle,
+            onValueChange = { onValueChange(it) },
+            decorationBox = { innerTextField ->
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = modifier
+                        .fillMaxWidth()
+                        .border(
+                            width = 1.dp,
+                            color = if (isError) errorColor else textFieldColor,
+                            shape = KoinTheme.shapes.extraSmall
+                        )
+                        .background(KoinTheme.colors.neutral100)
+                        .padding(contentPadding)
                 ) {
-                    if (value.isEmpty()) {
-                        Text(
-                            text = hint,
-                            color = KoinTheme.colors.neutral600,
-                            style = textStyle
+                    Box(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        if (value.isEmpty()) {
+                            Text(
+                                text = hint,
+                                color = hintColor,
+                                style = textStyle
+                            )
+                        }
+                        innerTextField()
+                    }
+                    if (isSendIconVisible) {
+                        Image(
+                            painter = sendIcon,
+                            contentDescription = "TextSend",
+                            modifier = sendIconModifier
+                                .size(20.dp)
+                                .clickable { onSendClick() }
                         )
                     }
-                    innerTextField()
-                }
-                if (isSendIconVisible) {
-                    Image(
-                        painter = painterResource(id = R.drawable.icon_qna_send),
-                        contentDescription = "QuestionDelete",
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clickable { onSendClick() }
-                    )
                 }
             }
+        )
+        if (isError) {
+            Row(
+                modifier = Modifier.padding(horizontal = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Image(
+                    painter = errorIcon,
+                    contentDescription = "TextField Error",
+                    modifier = errorIconModifier
+                        .size(16.dp)
+                )
+                Spacer(Modifier.width(4.dp))
+                Text(
+                    text = errorMessage,
+                    style = errorTextStyle,
+                    color = errorColor
+                )
+            }
         }
-    )
+    }
 }
 
 @Preview
@@ -104,5 +141,16 @@ fun DetailQnaTextFieldNoIconPreview() {
     DetailQnaTextField(
         value = "",
         isSendIconVisible = false
+    )
+}
+
+@Preview
+@Composable
+fun DetailQnaTextFieldErrorPreview() {
+    DetailQnaTextField(
+        value = "",
+        isSendIconVisible = false,
+        isError = true,
+        errorMessage = "필수 입력란입니다."
     )
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/qna/ClubDetailQna.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/qna/ClubDetailQna.kt
@@ -22,6 +22,7 @@ import `in`.koreatech.koin.domain.model.club.ClubQnasInfo
 import `in`.koreatech.koin.feature.club.R
 import `in`.koreatech.koin.feature.club.ui.detail.component.qnabox.DetailQnaBox
 
+//TODO QNA 로딩중 progrssbar 추가
 @Composable
 fun ClubDetailQna(
     qnaList: List<ClubQnasInfo.Qna>?,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/qna/ClubDetailQna.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/detail/qna/ClubDetailQna.kt
@@ -22,7 +22,7 @@ import `in`.koreatech.koin.domain.model.club.ClubQnasInfo
 import `in`.koreatech.koin.feature.club.R
 import `in`.koreatech.koin.feature.club.ui.detail.component.qnabox.DetailQnaBox
 
-//TODO QNA 로딩중 progrssbar 추가
+// TODO QNA 로딩중 progrssbar 추가
 @Composable
 fun ClubDetailQna(
     qnaList: List<ClubQnasInfo.Qna>?,

--- a/feature/club/src/main/res/drawable/icon_exclamation.xml
+++ b/feature/club/src/main/res/drawable/icon_exclamation.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="17dp"
+    android:viewportWidth="16"
+    android:viewportHeight="17">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M8,6.5V7.833M8,10.5H8.007M3.381,13.167H12.619C13.645,13.167 14.287,12.055 13.773,11.167L9.155,3.167C8.641,2.278 7.359,2.278 6.845,3.167L2.227,11.167C1.713,12.055 2.355,13.167 3.381,13.167Z"
+      android:strokeLineJoin="round"
+      android:fillColor="#00000000"
+      android:strokeColor="#F7941E"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/club/src/main/res/values/strings.xml
+++ b/feature/club/src/main/res/values/strings.xml
@@ -26,4 +26,12 @@
     <string name="detail_dialog_login_description">로그인 하시겠어요?</string>
     <string name="detail_snackbar_detail_intro_text">앱에서는 수정 기능이 준비 중입니다.\n브라우저에서 계속 진행해 주세요.</string>
     <string name="detail_snackbar_detail_intro_button">브라우저로 연결</string>
+    <string name="detail_snackbar_empowerment_success">권한 위임이 완료되었습니다.\n본 시간부로 동아리에 관한 모든 권한이 해제됩니다.</string>
+    <string name="detail_dialog_empowerment_title">권한 위임</string>
+    <string name="detail_dialog_empowerment_club_name">동아리명:&#160;</string>
+    <string name="detail_dialog_empowerment_old_id">현 권한자 아이디:&#160;</string>
+    <string name="detail_dialog_empowerment_new_id">향후 권한자 아이디:</string>
+    <string name="detail_dialog_empowerment_hint">아이디를 입력해주세요.</string>
+    <string name="detail_textfield_error_empty">필수 입력란입니다.</string>
+    <string name="detail_textfield_error_non_user_id">존재하지 않는 id 입니다.</string>
 </resources>


### PR DESCRIPTION
## 개요
* 동아리 Detail 에 manager empowerment 기능 추가

시간이 부족해서 QA 만 진행할 정도로 만들었습니다...

## 작업 내용
* 동아리 Detail 에 manager empowerment 기능 추가
* textField 입력창에 오류 메시지를 띄우는 기능 추가

| dialog | 성공 시 |
|:--:|:--:|
| <img src = https://github.com/user-attachments/assets/6e21b7f9-e37b-4999-a5e7-b157c682f284 width = 40%> |  <img src = https://github.com/user-attachments/assets/032685cd-9279-4e39-a842-84d4b7b8fbf7 width = 40%> |



## 추가 논의 사항
* 오류 처리 로직 변경 필요
* SideEffect 관련 변수를 constant 로 관리할 필요성
* Detail 정보 중 인스타, 구글 폼 양식 적용 + 링크 제공 필요
* qna 쪽 내부 스크롤 동작이 마음에 안들어서 방법 고안 중
  (qna 부분 스크롤 시 부모인 lazyColumn 이 아닌 자식인 qna 부분이 우선 스크롤됨 > 관계 역전 필요)
* qna 갱신 시 progress bar 보여주기