### PR TITLE
[Campus][Fix] API 27에서 버스 BottomSheet와 네비게이션바가 겹치던 문제 수정

### DIFF
--- a/feature/bus/src/main/java/in/koreatech/bus/screen/search/composable/SelectPlaceBottomSheet.kt
+++ b/feature/bus/src/main/java/in/koreatech/bus/screen/search/composable/SelectPlaceBottomSheet.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,6 +69,9 @@ internal fun SelectPlaceBottomSheet(
         }
 
     ModalBottomSheet(
+        sheetState = rememberModalBottomSheetState(
+            skipPartiallyExpanded = true
+        ),
         onDismissRequest = onDismissRequest,
         modifier = modifier,
         containerColor = Color.White,
@@ -77,8 +81,7 @@ internal fun SelectPlaceBottomSheet(
             text = sheetTitle,
             style = KoinTheme.typography.medium18,
             fontWeight = FontWeight.SemiBold,
-            modifier =
-            Modifier
+            modifier = Modifier
                 .padding(horizontal = 32.dp)
                 .padding(bottom = 12.dp)
         )
@@ -95,8 +98,7 @@ internal fun SelectPlaceBottomSheet(
                     showClickRipple = false,
                     title = stringResource(it.titleRes),
                     contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
-                    chipColors =
-                    if (disabledPlace == it) {
+                    chipColors = if (disabledPlace == it) {
                         TextChipDefaults.chipColors(
                             unselectedContainerColor = KoinTheme.colors.neutral50,
                             unselectedContentColor = KoinTheme.colors.neutral300
@@ -121,8 +123,7 @@ internal fun SelectPlaceBottomSheet(
 
         Spacer(modifier = Modifier.height(140.dp))
         FilledButton(
-            modifier =
-            Modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 32.dp)
                 .padding(bottom = 36.dp),


### PR DESCRIPTION
close #723 

## 개요
* API 27에서 버스 BottomSheet와 네비게이션바가 겹치던 문제 수정

## 작업내용
* Partically expanded를 비활성화 했습니다.

## 스크린샷
|전|후|
|--|--|
|![Screenshot_20250601-220326](https://github.com/user-attachments/assets/99ceb0e9-cfa1-4ab7-a612-4b6382e38fda)|![Screenshot_20250601-230314](https://github.com/user-attachments/assets/748204ed-8a00-4998-8c98-a1ccbd0c52b7)|