### PR TITLE
[Campus][Fix] 뒤로가기 동작이 다른 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
@@ -154,7 +154,7 @@ class ArticleActivity : ActivityBase() {
 
     private fun setToolbar(state: ArticleToolbarState) {
         binding.toolbarArticleList.apply {
-            setOnNavigationIconClickListener { finish() }
+            setOnNavigationIconClickListener { onBackPressedCallback.handleOnBackPressed() }
             setTitle(getString(state.title))
             setMenus(
                 ToolbarMenu(

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
@@ -95,6 +95,7 @@ class ArticleActivity : ActivityBase() {
         when (link) {
             "article_keyword" -> {
                 setNavigationGraph()
+                navController.popBackStack()
                 navController.navigate(
                     R.id.articleKeywordFragment
                 ) // See ArticleKeywordFragment, LoginActivity
@@ -103,6 +104,7 @@ class ArticleActivity : ActivityBase() {
                 setNavigationGraph()
                 val articleId = uri.getQueryParameter("article_id")?.toIntOrNull() ?: 0
                 val boardId = uri.getQueryParameter("board_id")?.toIntOrNull() ?: 0
+                navController.popBackStack()
                 navController.navigate(
                     R.id.articleDetailFragment,
                     bundleOf(


### PR DESCRIPTION
close #788 

## 개요
* 뒤로가기 동작이 다른 문제 수정

작업 내용
* 뒤로가기 클릭 시 onbackpresseddispatcher를 사용하도록 수정했습니다.
* 딥링크를 통해 게시글, 키워드 알림 화면에 접근할 경우, backstack을 날려 최상위 화면이 되도록 수정했습니다.