### PR TITLE
[Campus][Fix] 배너 광고 누락된 이미지 캐싱 적용

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,9 +61,11 @@ dependencies {
     // Dependency - leakcanary
     debugImplementation(libs.leakcanary.android)
 
-    // Dependency - glide
+    // Dependency - glide & coil
     implementation(libs.glide)
     ksp(libs.glide.ksp)
+    implementation(libs.coil)
+    implementation(libs.coil.gif)
 
     // Dependency - sticky scroll view
     api(libs.stickyScrollView)

--- a/core/src/main/java/in/koreatech/koin/core/util/KoinCoilImageLoader.kt
+++ b/core/src/main/java/in/koreatech/koin/core/util/KoinCoilImageLoader.kt
@@ -1,0 +1,27 @@
+package `in`.koreatech.koin.core.util
+
+import android.content.Context
+import android.os.Build
+import coil.ImageLoader
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
+import coil.util.DebugLogger
+import `in`.koreatech.koin.core.BuildConfig
+
+object KoinCoilImageLoader {
+    fun getImageLoader(context: Context, useGif: Boolean = false): ImageLoader {
+        return ImageLoader.Builder(context)
+            .logger(if (BuildConfig.IS_DEBUG) DebugLogger() else null)
+            .components {
+                if (useGif) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        add(ImageDecoderDecoder.Factory())
+                    } else {
+                        add(GifDecoder.Factory())
+                    }
+                }
+            }
+            .respectCacheHeaders(false)
+            .build()
+    }
+}

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -13,6 +13,9 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -32,6 +35,7 @@ import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.toast.ToastUtil
+import `in`.koreatech.koin.core.util.KoinCoilImageLoader
 import `in`.koreatech.koin.domain.constant.KOIN_PLAYSTORE_URL
 import `in`.koreatech.koin.feature.banner.BANNER_AUTO_SCROLL_MILLISECONDS
 import `in`.koreatech.koin.feature.banner.R
@@ -113,6 +117,9 @@ private fun BannerContent(
     dismiss: () -> Unit = {}
 ) {
     val context = LocalContext.current
+
+    val resizedImageUrl by remember(banner.imageUrl) { mutableStateOf(ImageUtil.getResizedImageUrl(banner.imageUrl, width = 400)) }
+
     SubcomposeAsyncImage(
         modifier = modifier
             .fillMaxSize()
@@ -136,8 +143,10 @@ private fun BannerContent(
                 dismiss()
             },
         contentScale = ContentScale.Crop,
+        imageLoader = KoinCoilImageLoader.getImageLoader(context),
         model = ImageRequest.Builder(LocalContext.current)
-            .data(ImageUtil.getResizedImageUrl(banner.imageUrl, width = 400))
+            .data(resizedImageUrl)
+            .diskCacheKey(resizedImageUrl)
             .crossfade(true)
             .build(),
         alignment = Alignment.BottomCenter,

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerImage.kt
@@ -146,7 +146,6 @@ private fun BannerContent(
         imageLoader = KoinCoilImageLoader.getImageLoader(context),
         model = ImageRequest.Builder(LocalContext.current)
             .data(resizedImageUrl)
-            .diskCacheKey(resizedImageUrl)
             .crossfade(true)
             .build(),
         alignment = Alignment.BottomCenter,


### PR DESCRIPTION
Closes #817 

## 개요
* 배너 광고 누락된 이미지 캐싱 적용

## 작업 내용
* `KoinCoilImageLoader`를 추가했습니다.
* 누락된 이미지 배너 이미지 캐싱을 추가했습니다.

## 추가적인 내용
* 백엔드 서버에서 내려주는 응답에 [Cache-Control](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Cache-Control) 헤더가 포함되지 않아, coil에서 이미지가 디스크에 캐싱되어 있더라도 캐싱된 이미지를 사용하지 않고 매번 새 이미지를 요청합니다.
* 이를 해결하기 위해, `respectCacheHeaders(false)`를 선언하여 Cache-Control 헤더를 무시하고 항상 캐싱된 이미지를 사용하도록 수정했습니다.