### PR TITLE
[Campus][Fix] 잘못된 동아리 카테고리 아이템을 가져오던 문제 수정

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
@@ -79,7 +79,8 @@ fun ClubListScreen(
 
     val snackbarHostState = remember { SnackbarHostState() }
 
-    LaunchedEffect(Unit, uiState.categoryId) {
+    LaunchedEffect(uiState.isInitialized) {
+        if (!uiState.isInitialized) return@LaunchedEffect
         viewModel.getClubs()
     }
 

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListState.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListState.kt
@@ -7,6 +7,7 @@ import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class ClubListState(
+    val isInitialized: Boolean = false,
     val isLoading: Boolean = false,
     val categoryId: Int? = null,
     val sortType: ClubSort = ClubSort.NONE,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
@@ -35,7 +35,7 @@ class ClubListViewModel @Inject constructor(
             val categoryId = savedStateHandle.get<Int?>(CATEGORY_ID)
             intent {
                 reduce {
-                    state.copy(categoryId = categoryId.takeIf { it != -1 })
+                    state.copy(categoryId = categoryId.takeIf { it != -1 }, isInitialized = true)
                 }
             }
         }


### PR DESCRIPTION
close #774 

## 개요
* 잘못된 동아리 카테고리 아이템을 가져오던 문제 수정

## 작업 내용
* category id가 초기화 되기 전에 API 요청을 시도해 잘못된 데이터를 가져오던 문제를 수정했습니다.