### PR TITLE
[User][Feature] 마케팅 수신 동의 약관 및 알림 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/NotificationMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/NotificationMapper.kt
@@ -36,6 +36,7 @@ fun String.toSubscribesType(): SubscribesType =
         Subscribes.ARTICLE_KEYWORD -> SubscribesType.ARTICLE_KEYWORD
         Subscribes.REVIEW_PROMPT -> SubscribesType.REVIEW_PROMPT
         Subscribes.LOST_ITEM_CHAT -> SubscribesType.LOST_ITEM_CHAT
+        Subscribes.MARKETING -> SubscribesType.MARKETING
         else -> SubscribesType.NOTHING
     }
 

--- a/domain/src/main/java/in/koreatech/koin/domain/model/notification/NotificationPermissionInfo.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/notification/NotificationPermissionInfo.kt
@@ -17,6 +17,7 @@ data class Subscribes(
         const val ARTICLE_KEYWORD = "ARTICLE_KEYWORD"
         const val REVIEW_PROMPT = "REVIEW_PROMPT"
         const val LOST_ITEM_CHAT = "LOST_ITEM_CHAT"
+        const val MARKETING = "MARKETING"
     }
 }
 
@@ -38,7 +39,8 @@ enum class SubscribesType {
     NOTHING,
     ARTICLE_KEYWORD,
     REVIEW_PROMPT,
-    LOST_ITEM_CHAT
+    LOST_ITEM_CHAT,
+    MARKETING
 }
 
 enum class SubscribesDetailType {

--- a/koin/src/main/java/in/koreatech/koin/ui/notification/NotificationActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/notification/NotificationActivity.kt
@@ -15,6 +15,8 @@ import `in`.koreatech.koin.core.activity.ActivityBase
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventLogger
+import `in`.koreatech.koin.core.dialog.AlertModalDialog
+import `in`.koreatech.koin.core.dialog.AlertModalDialogData
 import `in`.koreatech.koin.core.permission.checkNotificationPermission
 import `in`.koreatech.koin.core.util.dataBinding
 import `in`.koreatech.koin.core.util.setAppBarButtonClickedListener
@@ -31,6 +33,30 @@ class NotificationActivity : ActivityBase() {
     override val screenTitle: String = "알림"
     private val binding by dataBinding<ActivityNotificationBinding>(R.layout.activity_notification)
     private val viewModel: NotificationViewModel by viewModels()
+
+    private val permissionModal: AlertModalDialog by lazy {
+        AlertModalDialog(
+            this,
+            AlertModalDialogData(
+                title = R.string.notification_permission_dialog_title,
+                message = R.string.notification_permission_dialog_message,
+                positiveButtonText = R.string.notification_permission_dialog_positive,
+                negativeButtonText = R.string.notification_permission_dialog_negative
+            ),
+            onPositiveButtonClicked = {
+                intentAppSettings()
+                it.dismiss()
+            },
+            onNegativeButtonClicked = {
+                if (!checkNotificationPermission()) {
+                    permissionDenied()
+                } else {
+                    permissionGranted()
+                }
+                it.dismiss()
+            }
+        )
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -67,6 +93,7 @@ class NotificationActivity : ActivityBase() {
         viewModel.getPermissionInfo()
         with(binding) {
             textViewNotificationSetting.isVisible = false
+            notificationMarketing.isChecked = true
             notificationDiningSoldOut.isEnabled = true
             notificationShopEvent.isEnabled = true
             notificationReviewPrompt.isEnabled = true
@@ -78,6 +105,7 @@ class NotificationActivity : ActivityBase() {
         updateDiningSoldOutVisibility(false)
         with(binding) {
             textViewNotificationSetting.isVisible = true
+            notificationMarketing.isChecked = false
             notificationDiningSoldOut.disableAll()
             notificationShopEvent.disableAll()
             notificationReviewPrompt.disableAll()
@@ -128,6 +156,14 @@ class NotificationActivity : ActivityBase() {
 
                                     SubscribesType.LOST_ITEM_CHAT ->
                                         with(binding.notificationChat) {
+                                            if (isChecked != it.isPermit) {
+                                                fakeChecked = it.isPermit
+                                                isChecked = it.isPermit
+                                            }
+                                        }
+
+                                    SubscribesType.MARKETING ->
+                                        with(binding.notificationMarketing) {
                                             if (isChecked != it.isPermit) {
                                                 fakeChecked = it.isPermit
                                                 isChecked = it.isPermit
@@ -186,6 +222,14 @@ class NotificationActivity : ActivityBase() {
     }
 
     private fun subscribeNotification() {
+        binding.notificationMarketing.setOnSwitchClickListener { isChecked ->
+            if (checkNotificationPermission()) {
+                handleSubscription(isChecked, SubscribesType.MARKETING)
+            } else {
+                permissionModal.show()
+            }
+        }
+
         binding.notificationDiningSoldOut.setOnSwitchClickListener { isChecked ->
             EventLogger.logClickEvent(
                 EventAction.CAMPUS,

--- a/koin/src/main/java/in/koreatech/koin/ui/setting/SettingActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/setting/SettingActivity.kt
@@ -19,6 +19,9 @@ import `in`.koreatech.koin.ui.changepassword.ChangePasswordContract
 import `in`.koreatech.koin.ui.login.LoginActivity
 import `in`.koreatech.koin.ui.notification.NotificationActivity
 import `in`.koreatech.koin.ui.term.TermActivity
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
 import `in`.koreatech.koin.ui.userinfo.UserInfoActivity
 import `in`.koreatech.koin.util.SnackbarUtil
 import kotlinx.coroutines.launch
@@ -100,14 +103,14 @@ class SettingActivity : ActivityBase() {
             svPrivacyPolicy.setOnSettingClickListener {
                 startActivity(
                     Intent(this@SettingActivity, TermActivity::class.java).apply {
-                        putExtra(TermActivity.KEY_TERM, TermActivity.TERM_PRIVACY_POLICY)
+                        putExtra(KEY_TERM, TERM_PRIVACY_POLICY)
                     }
                 )
             }
             svKoinTerms.setOnSettingClickListener {
                 startActivity(
                     Intent(this@SettingActivity, TermActivity::class.java).apply {
-                        putExtra(TermActivity.KEY_TERM, TermActivity.TERM_KOIN)
+                        putExtra(KEY_TERM, TERM_KOIN)
                     }
                 )
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/setting/SettingActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/setting/SettingActivity.kt
@@ -21,6 +21,7 @@ import `in`.koreatech.koin.ui.notification.NotificationActivity
 import `in`.koreatech.koin.ui.term.TermActivity
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_MARKETING
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
 import `in`.koreatech.koin.ui.userinfo.UserInfoActivity
 import `in`.koreatech.koin.util.SnackbarUtil
@@ -111,6 +112,13 @@ class SettingActivity : ActivityBase() {
                 startActivity(
                     Intent(this@SettingActivity, TermActivity::class.java).apply {
                         putExtra(KEY_TERM, TERM_KOIN)
+                    }
+                )
+            }
+            svMarketingTerms.setOnSettingClickListener {
+                startActivity(
+                    Intent(this@SettingActivity, TermActivity::class.java).apply {
+                        putExtra(KEY_TERM, TERM_MARKETING)
                     }
                 )
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
@@ -13,6 +13,10 @@ import `in`.koreatech.koin.core.appbar.AppBarBase
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.databinding.ActivityTermBinding
 import `in`.koreatech.koin.domain.model.term.Term
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_UNKNOWN
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -51,6 +55,7 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
     }
 
     private fun loadTerm() {
+        viewModel.setTermType(intent.getStringExtra(KEY_TERM) ?: TERM_UNKNOWN)
         when (intent.getStringExtra(KEY_TERM)) {
             TERM_KOIN -> {
                 viewModel.loadKoinTerm()
@@ -121,12 +126,5 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
             articleAdapter.submitList(term.articles.map { it.article })
             contentAdapter.submitList(term.articles)
         }
-    }
-
-    companion object {
-        const val KEY_TERM = "key_term"
-        const val TERM_KOIN = "term_koin"
-        const val TERM_PRIVACY_POLICY = "term_privacy_policy"
-        private const val TERM_UNKNOWN = "term_unknown"
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.ui.term
 
 import android.os.Bundle
-import android.view.View
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -11,21 +10,15 @@ import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
 import `in`.koreatech.koin.core.appbar.AppBarBase
-import `in`.koreatech.koin.core.permission.checkNotificationPermission
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.databinding.ActivityTermBinding
-import `in`.koreatech.koin.domain.model.notification.SubscribesType
 import `in`.koreatech.koin.domain.model.term.Term
-import `in`.koreatech.koin.ui.notification.viewmodel.NotificationUiState
-import `in`.koreatech.koin.ui.notification.viewmodel.NotificationViewModel
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_MARKETING
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_UNKNOWN
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class TermActivity : ActivityBase(R.layout.activity_term) {
@@ -41,7 +34,6 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
     private var term = TERM_UNKNOWN
 
     private val viewModel by viewModels<TermViewModel>()
-    private val notificationViewModel: NotificationViewModel by viewModels()
 
     private val articleAdapter by lazy {
         TermArticleAdapter(
@@ -61,24 +53,6 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
         loadTerm()
         initView()
         initObservers()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        if (!checkNotificationPermission()) {
-            permissionDenied()
-        } else {
-            permissionGranted()
-        }
-    }
-
-    private fun permissionGranted() {
-        notificationViewModel.getPermissionInfo()
-        // TODO
-    }
-
-    private fun permissionDenied() {
-        // TODO
     }
 
     private fun loadTerm() {
@@ -121,14 +95,6 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
             rvContent.adapter = contentAdapter
             rvContent.layoutManager = LinearLayoutManager(this@TermActivity)
             rvContent.isNestedScrollingEnabled = false
-
-            notificationHeaderTermMarketingTermSwitch.setOnSwitchClickListener { isChecked ->
-                if (isChecked) {
-                    notificationViewModel.updateSubscription(SubscribesType.MARKETING)
-                } else {
-                    notificationViewModel.deleteSubscription(SubscribesType.MARKETING)
-                }
-            }
         }
     }
 
@@ -145,46 +111,6 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
                         is TermState.Failure -> {
                             ToastUtil.getInstance().makeShort("약관을 불러오는 데 실패했습니다. 다시 시도해주세요")
                         }
-                    }
-                }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                viewModel.termType.collectLatest {
-                    binding.notificationHeaderTermMarketingTermSwitch.visibility = if (it == TERM_MARKETING) {
-                        View.VISIBLE
-                    } else {
-                        View.GONE
-                    }
-                }
-            }
-        }
-        lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.STARTED) {
-                notificationViewModel.notificationUiState.collect { uiState ->
-                    when (uiState) {
-                        is NotificationUiState.Success -> {
-                            uiState.notificationPermissionInfo.subscribes.forEach {
-                                when (it.type) {
-                                    SubscribesType.MARKETING -> {
-                                        Timber.d("marketing: ${it.isPermit}")
-                                        with(binding.notificationHeaderTermMarketingTermSwitch) {
-                                            if (isChecked != it.isPermit) {
-                                                fakeChecked = it.isPermit
-                                                isChecked = it.isPermit
-                                            }
-                                        }
-                                    }
-
-                                    SubscribesType.NOTHING -> Unit
-                                    else -> Unit
-                                }
-                            }
-                        }
-
-                        is NotificationUiState.Failed -> {}
-                        is NotificationUiState.Nothing -> {}
                     }
                 }
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
@@ -13,11 +13,6 @@ import `in`.koreatech.koin.core.appbar.AppBarBase
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.databinding.ActivityTermBinding
 import `in`.koreatech.koin.domain.model.term.Term
-import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
-import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
-import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_MARKETING
-import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
-import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_UNKNOWN
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -56,7 +51,6 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
     }
 
     private fun loadTerm() {
-        viewModel.setTermType(intent.getStringExtra(KEY_TERM) ?: TERM_UNKNOWN)
         when (intent.getStringExtra(KEY_TERM)) {
             TERM_KOIN -> {
                 viewModel.loadKoinTerm()
@@ -131,5 +125,12 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
             articleAdapter.submitList(term.articles.map { it.article })
             contentAdapter.submitList(term.articles)
         }
+    }
+    companion object {
+        const val KEY_TERM = "key_term"
+        const val TERM_KOIN = "term_koin"
+        const val TERM_PRIVACY_POLICY = "term_privacy_policy"
+        const val TERM_MARKETING = "term_marketing"
+        private const val TERM_UNKNOWN = "term_unknown"
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.ui.term
 
 import android.os.Bundle
+import android.view.View
 import androidx.activity.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -10,14 +11,21 @@ import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
 import `in`.koreatech.koin.core.activity.ActivityBase
 import `in`.koreatech.koin.core.appbar.AppBarBase
+import `in`.koreatech.koin.core.permission.checkNotificationPermission
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.databinding.ActivityTermBinding
+import `in`.koreatech.koin.domain.model.notification.SubscribesType
 import `in`.koreatech.koin.domain.model.term.Term
+import `in`.koreatech.koin.ui.notification.viewmodel.NotificationUiState
+import `in`.koreatech.koin.ui.notification.viewmodel.NotificationViewModel
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.KEY_TERM
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_KOIN
+import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_MARKETING
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_PRIVACY_POLICY
 import `in`.koreatech.koin.ui.term.TermViewModel.Companion.TERM_UNKNOWN
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class TermActivity : ActivityBase(R.layout.activity_term) {
@@ -33,6 +41,7 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
     private var term = TERM_UNKNOWN
 
     private val viewModel by viewModels<TermViewModel>()
+    private val notificationViewModel: NotificationViewModel by viewModels()
 
     private val articleAdapter by lazy {
         TermArticleAdapter(
@@ -54,6 +63,24 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
         initObservers()
     }
 
+    override fun onResume() {
+        super.onResume()
+        if (!checkNotificationPermission()) {
+            permissionDenied()
+        } else {
+            permissionGranted()
+        }
+    }
+
+    private fun permissionGranted() {
+        notificationViewModel.getPermissionInfo()
+        // TODO
+    }
+
+    private fun permissionDenied() {
+        // TODO
+    }
+
     private fun loadTerm() {
         viewModel.setTermType(intent.getStringExtra(KEY_TERM) ?: TERM_UNKNOWN)
         when (intent.getStringExtra(KEY_TERM)) {
@@ -63,6 +90,10 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
 
             TERM_PRIVACY_POLICY -> {
                 viewModel.loadPrivacyTerm()
+            }
+
+            TERM_MARKETING -> {
+                viewModel.loadMarketingTerm()
             }
 
             else -> {
@@ -90,6 +121,14 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
             rvContent.adapter = contentAdapter
             rvContent.layoutManager = LinearLayoutManager(this@TermActivity)
             rvContent.isNestedScrollingEnabled = false
+
+            notificationHeaderTermMarketingTermSwitch.setOnSwitchClickListener { isChecked ->
+                if (isChecked) {
+                    notificationViewModel.updateSubscription(SubscribesType.MARKETING)
+                } else {
+                    notificationViewModel.deleteSubscription(SubscribesType.MARKETING)
+                }
+            }
         }
     }
 
@@ -106,6 +145,46 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
                         is TermState.Failure -> {
                             ToastUtil.getInstance().makeShort("약관을 불러오는 데 실패했습니다. 다시 시도해주세요")
                         }
+                    }
+                }
+            }
+        }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.termType.collectLatest {
+                    binding.notificationHeaderTermMarketingTermSwitch.visibility = if (it == TERM_MARKETING) {
+                        View.VISIBLE
+                    } else {
+                        View.GONE
+                    }
+                }
+            }
+        }
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                notificationViewModel.notificationUiState.collect { uiState ->
+                    when (uiState) {
+                        is NotificationUiState.Success -> {
+                            uiState.notificationPermissionInfo.subscribes.forEach {
+                                when (it.type) {
+                                    SubscribesType.MARKETING -> {
+                                        Timber.d("marketing: ${it.isPermit}")
+                                        with(binding.notificationHeaderTermMarketingTermSwitch) {
+                                            if (isChecked != it.isPermit) {
+                                                fakeChecked = it.isPermit
+                                                isChecked = it.isPermit
+                                            }
+                                        }
+                                    }
+
+                                    SubscribesType.NOTHING -> Unit
+                                    else -> Unit
+                                }
+                            }
+                        }
+
+                        is NotificationUiState.Failed -> {}
+                        is NotificationUiState.Nothing -> {}
                     }
                 }
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.ui.term
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.usecase.notification.UpdateNotificationSubscriptionUseCase
 import `in`.koreatech.koin.domain.usecase.signup.GetKoinTermUseCase
 import `in`.koreatech.koin.domain.usecase.signup.GetMarketingTermUseCase
 import `in`.koreatech.koin.domain.usecase.signup.GetPrivacyTermUseCase
@@ -12,24 +11,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @HiltViewModel
 class TermViewModel @Inject constructor(
     private val getKoinTermUseCase: GetKoinTermUseCase,
     private val getPrivacyTermUseCase: GetPrivacyTermUseCase,
-    private val getMarketingTermUseCase: GetMarketingTermUseCase,
-    private val updateNotificationSubscriptionUseCase: UpdateNotificationSubscriptionUseCase
+    private val getMarketingTermUseCase: GetMarketingTermUseCase
 ) : ViewModel() {
     private val _term: MutableStateFlow<TermState> = MutableStateFlow(TermState.Init)
     val term: StateFlow<TermState> get() = _term.asStateFlow()
 
     private val _termType: MutableStateFlow<String> = MutableStateFlow(TERM_UNKNOWN)
-    val termType: StateFlow<String> get() = _termType.asStateFlow()
 
     fun setTermType(type: String) {
         _termType.value = type
-        Timber.d("term type: ${_termType.value}")
     }
 
     fun loadKoinTerm() {

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
@@ -21,12 +21,6 @@ class TermViewModel @Inject constructor(
     private val _term: MutableStateFlow<TermState> = MutableStateFlow(TermState.Init)
     val term: StateFlow<TermState> get() = _term.asStateFlow()
 
-    private val _termType: MutableStateFlow<String> = MutableStateFlow(TERM_UNKNOWN)
-
-    fun setTermType(type: String) {
-        _termType.value = type
-    }
-
     fun loadKoinTerm() {
         viewModelScope.launch {
             getKoinTermUseCase()
@@ -61,13 +55,5 @@ class TermViewModel @Inject constructor(
                     _term.value = TermState.Failure(it.message ?: "")
                 }
         }
-    }
-
-    companion object {
-        const val KEY_TERM = "key_term"
-        const val TERM_KOIN = "term_koin"
-        const val TERM_PRIVACY_POLICY = "term_privacy_policy"
-        const val TERM_MARKETING = "term_marketing"
-        const val TERM_UNKNOWN = "term_unknown"
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
@@ -3,18 +3,23 @@ package `in`.koreatech.koin.ui.term
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.usecase.notification.UpdateNotificationSubscriptionUseCase
 import `in`.koreatech.koin.domain.usecase.signup.GetKoinTermUseCase
+import `in`.koreatech.koin.domain.usecase.signup.GetMarketingTermUseCase
 import `in`.koreatech.koin.domain.usecase.signup.GetPrivacyTermUseCase
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @HiltViewModel
 class TermViewModel @Inject constructor(
     private val getKoinTermUseCase: GetKoinTermUseCase,
     private val getPrivacyTermUseCase: GetPrivacyTermUseCase,
+    private val getMarketingTermUseCase: GetMarketingTermUseCase,
+    private val updateNotificationSubscriptionUseCase: UpdateNotificationSubscriptionUseCase
 ) : ViewModel() {
     private val _term: MutableStateFlow<TermState> = MutableStateFlow(TermState.Init)
     val term: StateFlow<TermState> get() = _term.asStateFlow()
@@ -24,6 +29,7 @@ class TermViewModel @Inject constructor(
 
     fun setTermType(type: String) {
         _termType.value = type
+        Timber.d("term type: ${_termType.value}")
     }
 
     fun loadKoinTerm() {
@@ -50,11 +56,23 @@ class TermViewModel @Inject constructor(
         }
     }
 
+    fun loadMarketingTerm() {
+        viewModelScope.launch {
+            getMarketingTermUseCase()
+                .onSuccess {
+                    _term.value = TermState.Success(it)
+                }
+                .onFailure {
+                    _term.value = TermState.Failure(it.message ?: "")
+                }
+        }
+    }
 
     companion object {
         const val KEY_TERM = "key_term"
         const val TERM_KOIN = "term_koin"
         const val TERM_PRIVACY_POLICY = "term_privacy_policy"
+        const val TERM_MARKETING = "term_marketing"
         const val TERM_UNKNOWN = "term_unknown"
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermViewModel.kt
@@ -14,10 +14,17 @@ import kotlinx.coroutines.launch
 @HiltViewModel
 class TermViewModel @Inject constructor(
     private val getKoinTermUseCase: GetKoinTermUseCase,
-    private val getPrivacyTermUseCase: GetPrivacyTermUseCase
+    private val getPrivacyTermUseCase: GetPrivacyTermUseCase,
 ) : ViewModel() {
     private val _term: MutableStateFlow<TermState> = MutableStateFlow(TermState.Init)
     val term: StateFlow<TermState> get() = _term.asStateFlow()
+
+    private val _termType: MutableStateFlow<String> = MutableStateFlow(TERM_UNKNOWN)
+    val termType: StateFlow<String> get() = _termType.asStateFlow()
+
+    fun setTermType(type: String) {
+        _termType.value = type
+    }
 
     fun loadKoinTerm() {
         viewModelScope.launch {
@@ -41,5 +48,13 @@ class TermViewModel @Inject constructor(
                     _term.value = TermState.Failure(it.message ?: "")
                 }
         }
+    }
+
+
+    companion object {
+        const val KEY_TERM = "key_term"
+        const val TERM_KOIN = "term_koin"
+        const val TERM_PRIVACY_POLICY = "term_privacy_policy"
+        const val TERM_UNKNOWN = "term_unknown"
     }
 }

--- a/koin/src/main/res/layout/activity_notification.xml
+++ b/koin/src/main/res/layout/activity_notification.xml
@@ -50,6 +50,16 @@
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintTop_toTopOf="parent" />
 
+                        <in.koreatech.koin.core.view.notificaiton.NotificationHeader
+                            android:id="@+id/notification_marketing"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            app:description="@string/notification_marketing_term_switch_description"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/text_view_notification_setting"
+                            app:text="@string/notification_marketing_term_switch" />
+
                         <androidx.appcompat.widget.AppCompatTextView
                             android:id="@+id/text_view_dining"
                             android:layout_width="0dp"
@@ -62,7 +72,7 @@
                             android:textColor="@color/neutral_600"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/text_view_notification_setting" />
+                            app:layout_constraintTop_toBottomOf="@id/notification_marketing" />
 
                         <in.koreatech.koin.core.view.notificaiton.NotificationHeader
                             android:id="@+id/notification_dining_sold_out"

--- a/koin/src/main/res/layout/activity_setting.xml
+++ b/koin/src/main/res/layout/activity_setting.xml
@@ -117,6 +117,16 @@
                 app:layout_constraintTop_toBottomOf="@id/sv_privacy_policy" />
 
             <in.koreatech.koin.core.view.setting.SettingView
+                android:id="@+id/sv_marketing_terms"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:headText="@string/setting_item_marketing_terms"
+                app:headTextAppearance="@style/TextAppearance.Koin.Regular.16"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/sv_koin_terms" />
+
+            <in.koreatech.koin.core.view.setting.SettingView
                 android:id="@+id/sv_open_source_license"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
@@ -124,7 +134,7 @@
                 app:headTextAppearance="@style/TextAppearance.Koin.Regular.16"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/sv_koin_terms" />
+                app:layout_constraintTop_toBottomOf="@id/sv_marketing_terms" />
 
             <in.koreatech.koin.core.view.setting.SettingView
                 android:id="@+id/sv_app_version"

--- a/koin/src/main/res/layout/activity_term.xml
+++ b/koin/src/main/res/layout/activity_term.xml
@@ -27,6 +27,24 @@
                 app:titleText="@string/setting_item_koin_terms"
                 app:titleTextColor="@color/neutral_0" />
 
+            <in.koreatech.koin.core.view.notificaiton.NotificationHeader
+                android:id="@+id/notification_header_term_marketing_term_switch"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                app:description="@string/term_marketing_term_switch_description"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:visibility="gone"
+                app:layout_constraintHorizontal_bias="0.0"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/appbar_term_koin"
+                app:text="@string/term_marketing_term_switch_title" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/gray2"
+                app:layout_constraintTop_toBottomOf="@id/notification_header_term_marketing_term_switch" />
+
             <TextView
                 android:id="@+id/tv_term_koin_title"
                 android:layout_width="0dp"
@@ -38,7 +56,7 @@
                 android:textColor="@color/neutral_800"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/appbar_term_koin" />
+                app:layout_constraintTop_toBottomOf="@id/notification_header_term_marketing_term_switch" />
 
             <View
                 android:layout_width="0dp"

--- a/koin/src/main/res/layout/activity_term.xml
+++ b/koin/src/main/res/layout/activity_term.xml
@@ -27,24 +27,6 @@
                 app:titleText="@string/setting_item_koin_terms"
                 app:titleTextColor="@color/neutral_0" />
 
-            <in.koreatech.koin.core.view.notificaiton.NotificationHeader
-                android:id="@+id/notification_header_term_marketing_term_switch"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                app:description="@string/term_marketing_term_switch_description"
-                app:layout_constraintEnd_toEndOf="parent"
-                android:visibility="gone"
-                app:layout_constraintHorizontal_bias="0.0"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/appbar_term_koin"
-                app:text="@string/term_marketing_term_switch_title" />
-
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="1dp"
-                android:background="@color/gray2"
-                app:layout_constraintTop_toBottomOf="@id/notification_header_term_marketing_term_switch" />
-
             <TextView
                 android:id="@+id/tv_term_koin_title"
                 android:layout_width="0dp"
@@ -56,7 +38,7 @@
                 android:textColor="@color/neutral_800"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/notification_header_term_marketing_term_switch" />
+                app:layout_constraintTop_toBottomOf="@id/appbar_term_koin" />
 
             <View
                 android:layout_width="0dp"

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -390,6 +390,13 @@
     <string name="notification_article_keyword">공지사항 키워드 알림</string>
     <string name="notification_dining_photo_upload_description">식단 사진이 업로드 될 경우 알림을 받습니다.</string>
 
+    <string name="notification_marketing_term_switch">마케팅 정보 수신 동의</string>
+    <string name="notification_marketing_term_switch_description">마케팅 정보 수신 동의/해제</string>
+    <string name="notification_permission_dialog_title">알림 권한이 꺼져 있어요.</string>
+    <string name="notification_permission_dialog_message">알림을 받으시려면 기기의 알림 권한이 필요해요.\n설정 화면으로 이동할까요?</string>
+    <string name="notification_permission_dialog_positive">설정 이동</string>
+    <string name="notification_permission_dialog_negative">취소</string>
+
     <!-- force update -->
     <string name="force_update_do_update">업데이트하기</string>
     <string name="force_update_already_update">이미 업데이트를 하셨나요?</string>
@@ -667,10 +674,6 @@
     <string name="store_review_is_modify">%1$s (수정됨)</string>
     <string name="login_request_to_write_review">리뷰 작성 시 로그인을 해주세요.</string>
     <string name="request_notification_permission">설정에서 알림 권한을 허용해주세요</string>
-
-    <!-- Terms -->
-    <string name="term_marketing_term_switch_title">마케팅 정보 수신 동의</string>
-    <string name="term_marketing_term_switch_description">마케팅 정보 수신 동의/해제</string>
 
     <!-- etc -->
     <string name="copyright_2024">Copyright 2024. BCSD Lab. All rights reserved.</string>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -245,6 +245,7 @@
     <string name="setting_title_service">서비스</string>
     <string name="setting_item_privacy_policy">개인정보 처리방침</string>
     <string name="setting_item_koin_terms">코인 이용약관</string>
+    <string name="setting_item_marketing_terms">마케팅 수신 동의 약관</string>
     <string name="setting_item_open_source_license">오픈소스 라이선스</string>
     <string name="setting_item_app_version">앱 버전</string>
     <string name="setting_item_contact">문의하기</string>
@@ -666,6 +667,10 @@
     <string name="store_review_is_modify">%1$s (수정됨)</string>
     <string name="login_request_to_write_review">리뷰 작성 시 로그인을 해주세요.</string>
     <string name="request_notification_permission">설정에서 알림 권한을 허용해주세요</string>
+
+    <!-- Terms -->
+    <string name="term_marketing_term_switch_title">마케팅 정보 수신 동의</string>
+    <string name="term_marketing_term_switch_description">마케팅 정보 수신 동의/해제</string>
 
     <!-- etc -->
     <string name="copyright_2024">Copyright 2024. BCSD Lab. All rights reserved.</string>


### PR DESCRIPTION
issue: #687 

## 개요
* 마케팅 수신 동의 약관 및 알림 추가

## 작업 내용
* 마케팅 수신 동의 약관을 추가했습니다.
* 마케팅 알림 토글을 추가했습니다.

## 스크린샷
|약관|마케팅 수신 알림|권한 동의 다이얼로그|
|--|--|--|
|![image](https://github.com/user-attachments/assets/68948b60-2404-4cd5-9533-8823e481030c)|![image](https://github.com/user-attachments/assets/0c4e878c-703e-42c6-bfee-a7a5b9cf9c4c)|![image](https://github.com/user-attachments/assets/cd36f611-dbcf-4cf3-92bb-aea502327659)|