### PR TITLE
[Campus][feature] 동아리 Detail 화면 버튼 padding 값 유동적 변경

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -55,7 +54,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -318,7 +316,7 @@ fun ClubDetail(
                         }
                         state.userId?.let {
                             if (state.clubDetails?.manager == true) {
-                                val dynamicPadding = if((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
+                                val dynamicPadding = if ((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -54,6 +55,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -282,13 +284,17 @@ fun ClubDetail(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Row(
+                            modifier = Modifier.weight(1f),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
                                 text = state.clubDetails?.name ?: "",
                                 style = KoinTheme.typography.bold20,
                                 modifier = Modifier
-                                    .padding(end = 8.dp)
+                                    .padding(end = 16.dp)
+                                    .weight(1f, fill = false),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
                             )
                             Image(
                                 painter = if (state.clubDetails?.isLiked == true) painterResource(id = R.drawable.icon_like_true) else painterResource(id = R.drawable.icon_like_false),
@@ -302,28 +308,30 @@ fun ClubDetail(
                                         } ?: viewModel.showLoginDialog()
                                     }
                             )
-                            if (state.clubDetails?.isLikedHidden == true) {
+                            if (state.clubDetails?.isLikedHidden != true) {
                                 Text(
                                     text = "${state.clubDetails?.likes}",
-                                    style = KoinTheme.typography.medium14
+                                    style = KoinTheme.typography.medium14,
+                                    modifier = Modifier.padding(end = 8.dp)
                                 )
                             }
                         }
                         state.userId?.let {
                             if (state.clubDetails?.manager == true) {
+                                val dynamicPadding = if((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     FilledButton(
                                         text = stringResource(R.string.detail_fix_button),
                                         onClick = {}, // 동아리 정보 수정 버튼 클릭
-                                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 5.dp)
+                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     FilledButton(
                                         text = stringResource(R.string.detail_empowerment_button),
                                         onClick = { viewModel.showEmpowermentDialog() },
-                                        contentPadding = PaddingValues(horizontal = 25.dp, vertical = 5.dp)
+                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
                                     )
                                 }
                             }


### PR DESCRIPTION
## 개요
* 동아리 Detail 화면 버튼 padding 값 유동적 변경

## 작업 내용
* 동아리에 isLikedHidden 값과 동작이 반대로 되던 문제를 수정했습니다.
* 동아리 버튼을 동아리 명칭 길이에 따라 유동적으로 변합니다.
   * 최대한 box 크기에 따라 조정하고 싶었는데 서로가 서로의 크기의 영향을 받기 때문에  구현이 너무나도 어렵습니다...
* 동아리 명칭이 최대 2줄 + overflow 시 ... 처리가 됩니다.


| 사진 (명칭 길이 짧음 [10자 미만]) | 사진 (명칭 길이 짧음 [10자 이상]) | 사진 (명칭 길이 짧음 [최대 길이 초과]) |
|:--:|:--:|:--:|
| <img src = https://github.com/user-attachments/assets/b9e9fe04-8c25-42b4-a667-908ce4e77f3a width = 90%> | <img src = https://github.com/user-attachments/assets/70ca14f7-c51f-4e15-ae7d-eb0f01456789 width = 90%> | <img src = https://github.com/user-attachments/assets/2bc8889d-2427-4f39-b3f1-634f5fce433b width = 90%> |


## 추가 논의 사항