### PR TITLE
[Campus][fix] 동아리 Detail QA 1차 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/ClubMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/ClubMapper.kt
@@ -57,7 +57,7 @@ fun ClubDetailsResponse.toClubDetails() = ClubDetails(
     manager,
     isLiked,
     updatedAt,
-    isLikedHidden
+    isLikeHidden
 )
 
 fun ClubQnasResponse.toClubQnasInfo() = ClubQnasInfo(

--- a/data/src/main/java/in/koreatech/koin/data/repository/ClubRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ClubRepositoryImpl.kt
@@ -207,7 +207,7 @@ class ClubRepositoryImpl @Inject constructor(
                     400 -> throw ClubError.AlreadyManager
                     401 -> throw ClubError.Unauthorized
                     403 -> throw ClubError.NotClubManager
-                    404 -> throw ClubError.UserIdNotFound // TODO recover throw ClubError.ClubNotFound
+                    404 -> throw ClubError.UserIdNotFound
                     else -> throw e.getErrorResponse().toKoinUnknownErrorException()
                 }
             }

--- a/data/src/main/java/in/koreatech/koin/data/response/club/ClubDetailsResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/club/ClubDetailsResponse.kt
@@ -18,5 +18,5 @@ data class ClubDetailsResponse(
     @SerializedName("manager") val manager: Boolean,
     @SerializedName("is_liked") val isLiked: Boolean,
     @SerializedName("updated_at") val updatedAt: String,
-    @SerializedName("is_liked_hidden") val isLikedHidden: Boolean
+    @SerializedName("is_like_hidden") val isLikeHidden: Boolean
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/model/club/ClubDetails.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/club/ClubDetails.kt
@@ -16,5 +16,5 @@ data class ClubDetails(
     val manager: Boolean,
     val isLiked: Boolean,
     val updatedAt: String,
-    val isLikedHidden: Boolean
+    val isLikeHidden: Boolean
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -23,6 +23,8 @@ fun String.toUnderlineForHtml() = "<u>$this</u>"
 
 fun String.toColorForHtml(color: String) = "<font color = '#${color.substring(3)}'>$this</font>" // color = #ff000000 형태
 
+fun String.formatInstagramUrlForm() = "${INSTAGRAM_URL}/${this}"
+
 fun String.formatInstagramLinkForm() = "@${this.removePrefix("${INSTAGRAM_URL}/").removeSuffix("/")}"
 
 fun String.isNameFormat(): Boolean = this.matches(Regex("""^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$"""))

--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -23,7 +23,7 @@ fun String.toUnderlineForHtml() = "<u>$this</u>"
 
 fun String.toColorForHtml(color: String) = "<font color = '#${color.substring(3)}'>$this</font>" // color = #ff000000 형태
 
-fun String.formatInstagramUrlForm() = "${INSTAGRAM_URL}/${this}"
+fun String.formatInstagramUrlForm() = "${INSTAGRAM_URL}/$this"
 
 fun String.formatInstagramLinkForm() = "@${this.removePrefix("${INSTAGRAM_URL}/").removeSuffix("/")}"
 

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/model/ParcelizeClubDetails.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/model/ParcelizeClubDetails.kt
@@ -21,7 +21,7 @@ data class ParcelizeClubDetails(
     val manager: Boolean,
     val isLiked: Boolean,
     val updatedAt: String,
-    val isLikedHidden: Boolean
+    val isLikeHidden: Boolean
 ) : Parcelable
 
 fun ClubDetails?.toParcelizeClubDetails(): ParcelizeClubDetails? {
@@ -42,6 +42,6 @@ fun ClubDetails?.toParcelizeClubDetails(): ParcelizeClubDetails? {
         manager = manager,
         isLiked = isLiked,
         updatedAt = updatedAt,
-        isLikedHidden = isLikedHidden
+        isLikeHidden = isLikeHidden
     )
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.feature.club.ui.clubdetail
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -16,7 +17,6 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -25,7 +25,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -39,6 +41,7 @@ import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -47,9 +50,15 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -67,6 +76,7 @@ import `in`.koreatech.koin.domain.constant.KOIN_WEB_STAGE_URL
 import `in`.koreatech.koin.domain.constant.KOIN_WEB_URL
 import `in`.koreatech.koin.domain.constant.LOGIN_ACTIVITY_URL
 import `in`.koreatech.koin.domain.util.ext.formatInstagramLinkForm
+import `in`.koreatech.koin.domain.util.ext.formatInstagramUrlForm
 import `in`.koreatech.koin.domain.util.ext.formatPhoneNumber
 import `in`.koreatech.koin.domain.util.ext.isGoogleFormUrl
 import `in`.koreatech.koin.domain.util.ext.isInstagramUrl
@@ -83,6 +93,7 @@ import `in`.koreatech.koin.feature.club.type.DetailIntroType.DETAIL_LOCATION
 import `in`.koreatech.koin.feature.club.type.DetailIntroType.DETAIL_OPEN_CHAT
 import `in`.koreatech.koin.feature.club.type.DetailIntroType.DETAIL_PHONE_NUMBER
 import `in`.koreatech.koin.feature.club.type.DetailTabType
+import `in`.koreatech.koin.feature.club.ui.clubdetail.component.dialog.DetailImageDialog
 import `in`.koreatech.koin.feature.club.ui.clubdetail.component.dialog.DetailLoginDialog
 import `in`.koreatech.koin.feature.club.ui.clubdetail.component.dialog.content.DetailDialogAddQnaContent
 import `in`.koreatech.koin.feature.club.ui.clubdetail.component.dialog.content.DetailDialogEmpowermentContent
@@ -117,6 +128,9 @@ fun ClubDetail(
     val qnaList = state.clubQnasInfo?.qnas
     val tabList = DetailTabType.entries.map { it.strResId }
 
+    val localDensity = LocalDensity.current
+    val stickyHeaderHeightDp = remember { mutableStateOf(0.dp) }
+
     val pagerState = rememberPagerState(initialPage = initialPage) { tabList.size }
     val scope = rememberCoroutineScope()
 
@@ -125,6 +139,35 @@ fun ClubDetail(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val listState = rememberLazyListState()
+
+    val parentAllScrolled = remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
+
+    val qnaScrollState = rememberScrollState()
+    val isParentScrollable = remember { mutableStateOf(false) }
+    val isChildScrollable = remember { mutableStateOf(false) }
+    val nestedScrollConnection = remember {
+        object : NestedScrollConnection {
+            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+                return if (available.y < 0) {
+                    if (parentAllScrolled.value) {
+                        isChildScrollable.value = true
+                        isParentScrollable.value = false
+                        Offset.Zero
+                    } else {
+                        isChildScrollable.value = false
+                        isParentScrollable.value = true
+                        Offset.Zero
+                    }
+                } else {
+                    if(qnaScrollState.value == 0) {
+                        isChildScrollable.value = false
+                        isParentScrollable.value = true
+                    }
+                    Offset.Zero
+                }
+            }
+        }
+    }
 
     viewModel.collectSideEffect { sideEffect ->
         handleSideEffect(sideEffect, context, snackbarHostState)
@@ -143,6 +186,7 @@ fun ClubDetail(
         containerColor = KoinTheme.colors.neutral0,
         topBar = {
             KoinTopAppBar(
+                modifier = Modifier,
                 title = state.clubDetails?.name ?: "",
                 onNavigationIconClick = onTopbarBackClick
             )
@@ -188,6 +232,17 @@ fun ClubDetail(
         }
     ) { contentPadding ->
 
+        if (state.clubDetails == null) {
+            Column (
+                Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ){
+                CircularProgressIndicator()
+            }
+            return@Scaffold
+        }
+
         if (state.showLoginDialog) {
             DetailLoginDialog(
                 title = stringResource(R.string.detail_dialog_login_title),
@@ -203,7 +258,6 @@ fun ClubDetail(
         if (state.showAddQnaDialog) {
             var addQnaText by remember { mutableStateOf("") }
             DetailDialog(
-                modifier = Modifier,
                 title = stringResource(R.string.detail_add_qna_button),
                 onPositive = {
                     viewModel.addClubQna(
@@ -237,7 +291,7 @@ fun ClubDetail(
                 content = {
                     DetailDialogEmpowermentContent(
                         clubName = state.clubDetails?.name ?: "",
-                        managerId = state.userId ?: -1,
+                        managerId = state.userEmail ?: "",
                         text = newManagerText,
                         onValueChange = { newManagerText = it.trim() },
                         isError = state.textFieldErrorMessageResId != null,
@@ -247,20 +301,34 @@ fun ClubDetail(
             )
         }
 
+        if (state.showImageDialog) {
+            DetailImageDialog (
+                imageModel = ImageRequest.Builder(context)
+                    .data(state.clubDetails?.imageUrl)
+                    .size(400, 400)
+                    .build(),
+                onDismiss = { viewModel.dismissImageDialog() }
+            )
+        }
+
         LazyColumn(
             modifier = Modifier
                 .padding(contentPadding)
                 .consumeWindowInsets(contentPadding)
                 .systemBarsPadding()
-                .fillMaxSize(),
+                .fillMaxSize()
+                .nestedScroll(nestedScrollConnection),
             state = listState,
             horizontalAlignment = Alignment.CenterHorizontally,
-            userScrollEnabled = true
+            userScrollEnabled = isParentScrollable.value
         ) {
             item {
                 SubcomposeAsyncImage(
                     modifier = Modifier
-                        .size(200.dp),
+                        .size(200.dp)
+                        .clickable {
+                            viewModel.showImageDialog()
+                        },
                     model = ImageRequest.Builder(context)
                         .data(state.clubDetails?.imageUrl)
                         .size(400, 400)
@@ -374,14 +442,17 @@ fun ClubDetail(
                                         outputText = "${stringResource(intro.first.strResId)}$it"
                                         onClick = { mutableMaxLine.value = if(mutableMaxLine.value == 2) 10 else 2 }
                                     }
-                                    DETAIL_INSTAGRAM -> outputText = it.formatInstagramLinkForm()
+                                    DETAIL_INSTAGRAM -> {
+                                        linkUrl = if(it.isInstagramUrl()) it else it.formatInstagramUrlForm()
+                                        onClick = { viewModel.openUrl(linkUrl) }
+                                        outputText = it.formatInstagramLinkForm()
+                                    }
                                     DETAIL_GOOGLE_FORM -> outputText = it.removePrefix(HTTPS_URL)
                                     DETAIL_OPEN_CHAT -> outputText = it.removePrefix(HTTPS_URL)
                                     DETAIL_PHONE_NUMBER -> outputText = if (it.isValidPhoneNumber) it.formatPhoneNumber() else it
                                     else -> outputText = it
                                 }
                                 if (
-                                    it.isInstagramUrl() ||
                                     it.isGoogleFormUrl() ||
                                     it.isOpenChatUrl()
                                 ) {
@@ -437,6 +508,10 @@ fun ClubDetail(
             }
             stickyHeader {
                 DetailTabRow(
+                    modifier = Modifier
+                        .onGloballyPositioned { layoutCoordinates ->
+                            stickyHeaderHeightDp.value = with(localDensity) {layoutCoordinates.size.height.toDp()}
+                        },
                     selectedTabIndex = pagerState.currentPage,
                     onTabSelected = {
                         scope.launch {
@@ -447,10 +522,12 @@ fun ClubDetail(
                 )
             }
             item {
-                val deviceHeightDp = LocalConfiguration.current.screenHeightDp.dp
+                val deleteHeightDP = contentPadding.calculateTopPadding().value.dp + 20.dp
+                val deviceHeightDp = LocalConfiguration.current.screenHeightDp.dp - deleteHeightDP
                 HorizontalPager(
                     modifier = Modifier
-                        .fillMaxSize(),
+                        .fillMaxSize()
+                        .height(deviceHeightDp),
                     state = pagerState,
                     verticalAlignment = Alignment.Top
                 ) { page ->
@@ -460,8 +537,7 @@ fun ClubDetail(
                             val snackbarActionLabel = stringResource(R.string.detail_snackbar_detail_intro_button)
                             ClubDetailIntro(
                                 modifier = Modifier
-                                    .fillMaxSize()
-                                    .heightIn(min = deviceHeightDp),
+                                    .fillMaxSize(),
                                 onFixIntroClick = {
                                     scope.launch {
                                         val result = snackbarHostState.showSnackbar(
@@ -488,7 +564,6 @@ fun ClubDetail(
                                     Box(
                                         modifier = Modifier
                                             .fillMaxSize()
-                                            .heightIn(min = deviceHeightDp)
                                             .zIndex(1f)
                                     ) {
                                         CircularProgressIndicator(
@@ -501,7 +576,7 @@ fun ClubDetail(
                                 ClubDetailQna(
                                     modifier = Modifier
                                         .fillMaxSize()
-                                        .heightIn(min = deviceHeightDp),
+                                        .verticalScroll(qnaScrollState, enabled = isChildScrollable.value),
                                     qnaList = qnaList,
                                     isManager = state.clubDetails?.manager ?: false,
                                     userId = state.userId,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -12,14 +12,17 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
@@ -42,22 +45,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
-import androidx.compose.ui.input.nestedscroll.NestedScrollSource
-import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -127,9 +123,6 @@ fun ClubDetail(
     val qnaList = state.clubQnasInfo?.qnas
     val tabList = DetailTabType.entries.map { it.strResId }
 
-    val localDensity = LocalDensity.current
-    val stickyHeaderHeightDp = remember { mutableStateOf(0.dp) }
-
     val pagerState = rememberPagerState(initialPage = initialPage) { tabList.size }
     val scope = rememberCoroutineScope()
 
@@ -139,34 +132,8 @@ fun ClubDetail(
 
     val listState = rememberLazyListState()
 
-    val parentAllScrolled = remember { derivedStateOf { listState.firstVisibleItemIndex > 0 } }
-
     val qnaScrollState = rememberScrollState()
-    val isParentScrollable = remember { mutableStateOf(false) }
-    val isChildScrollable = remember { mutableStateOf(false) }
-    val nestedScrollConnection = remember {
-        object : NestedScrollConnection {
-            override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
-                return if (available.y < 0) {
-                    if (parentAllScrolled.value) {
-                        isChildScrollable.value = true
-                        isParentScrollable.value = false
-                        Offset.Zero
-                    } else {
-                        isChildScrollable.value = false
-                        isParentScrollable.value = true
-                        Offset.Zero
-                    }
-                } else {
-                    if (qnaScrollState.value == 0) {
-                        isChildScrollable.value = false
-                        isParentScrollable.value = true
-                    }
-                    Offset.Zero
-                }
-            }
-        }
-    }
+    val isQnaScrollable = remember { derivedStateOf { !listState.canScrollForward || qnaScrollState.value != 0 } }
 
     viewModel.collectSideEffect { sideEffect ->
         handleSideEffect(sideEffect, context, snackbarHostState)
@@ -291,7 +258,7 @@ fun ClubDetail(
                 content = {
                     DetailDialogEmpowermentContent(
                         clubName = state.clubDetails?.name ?: "",
-                        managerId = state.userEmail ?: "",
+                        managerId = state.userLoginId ?: "",
                         text = newManagerText,
                         onValueChange = { newManagerText = it.trim() },
                         isError = state.textFieldErrorMessageResId != null,
@@ -305,7 +272,7 @@ fun ClubDetail(
             DetailImageDialog(
                 imageModel = ImageRequest.Builder(context)
                     .data(state.clubDetails?.imageUrl)
-                    .size(400, 400)
+                    .size(400)
                     .build(),
                 onDismiss = { viewModel.dismissImageDialog() }
             )
@@ -316,11 +283,10 @@ fun ClubDetail(
                 .padding(contentPadding)
                 .consumeWindowInsets(contentPadding)
                 .systemBarsPadding()
-                .fillMaxSize()
-                .nestedScroll(nestedScrollConnection),
+                .fillMaxSize(),
             state = listState,
             horizontalAlignment = Alignment.CenterHorizontally,
-            userScrollEnabled = isParentScrollable.value
+            userScrollEnabled = qnaScrollState.value == 0
         ) {
             item {
                 SubcomposeAsyncImage(
@@ -331,7 +297,7 @@ fun ClubDetail(
                         },
                     model = ImageRequest.Builder(context)
                         .data(state.clubDetails?.imageUrl)
-                        .size(400, 400)
+                        .size(400)
                         .build(),
                     contentDescription = "Club Image",
                     contentScale = ContentScale.Crop,
@@ -434,13 +400,13 @@ fun ClubDetail(
                             if (intro.second.isNullOrBlank()) return@forEach
                             var outputText = ""
                             var linkUrl = ""
-                            val mutableMaxLine = remember { mutableIntStateOf(2) }
+                            val showMore = remember { mutableStateOf(false) }
                             var onClick = {}
                             intro.second?.let {
                                 when (intro.first) {
                                     DETAIL_DESCRIPTION -> {
                                         outputText = "${stringResource(intro.first.strResId)}$it"
-                                        onClick = { mutableMaxLine.value = if (mutableMaxLine.value == 2) 10 else 2 }
+                                        onClick = { showMore.value = !showMore.value }
                                     }
                                     DETAIL_INSTAGRAM -> {
                                         linkUrl = if (it.isInstagramUrl()) it else it.formatInstagramUrlForm()
@@ -468,15 +434,12 @@ fun ClubDetail(
                                 )
                                 Text(
                                     text = outputText,
-                                    maxLines = if (intro.first == DETAIL_DESCRIPTION) mutableMaxLine.value else 1,
+                                    maxLines = if (intro.first == DETAIL_DESCRIPTION) if (showMore.value) 10 else 2 else 1,
                                     softWrap = false,
                                     style = KoinTheme.typography.medium18,
                                     color = if (linkUrl.isEmpty()) KoinTheme.colors.neutral800 else KoinTheme.colors.info700,
                                     overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier
-                                        .clickable {
-                                            onClick()
-                                        }
+                                    modifier = Modifier.clickable { onClick() }
                                 )
                             }
                         }
@@ -508,10 +471,6 @@ fun ClubDetail(
             }
             stickyHeader {
                 DetailTabRow(
-                    modifier = Modifier
-                        .onGloballyPositioned { layoutCoordinates ->
-                            stickyHeaderHeightDp.value = with(localDensity) { layoutCoordinates.size.height.toDp() }
-                        },
                     selectedTabIndex = pagerState.currentPage,
                     onTabSelected = {
                         scope.launch {
@@ -522,8 +481,8 @@ fun ClubDetail(
                 )
             }
             item {
-                val deleteHeightDP = contentPadding.calculateTopPadding().value.dp + 20.dp
-                val deviceHeightDp = LocalConfiguration.current.screenHeightDp.dp - deleteHeightDP
+                Modifier.windowInsetsTopHeight(WindowInsets.systemBars)
+                val deviceHeightDp = LocalConfiguration.current.screenHeightDp.dp - (contentPadding.calculateTopPadding().value.dp + 24.dp)
                 HorizontalPager(
                     modifier = Modifier
                         .fillMaxSize()
@@ -576,7 +535,7 @@ fun ClubDetail(
                                 ClubDetailQna(
                                     modifier = Modifier
                                         .fillMaxSize()
-                                        .verticalScroll(qnaScrollState, enabled = isChildScrollable.value),
+                                        .verticalScroll(qnaScrollState, enabled = isQnaScrollable.value),
                                     qnaList = qnaList,
                                     isManager = state.clubDetails?.manager ?: false,
                                     userId = state.userId,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -198,6 +198,7 @@ fun ClubDetail(
                 onClick = {
                     scope.launch {
                         listState.animateScrollToItem(0)
+                        qnaScrollState.scrollTo(0)
                     }
                 },
                 elevation = FloatingActionButtonDefaults.elevation(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.feature.club.ui.clubdetail
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -347,7 +348,8 @@ fun ClubDetail(
                                         } ?: viewModel.showLoginDialog()
                                     }
                             )
-                            if (state.clubDetails?.isLikedHidden != true) {
+                            if (state.clubDetails?.isLikeHidden != true) {
+                                Log.e("MYLOG","${state.clubDetails?.isLikeHidden ?: "hi"}")
                                 Text(
                                     text = "${state.clubDetails?.likes}",
                                     style = KoinTheme.typography.medium14

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -364,6 +364,7 @@ fun ClubDetail(
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         detailList.forEach { intro ->
+                            if (intro.second.isNullOrBlank()) return@forEach
                             var outputText = ""
                             var maxLines = 1
                             var linkUrl = ""

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.club.ui.clubdetail
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -159,7 +158,7 @@ fun ClubDetail(
                         Offset.Zero
                     }
                 } else {
-                    if(qnaScrollState.value == 0) {
+                    if (qnaScrollState.value == 0) {
                         isChildScrollable.value = false
                         isParentScrollable.value = true
                     }
@@ -233,11 +232,11 @@ fun ClubDetail(
     ) { contentPadding ->
 
         if (state.clubDetails == null) {
-            Column (
+            Column(
                 Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.Center
-            ){
+            ) {
                 CircularProgressIndicator()
             }
             return@Scaffold
@@ -302,7 +301,7 @@ fun ClubDetail(
         }
 
         if (state.showImageDialog) {
-            DetailImageDialog (
+            DetailImageDialog(
                 imageModel = ImageRequest.Builder(context)
                     .data(state.clubDetails?.imageUrl)
                     .size(400, 400)
@@ -440,10 +439,10 @@ fun ClubDetail(
                                 when (intro.first) {
                                     DETAIL_DESCRIPTION -> {
                                         outputText = "${stringResource(intro.first.strResId)}$it"
-                                        onClick = { mutableMaxLine.value = if(mutableMaxLine.value == 2) 10 else 2 }
+                                        onClick = { mutableMaxLine.value = if (mutableMaxLine.value == 2) 10 else 2 }
                                     }
                                     DETAIL_INSTAGRAM -> {
-                                        linkUrl = if(it.isInstagramUrl()) it else it.formatInstagramUrlForm()
+                                        linkUrl = if (it.isInstagramUrl()) it else it.formatInstagramUrlForm()
                                         onClick = { viewModel.openUrl(linkUrl) }
                                         outputText = it.formatInstagramLinkForm()
                                     }
@@ -468,7 +467,7 @@ fun ClubDetail(
                                 )
                                 Text(
                                     text = outputText,
-                                    maxLines = if(intro.first == DETAIL_DESCRIPTION) mutableMaxLine.value else 1,
+                                    maxLines = if (intro.first == DETAIL_DESCRIPTION) mutableMaxLine.value else 1,
                                     softWrap = false,
                                     style = KoinTheme.typography.medium18,
                                     color = if (linkUrl.isEmpty()) KoinTheme.colors.neutral800 else KoinTheme.colors.info700,
@@ -510,7 +509,7 @@ fun ClubDetail(
                 DetailTabRow(
                     modifier = Modifier
                         .onGloballyPositioned { layoutCoordinates ->
-                            stickyHeaderHeightDp.value = with(localDensity) {layoutCoordinates.size.height.toDp()}
+                            stickyHeaderHeightDp.value = with(localDensity) { layoutCoordinates.size.height.toDp() }
                         },
                     selectedTabIndex = pagerState.currentPage,
                     onTabSelected = {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -239,7 +239,7 @@ fun ClubDetail(
                         clubName = state.clubDetails?.name ?: "",
                         managerId = state.userId ?: -1,
                         text = newManagerText,
-                        onValueChange = { newManagerText = it },
+                        onValueChange = { newManagerText = it.trim() },
                         isError = state.textFieldErrorMessageResId != null,
                         errorMessage = state.textFieldErrorMessageResId?.let { stringResource(it) } ?: ""
                     )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.club.ui.clubdetail
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
-import android.util.Log
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -41,6 +40,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -349,7 +349,6 @@ fun ClubDetail(
                                     }
                             )
                             if (state.clubDetails?.isLikeHidden != true) {
-                                Log.e("MYLOG","${state.clubDetails?.isLikeHidden ?: "hi"}")
                                 Text(
                                     text = "${state.clubDetails?.likes}",
                                     style = KoinTheme.typography.medium14
@@ -366,13 +365,14 @@ fun ClubDetail(
                         detailList.forEach { intro ->
                             if (intro.second.isNullOrBlank()) return@forEach
                             var outputText = ""
-                            var maxLines = 1
                             var linkUrl = ""
+                            val mutableMaxLine = remember { mutableIntStateOf(2) }
+                            var onClick = {}
                             intro.second?.let {
                                 when (intro.first) {
                                     DETAIL_DESCRIPTION -> {
-                                        maxLines = 2
                                         outputText = "${stringResource(intro.first.strResId)}$it"
+                                        onClick = { mutableMaxLine.value = if(mutableMaxLine.value == 2) 10 else 2 }
                                     }
                                     DETAIL_INSTAGRAM -> outputText = it.formatInstagramLinkForm()
                                     DETAIL_GOOGLE_FORM -> outputText = it.removePrefix(HTTPS_URL)
@@ -386,6 +386,7 @@ fun ClubDetail(
                                     it.isOpenChatUrl()
                                 ) {
                                     linkUrl = it
+                                    onClick = { if (linkUrl.isNotEmpty()) viewModel.openUrl(linkUrl) }
                                 }
                             }
                             Row {
@@ -396,13 +397,14 @@ fun ClubDetail(
                                 )
                                 Text(
                                     text = outputText,
-                                    maxLines = maxLines,
+                                    maxLines = if(intro.first == DETAIL_DESCRIPTION) mutableMaxLine.value else 1,
+                                    softWrap = false,
                                     style = KoinTheme.typography.medium18,
                                     color = if (linkUrl.isEmpty()) KoinTheme.colors.neutral800 else KoinTheme.colors.info700,
                                     overflow = TextOverflow.Ellipsis,
                                     modifier = Modifier
                                         .clickable {
-                                            if (linkUrl.isNotEmpty()) viewModel.openUrl(linkUrl)
+                                            onClick()
                                         }
                                 )
                             }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailState.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailState.kt
@@ -9,7 +9,7 @@ import kotlinx.parcelize.Parcelize
 data class ClubDetailState(
     val isLoading: Boolean = false,
     val userId: Int? = null,
-    val userEmail: String? = null,
+    val userLoginId: String? = null,
     val clubId: Int = -1,
     val clubDetails: ParcelizeClubDetails? = null,
     val clubQnasInfo: ParcelizeClubQnasInfo? = null,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailState.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailState.kt
@@ -9,6 +9,7 @@ import kotlinx.parcelize.Parcelize
 data class ClubDetailState(
     val isLoading: Boolean = false,
     val userId: Int? = null,
+    val userEmail: String? = null,
     val clubId: Int = -1,
     val clubDetails: ParcelizeClubDetails? = null,
     val clubQnasInfo: ParcelizeClubQnasInfo? = null,
@@ -16,5 +17,6 @@ data class ClubDetailState(
     val showLoginDialog: Boolean = false,
     val showAddQnaDialog: Boolean = false,
     val showEmpowermentDialog: Boolean = false,
+    val showImageDialog: Boolean = false,
     val textFieldErrorMessageResId: Int? = null
 ) : Parcelable

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -75,10 +75,10 @@ class ClubDetailViewModel @Inject constructor(
         userInfoFlow.collect { user ->
             when (user) {
                 is User.Anonymous -> {
-                    reduce { state.copy(userId = null) }
+                    reduce { state.copy(userId = null, userEmail = null) }
                 }
                 is User.Student -> {
-                    reduce { state.copy(userId = user.id) }
+                    reduce { state.copy(userId = user.id, userEmail = user.email) }
                 }
             }
         }
@@ -314,5 +314,13 @@ class ClubDetailViewModel @Inject constructor(
 
     fun openUrl(url: String) = intent {
         postSideEffect(ClubDetailSideEffect.OpenUrl(url))
+    }
+
+    fun showImageDialog() = intent {
+        reduce { state.copy(showImageDialog = true) }
+    }
+
+    fun dismissImageDialog() = intent {
+        reduce { state.copy(showImageDialog = false) }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -75,10 +75,10 @@ class ClubDetailViewModel @Inject constructor(
         userInfoFlow.collect { user ->
             when (user) {
                 is User.Anonymous -> {
-                    reduce { state.copy(userId = null, userEmail = null) }
+                    reduce { state.copy(userId = null, userLoginId = null) }
                 }
                 is User.Student -> {
-                    reduce { state.copy(userId = user.id, userEmail = user.email) }
+                    reduce { state.copy(userId = user.id, userLoginId = user.email?.removeSuffix("@koreatech.ac.kr")) }
                 }
             }
         }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -139,7 +139,7 @@ class ClubDetailViewModel @Inject constructor(
     ) = intent {
         if (state.isLoading) return@intent
         reduce { state.copy(isLoading = true) }
-        if (content.isEmpty()) {
+        if (content.isBlank()) {
             reduce {
                 state.copy(
                     isLoading = false,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/DetailImageDialog.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/DetailImageDialog.kt
@@ -1,0 +1,57 @@
+package `in`.koreatech.koin.feature.club.ui.clubdetail.component.dialog
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.BasicAlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.stringResource
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
+import `in`.koreatech.koin.feature.club.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DetailImageDialog(
+    imageModel: ImageRequest,
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit = {},
+) {
+    BasicAlertDialog(
+        modifier =
+        modifier
+            .fillMaxWidth()
+            .wrapContentHeight(),
+        onDismissRequest = { onDismiss() }
+    ) {
+        SubcomposeAsyncImage(
+            modifier = Modifier
+                .fillMaxSize(),
+            model = imageModel,
+            contentDescription = "Club Image",
+            contentScale = ContentScale.FillWidth,
+            alignment = Alignment.Center,
+            loading = {
+                Box(
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            },
+            error = {
+                Box(
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(stringResource(R.string.detail_club_image_error))
+                }
+            }
+        )
+    }
+}

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/DetailImageDialog.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/DetailImageDialog.kt
@@ -22,7 +22,7 @@ import `in`.koreatech.koin.feature.club.R
 fun DetailImageDialog(
     imageModel: ImageRequest,
     modifier: Modifier = Modifier,
-    onDismiss: () -> Unit = {},
+    onDismiss: () -> Unit = {}
 ) {
     BasicAlertDialog(
         modifier =

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
@@ -5,8 +5,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
@@ -21,7 +21,7 @@ import `in`.koreatech.koin.feature.club.ui.clubdetail.component.textfield.Detail
 @Composable
 fun DetailDialogEmpowermentContent(
     clubName: String,
-    managerId: Int,
+    managerId: String?,
     modifier: Modifier = Modifier,
     text: String = "",
     isError: Boolean = false,
@@ -56,7 +56,7 @@ fun DetailDialogEmpowermentContent(
                 color = KoinTheme.colors.neutral800
             )
             Text(
-                text = managerId.toString(),
+                text = managerId?.removeSuffix("@koreatech.ac.kr") ?: "",
                 style = KoinTheme.typography.medium16,
                 color = KoinTheme.colors.neutral800
             )
@@ -69,19 +69,18 @@ fun DetailDialogEmpowermentContent(
                 style = KoinTheme.typography.medium16,
                 color = KoinTheme.colors.neutral800
             )
-            Spacer(modifier = Modifier.width(4.dp))
-            DetailQnaTextField(
-                value = text,
-                hint = stringResource(R.string.detail_dialog_empowerment_hint),
-                textStyle = KoinTheme.typography.regular14,
-                hintColor = KoinTheme.colors.neutral700,
-                onValueChange = onValueChange,
-                isSendIconVisible = false,
-                isError = isError,
-                errorMessage = errorMessage,
-                contentPadding = PaddingValues(horizontal = 16.dp, vertical = 7.dp)
-            )
         }
+        DetailQnaTextField(
+            value = text,
+            hint = stringResource(R.string.detail_dialog_empowerment_hint),
+            textStyle = KoinTheme.typography.regular14,
+            hintColor = KoinTheme.colors.neutral700,
+            onValueChange = onValueChange,
+            isSendIconVisible = false,
+            isError = isError,
+            errorMessage = errorMessage,
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 7.dp)
+        )
     }
 }
 
@@ -90,7 +89,7 @@ fun DetailDialogEmpowermentContent(
 fun DetailDialogEmpowermentContentPreView() {
     DetailDialogEmpowermentContent(
         clubName = "bcsd",
-        managerId = 6488,
+        managerId = "6488",
         modifier = Modifier
             .background(
                 color = KoinTheme.colors.neutral0
@@ -103,7 +102,7 @@ fun DetailDialogEmpowermentContentPreView() {
 fun DetailDialogEmpowermentContentErrorPreView() {
     DetailDialogEmpowermentContent(
         clubName = "bcsd",
-        managerId = 6488,
+        managerId = "6488",
         modifier = Modifier
             .background(
                 color = KoinTheme.colors.neutral0

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/dialog/content/DetailDialogEmpowermentContent.kt
@@ -19,7 +19,7 @@ import `in`.koreatech.koin.feature.club.ui.clubdetail.component.textfield.Detail
 @Composable
 fun DetailDialogEmpowermentContent(
     clubName: String,
-    managerId: String?,
+    managerId: String,
     modifier: Modifier = Modifier,
     text: String = "",
     isError: Boolean = false,
@@ -54,7 +54,7 @@ fun DetailDialogEmpowermentContent(
                 color = KoinTheme.colors.neutral800
             )
             Text(
-                text = managerId?.removeSuffix("@koreatech.ac.kr") ?: "",
+                text = managerId,
                 style = KoinTheme.typography.medium16,
                 color = KoinTheme.colors.neutral800
             )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
@@ -25,7 +25,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
@@ -169,7 +168,7 @@ fun DetailQnaBox(
                                     .size(20.dp)
                                     .padding(end = 4.dp)
                                     .clickable {
-                                        showDeleteQnaDialog = Pair(true, qnaId)
+                                        showDeleteQnaDialog = Pair(true, answerQnaId)
                                     }
                             )
                         }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
@@ -158,8 +158,6 @@ fun DetailQnaBox(
                         Text(
                             text = "$answerText",
                             style = KoinTheme.typography.regular18,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
                             modifier = Modifier
                                 .weight(1f)
                         )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/qnabox/DetailQnaBox.kt
@@ -99,8 +99,6 @@ fun DetailQnaBox(
                 Text(
                     text = "Q. $questionText",
                     style = KoinTheme.typography.regular18,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
                     modifier = Modifier
                         .weight(1f)
                 )
@@ -146,7 +144,7 @@ fun DetailQnaBox(
                             textFieldColor = KoinTheme.colors.primary300,
                             onValueChange = onAddAnswerTextChange,
                             onSendClick = {
-                                if (addAnswerText.isNotEmpty()) {
+                                if (addAnswerText.isNotBlank()) {
                                     onAddAnswerClick(qnaId, addAnswerText)
                                     isError = false
                                 } else {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/tabrow/DetailTabRow.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/tabrow/DetailTabRow.kt
@@ -29,7 +29,7 @@ fun DetailTabRow(
     indicator: @Composable (tabPositions: List<TabPosition>) -> Unit = @Composable { tabPositions ->
         if (selectedTabIndex < tabPositions.size) {
             TabRowDefaults.SecondaryIndicator(
-                modifier = modifier
+                modifier = Modifier
                     .tabIndicatorOffset(tabPositions[selectedTabIndex])
                     .height(1.dp),
                 color = indicatorColor

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
@@ -50,6 +50,7 @@ fun DetailQnaTextField(
     errorIconModifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(horizontal = 10.dp, vertical = 7.dp)
 ) {
+    val inputMaxLenght = 255
     Column(
         verticalArrangement = Arrangement
             .spacedBy(4.dp)
@@ -58,7 +59,13 @@ fun DetailQnaTextField(
             modifier = Modifier,
             value = value,
             textStyle = textStyle,
-            onValueChange = { if (it.length <= 255) onValueChange(it) },
+            onValueChange = {
+                if (it.length < inputMaxLenght) {
+                    onValueChange(it)
+                } else {
+                    onValueChange(it.take(inputMaxLenght))
+                }
+            },
             decorationBox = { innerTextField ->
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
@@ -58,7 +58,7 @@ fun DetailQnaTextField(
             modifier = Modifier,
             value = value,
             textStyle = textStyle,
-            onValueChange = { if(it.length <= 255) onValueChange(it) },
+            onValueChange = { if (it.length <= 255) onValueChange(it) },
             decorationBox = { innerTextField ->
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
@@ -58,7 +58,7 @@ fun DetailQnaTextField(
             modifier = Modifier,
             value = value,
             textStyle = textStyle,
-            onValueChange = { onValueChange(it) },
+            onValueChange = { if(it.length <= 255) onValueChange(it) },
             decorationBox = { innerTextField ->
                 Row(
                     horizontalArrangement = Arrangement.SpaceBetween,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -41,9 +43,10 @@ fun ClubDetailIntro(
                 )
             }
         }
+        Spacer(Modifier.height(200.dp))
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxWidth(),
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
@@ -4,12 +4,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -17,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.club.R

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
@@ -1,16 +1,23 @@
 package `in`.koreatech.koin.feature.club.ui.clubdetail.intro
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.club.R
@@ -41,8 +48,14 @@ fun ClubDetailIntro(
         }
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
+            Text(
+                text = stringResource(R.string.detail_detail_intro_in_development),
+                style = KoinTheme.typography.bold20
+            )
         }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
@@ -1,16 +1,12 @@
 package `in`.koreatech.koin.feature.club.ui.clubdetail.qna
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
@@ -1,12 +1,16 @@
 package `in`.koreatech.koin.feature.club.ui.clubdetail.qna
 
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/qna/ClubDetailQna.kt
@@ -39,17 +39,19 @@ fun ClubDetailQna(
         verticalArrangement = Arrangement.spacedBy(12.dp)
     ) {
         userId?.let {
-            Row {
-                Spacer(Modifier.weight(1f))
-                FilledButton(
-                    modifier = Modifier
-                        .padding(
-                            bottom = 4.dp
-                        ),
-                    text = stringResource(R.string.detail_add_qna_button),
-                    onClick = onAddQnaClick,
-                    contentPadding = PaddingValues(horizontal = 22.dp, vertical = 5.dp)
-                )
+            if (!isManager) {
+                Row {
+                    Spacer(Modifier.weight(1f))
+                    FilledButton(
+                        modifier = Modifier
+                            .padding(
+                                bottom = 4.dp
+                            ),
+                        text = stringResource(R.string.detail_add_qna_button),
+                        onClick = onAddQnaClick,
+                        contentPadding = PaddingValues(horizontal = 22.dp, vertical = 5.dp)
+                    )
+                }
             }
         }
         qnaList?.forEach {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -61,7 +61,7 @@ class ClubModifyViewModel @Inject constructor(
                         googleFormUrl = it.googleForm ?: "",
                         openChatUrl = it.openChat ?: "",
                         phoneNumber = it.phoneNumber ?: "",
-                        isLikeHidden = it.isLikedHidden,
+                        isLikeHidden = it.isLikeHidden,
                         likes = it.likes
                     )
                 }

--- a/feature/club/src/main/res/values/strings.xml
+++ b/feature/club/src/main/res/values/strings.xml
@@ -30,8 +30,9 @@
     <string name="detail_dialog_empowerment_title">권한 위임</string>
     <string name="detail_dialog_empowerment_club_name">동아리명:&#160;</string>
     <string name="detail_dialog_empowerment_old_id">현 권한자 아이디:&#160;</string>
-    <string name="detail_dialog_empowerment_new_id">향후 권한자 아이디:</string>
+    <string name="detail_dialog_empowerment_new_id">향후 권한자 아이디</string>
     <string name="detail_dialog_empowerment_hint">아이디를 입력해주세요.</string>
+    <string name="detail_detail_intro_in_development">아직 준비중입니다.</string>
 
     <string name="detail_error_empty_text_field">필수 입력란입니다.</string>
     <string name="detail_error_unauthorized">올바르지 않은 인증 정보입니다.</string>


### PR DESCRIPTION
issue:#739

## 개요
* 동아리 Detail QA 수정

## 작업 내용
구조가 더러운 것 같지만 일단 모두 수정, 구현했습니다.

clubDetails 객체를 나누지 않고 그대로 state 로 유지하는건 위험하지만
현재 clubDetails 내부에 특정 값을 바꾸는 코드 없이 오로지 clubDetails 만 갱신하므로
일단 현재 구조를 유지하겠습니다.

* id 입력에 공백을 금지했습니다.
* 좋아요 숨김처리 미적용 해결 - O
* qna 질문 표시 제한 해제 - O
* TextField 에 공백만 넣으면 터지는 오류 수정 - O
* TextField 에 최대 입력 길이 지정(255자) - O
* Dialog 에 글자가 깨지는 디자인 수정 - O
* 권한 위임에 잘못된 id 값 필드 수정 - O
* 답글 제거시 qna 자체가 제거되는 오류 수정 - O
* 동아리 이미지 클릭시 확대 이미지 보여주기 - O
* 동아리 정보에 빈값들은 출력 안함 - O
* 동아리 소개에 더보기 기능 추가 - O
* 화면 전체 로딩창 추가 - O
* tab 내부 고정값 화면 크기 유동적으로 변경 - O ( 이중 스크롤 구현 성공 > 단 매끄럽지 않음 )
* 상세 소개에 준비중입니다. 메시지 띄우기 - O
* 인스타 링크 id만 적어도 대응하기 - O


| 화면 | 사진 확대 | 권한 위임(+글자제한) |
|:--:|:--:|:--:|
| <img src = https://github.com/user-attachments/assets/39fc9dc2-92e9-4638-9323-e6f727a57fbf width = 80% > | <img src = https://github.com/user-attachments/assets/f4e82b27-73e9-40a9-bca4-7254f504016f width = 80% > | <img src = https://github.com/user-attachments/assets/7073fc35-cadb-43a3-8645-68171a9f65da width = 80% > |
