### PR TITLE
[Koin Project][Chore] API 요청 시 빈 String 대신 null로 보내도록 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/di/network/NoAuthNetworkModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/network/NoAuthNetworkModule.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.di.network
 
+import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -20,6 +21,7 @@ import `in`.koreatech.koin.data.api.StoreApi
 import `in`.koreatech.koin.data.api.TimetableApi
 import `in`.koreatech.koin.data.api.UserApi
 import `in`.koreatech.koin.data.api.VersionApi
+import `in`.koreatech.koin.data.util.EmptyStringToNullAdapter
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 import okhttp3.OkHttpClient
@@ -49,10 +51,12 @@ object NoAuthNetworkModule {
         @ServerUrl baseUrl: String,
         @NoAuth okHttpClient: OkHttpClient
     ): Retrofit {
+        val gson = GsonBuilder().registerTypeAdapter(String::class.java, EmptyStringToNullAdapter()).create()
+
         return Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl(baseUrl)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/util/EmptyStringToNullAdapter.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/EmptyStringToNullAdapter.kt
@@ -1,0 +1,18 @@
+package `in`.koreatech.koin.data.util
+
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonPrimitive
+import com.google.gson.JsonSerializationContext
+import com.google.gson.JsonSerializer
+import java.lang.reflect.Type
+
+class EmptyStringToNullAdapter : JsonSerializer<String> {
+    override fun serialize(src: String?, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
+        return if (src.isNullOrEmpty()) {
+            JsonNull.INSTANCE
+        } else {
+            JsonPrimitive(src)
+        }
+    }
+}

--- a/koin/src/main/java/in/koreatech/koin/di/network/AuthNetworkModule.kt
+++ b/koin/src/main/java/in/koreatech/koin/di/network/AuthNetworkModule.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.di.network
 
 import android.content.Context
+import com.google.gson.GsonBuilder
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -24,6 +25,7 @@ import `in`.koreatech.koin.data.api.auth.OwnerAuthApi
 import `in`.koreatech.koin.data.api.auth.TimetableAuthApi
 import `in`.koreatech.koin.data.api.auth.UserAuthApi
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
+import `in`.koreatech.koin.data.util.EmptyStringToNullAdapter
 import `in`.koreatech.koin.di.userAgent.UserAgentInterceptor
 import `in`.koreatech.koin.di.userAgent.UserAgentProvider
 import `in`.koreatech.koin.domain.usecase.user.DeleteUserRefreshTokenUseCase
@@ -112,10 +114,12 @@ object AuthNetworkModule {
         @ServerUrl baseUrl: String,
         @Auth okHttpClient: OkHttpClient
     ): Retrofit {
+        val gson = GsonBuilder().registerTypeAdapter(String::class.java, EmptyStringToNullAdapter()).create()
+
         return Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl(baseUrl)
-            .addConverterFactory(GsonConverterFactory.create())
+            .addConverterFactory(GsonConverterFactory.create(gson))
             .build()
     }
 


### PR DESCRIPTION
close #768 

## 개요
* API 요청 시 빈 String 대신 null로 보내도록 수정

## 작업 내용
* `EmptyStringToNullAdapter`를 추가했습니다