### PR TITLE
[KoinProject][Fix] PR Label 생성기가 release 브랜치에도 적용되는 오류 수정

### DIFF
--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -21,7 +21,7 @@ jobs:
           CAMPUS_REGEX="\[[cC][aA][mM][pP][uU][sS]\]"
           BUSINESS_REGEX="\[[bB][uU][sS][iI][nN][eE][sS][sS]\]"
           USER_REGEX="\[[uU][sS][eE][rR]\]"
-          KOIN_PROJECT_REGEX="\[[kK][oO][iI][nN][[:space:]][pP][rR][oO][jJ][eE][cC][tT]\]"
+          KOIN_PROJECT_REGEX="\[[kK][oO][iI][nN][[:space:]]?[pP][rR][oO][jJ][eE][cC][tT]\]"
 
           # Team 별 TAG
           CAMPUS_TAG="campus"

--- a/.github/workflows/auto_pr_label_adder.yml
+++ b/.github/workflows/auto_pr_label_adder.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto_pr_label_adder:
-    if: github.base_ref != 'production'
+    if: github.base_ref != 'production' || !startsWith(github.head_ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - name: Check Team and Job From PR


### PR DESCRIPTION
close #760

## 개요
* PR Label 생성기가 release 브랜치에도 적용되는 오류 수정
* KoinProject 검사에 Koin 과 Project 사이의 공백이 있어도, 없어도 검사하도록 수정

## 작업 내용
* 이제 auto-pr-laber 작업이 release/ 로 시작하는 브랜치는 검사하지 않습니다.
* 이제 Koin Project 와 KoinProject 둘 다 인식 가능합니다. 