### PR TITLE
[Campus][Fix] 동아리 detail 에 설명란이 한줄만 출력되는 버그 수정

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -456,7 +456,6 @@ fun ClubDetail(
                                 Text(
                                     text = outputText,
                                     maxLines = if (intro.first == DETAIL_DESCRIPTION) if (showMore.value) 10 else 2 else 1,
-                                    softWrap = false,
                                     style = KoinTheme.typography.medium18,
                                     color = if (linkUrl.isEmpty()) KoinTheme.colors.neutral800 else KoinTheme.colors.info700,
                                     overflow = TextOverflow.Ellipsis,


### PR DESCRIPTION
issue #759 

## 개요
* 동아리 detail 에 설명란이 한줄만 출력되는 버그 수정 (더보기가 동작 안함)

## 작업내용
* Text 에 줄넘김 방지 조건을 해제했습니다.