### PR TITLE
[User][Fix] 로그인 오류 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -37,7 +37,7 @@ class ArticleRepositoryImpl @Inject constructor(
     val user =
         userRepository.getUserInfoFlow().distinctUntilChanged()
             .onEach { user ->
-                if (user.isStudent) {
+                if (user.isStudent || user.isGeneral) {
                     _myKeywords.emit(articleRemoteDataSource.fetchMyKeyword().keywords)
                 } else {
                     _myKeywords.emit(

--- a/data/src/main/java/in/koreatech/koin/data/response/user/GeneralUserResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/user/GeneralUserResponse.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class GeneralUserResponse(
     @SerializedName("id") val id: Int,
     @SerializedName("login_id") val loginId: String,
-    @SerializedName("email") val email: String,
+    @SerializedName("email") val email: String?,
     @SerializedName("anonymous_nickname") val anonymousNickname: String?,
     @SerializedName("gender") val gender: Int,
     @SerializedName("name") val name: String,

--- a/data/src/main/java/in/koreatech/koin/data/response/user/StudentUserResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/user/StudentUserResponse.kt
@@ -9,7 +9,7 @@ data class StudentUserResponse(
     @SerializedName("anonymous_nickname") val anonymousNickname: String?,
     @SerializedName("gender") val gender: Int?, // Old user does not have this field
     @SerializedName("major") val major: String?, // Old user does not have this field
-    @SerializedName("name") val name: String, // Old user does not have this field
+    @SerializedName("name") val name: String?, // Old user does not have this field
     @SerializedName("nickname") val nickname: String?, // Old user does not have this field
     @SerializedName("phone_number") val phoneNumber: String?, // Old user does not have this field
     @SerializedName("student_number") val studentNumber: String?, // Old user does not have this field

--- a/data/src/main/java/in/koreatech/koin/data/response/user/StudentUserResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/user/StudentUserResponse.kt
@@ -5,7 +5,7 @@ import com.google.gson.annotations.SerializedName
 data class StudentUserResponse(
     @SerializedName("id") val id: Int,
     @SerializedName("login_id") val loginId: String,
-    @SerializedName("email") val email: String,
+    @SerializedName("email") val email: String?,
     @SerializedName("anonymous_nickname") val anonymousNickname: String?,
     @SerializedName("gender") val gender: Int?, // Old user does not have this field
     @SerializedName("major") val major: String?, // Old user does not have this field

--- a/data/src/main/java/in/koreatech/koin/data/source/local/UserLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/UserLocalDataSource.kt
@@ -14,6 +14,7 @@ import `in`.koreatech.koin.data.mapper.toUser
 import `in`.koreatech.koin.data.response.user.GeneralUserResponse
 import `in`.koreatech.koin.data.response.user.StudentUserResponse
 import `in`.koreatech.koin.domain.model.user.User
+import `in`.koreatech.koin.domain.model.user.UserType
 import javax.inject.Inject
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -32,7 +33,13 @@ class UserLocalDataSource @Inject constructor(
         userDataStore.data.map { pref ->
             try {
                 if (pref[PREF_KEY_IS_LOGIN] == true) {
-                    return@map Gson().fromJson(pref[PREF_KEY_USER_INFO], StudentUserResponse::class.java).toUser() // Set default userType to STUDENT if logged in
+                    if (pref[PREF_KEY_USER_TYPE] == UserType.STUDENT.name || pref[PREF_KEY_USER_TYPE] == UserType.COUNCIL.name) {
+                        return@map Gson().fromJson(pref[PREF_KEY_USER_INFO], StudentUserResponse::class.java).toUser()
+                    } else if (pref[PREF_KEY_USER_TYPE] == UserType.GENERAL.name) {
+                        return@map Gson().fromJson(pref[PREF_KEY_USER_INFO], GeneralUserResponse::class.java).toUser()
+                    } else {
+                        return@map User.Anonymous
+                    }
                 } else {
                     return@map User.Anonymous
                 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/user/User.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/user/User.kt
@@ -4,7 +4,7 @@ sealed class User {
     data class Student(
         val id: Int,
         val loginId: String,
-        val email: String,
+        val email: String?,
         val anonymousNickname: String?,
         val gender: Gender,
         val major: String?,
@@ -18,7 +18,7 @@ sealed class User {
     data class General(
         val id: Int,
         val loginId: String,
-        val email: String,
+        val email: String?,
         val anonymousNickname: String?,
         val gender: Gender,
         val name: String,


### PR DESCRIPTION
issue: #592 

## 개요
* 로그인 오류 수정

## 작업 내용
* `email` 값이 not-null이던 문제를 수정했습니다.
* `keyword/me` API에 대해 일반인이 Anonymous로 취급되던 문제를 수정했습니다.
* 학생의 `name` 필드를 nullable로 수정했습니다. 기존 유저의 경우 이름이 필수가 아니었습니다.
* `UserLocalDataSource`에서 일반 사용자에 대한 역직렬화 로직이 누락된 문제를 수정했습니다.