### PR TITLE
[Campus][fix] 동아리 Detail 화면 디자인 수정

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -55,7 +54,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.max
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -318,7 +316,7 @@ fun ClubDetail(
                         }
                         state.userId?.let {
                             if (state.clubDetails?.manager == true) {
-                                val dynamicPadding = if((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
+                                val dynamicPadding = if ((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -316,7 +316,7 @@ fun ClubDetail(
                             maxLines = 2,
                             overflow = TextOverflow.Ellipsis
                         )
-                        Row (
+                        Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Image(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -54,6 +55,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.max
 import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
@@ -282,13 +284,17 @@ fun ClubDetail(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Row(
+                            modifier = Modifier.weight(1f),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
                             Text(
                                 text = state.clubDetails?.name ?: "",
                                 style = KoinTheme.typography.bold20,
                                 modifier = Modifier
-                                    .padding(end = 8.dp)
+                                    .padding(end = 16.dp)
+                                    .weight(1f, fill = false),
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
                             )
                             Image(
                                 painter = if (state.clubDetails?.isLiked == true) painterResource(id = R.drawable.icon_like_true) else painterResource(id = R.drawable.icon_like_false),
@@ -302,28 +308,30 @@ fun ClubDetail(
                                         } ?: viewModel.showLoginDialog()
                                     }
                             )
-                            if (state.clubDetails?.isLikedHidden == true) {
+                            if (state.clubDetails?.isLikedHidden != true) {
                                 Text(
                                     text = "${state.clubDetails?.likes}",
-                                    style = KoinTheme.typography.medium14
+                                    style = KoinTheme.typography.medium14,
+                                    modifier = Modifier.padding(end = 8.dp)
                                 )
                             }
                         }
                         state.userId?.let {
                             if (state.clubDetails?.manager == true) {
+                                val dynamicPadding = if((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
                                 Row(
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
                                     FilledButton(
                                         text = stringResource(R.string.detail_fix_button),
                                         onClick = {}, // 동아리 정보 수정 버튼 클릭
-                                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 5.dp)
+                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
                                     )
                                     Spacer(modifier = Modifier.width(8.dp))
                                     FilledButton(
                                         text = stringResource(R.string.detail_empowerment_button),
                                         onClick = { viewModel.showEmpowermentDialog() },
-                                        contentPadding = PaddingValues(horizontal = 25.dp, vertical = 5.dp)
+                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
                                     )
                                 }
                             }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -295,7 +295,7 @@ fun ClubDetail(
                                     FilledButton(
                                         text = stringResource(R.string.detail_fix_button),
                                         onClick = {}, // 동아리 정보 수정 버튼 클릭
-                                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 5.dp)
+                                        contentPadding = PaddingValues(horizontal = 25.dp, vertical = 5.dp)
                                     )
                                 }
                             }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -313,7 +313,7 @@ fun ClubDetail(
                             modifier = Modifier
                                 .padding(end = 16.dp)
                                 .weight(1f, fill = false),
-                            maxLines = 1,
+                            maxLines = 2,
                             overflow = TextOverflow.Ellipsis
                         )
                         Row (

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -278,22 +278,47 @@ fun ClubDetail(
                 ) {
                     Row(
                         modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        state.userId?.let {
+                            if (state.clubDetails?.manager == true) {
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    FilledButton(
+                                        text = stringResource(R.string.detail_empowerment_button),
+                                        onClick = { viewModel.showEmpowermentDialog() },
+                                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 5.dp)
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    FilledButton(
+                                        text = stringResource(R.string.detail_fix_button),
+                                        onClick = {}, // 동아리 정보 수정 버튼 클릭
+                                        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 5.dp)
+                                    )
+                                }
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
                         horizontalArrangement = Arrangement.SpaceBetween,
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Row(
-                            modifier = Modifier.weight(1f),
+                        Text(
+                            text = state.clubDetails?.name ?: "",
+                            style = KoinTheme.typography.bold20,
+                            modifier = Modifier
+                                .padding(end = 16.dp)
+                                .weight(1f, fill = false),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                        Row (
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                text = state.clubDetails?.name ?: "",
-                                style = KoinTheme.typography.bold20,
-                                modifier = Modifier
-                                    .padding(end = 16.dp)
-                                    .weight(1f, fill = false),
-                                maxLines = 2,
-                                overflow = TextOverflow.Ellipsis
-                            )
                             Image(
                                 painter = if (state.clubDetails?.isLiked == true) painterResource(id = R.drawable.icon_like_true) else painterResource(id = R.drawable.icon_like_false),
                                 contentDescription = "",
@@ -309,33 +334,12 @@ fun ClubDetail(
                             if (state.clubDetails?.isLikedHidden != true) {
                                 Text(
                                     text = "${state.clubDetails?.likes}",
-                                    style = KoinTheme.typography.medium14,
-                                    modifier = Modifier.padding(end = 8.dp)
+                                    style = KoinTheme.typography.medium14
                                 )
                             }
                         }
-                        state.userId?.let {
-                            if (state.clubDetails?.manager == true) {
-                                val dynamicPadding = if ((state.clubDetails?.name ?: "").length >= 10) 5.dp else 24.dp
-                                Row(
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    FilledButton(
-                                        text = stringResource(R.string.detail_fix_button),
-                                        onClick = {}, // 동아리 정보 수정 버튼 클릭
-                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
-                                    )
-                                    Spacer(modifier = Modifier.width(8.dp))
-                                    FilledButton(
-                                        text = stringResource(R.string.detail_empowerment_button),
-                                        onClick = { viewModel.showEmpowermentDialog() },
-                                        contentPadding = PaddingValues(horizontal = dynamicPadding, vertical = 5.dp)
-                                    )
-                                }
-                            }
-                        }
                     }
-                    Spacer(modifier = Modifier.height(12.dp))
+                    Spacer(modifier = Modifier.height(16.dp))
 
                     Column(
                         modifier = Modifier.fillMaxWidth(),


### PR DESCRIPTION
## 개요
* 동아리 Detail 화면 디자인 수정

## 작업 내용
* 동아리에 isLikedHidden 값과 동작이 반대로 되던 문제를 수정했습니다.
* 동아리 수정, 권한 위임 버튼과 동아리 명칭, 좋아요 버튼을 2줄로 나눴습니다.
* 동아리 명칭이 최대 2줄 + overflow 시 ... 처리가 됩니다.

S23+ 환경
| 사진 | 사진 (최대 길이 초과) |
|:--:|:--:|
| <img src = https://github.com/user-attachments/assets/b9302634-7be1-4e68-a31e-d662c597fb3c width = 90%> | <img src = https://github.com/user-attachments/assets/a81e8bcb-0009-4253-bce4-16a760b851fc width = 90%> |


## 추가 논의 사항