### PR TITLE
[User][Fix] 유저팀 스프린트 QA 수정

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/ext/StringExtensions.kt
@@ -36,7 +36,7 @@ fun String.formatInstagramUrlForm() = "${INSTAGRAM_URL}/$this"
 
 fun String.formatInstagramLinkForm() = "@${this.removePrefix("${INSTAGRAM_URL}/").removeSuffix("/")}"
 
-fun String.isNameFormat(): Boolean = this.matches(Regex("""^[ㄱ-ㅎ가-힣a-zA-Z0-9]+$"""))
+fun String.isNameFormat(): Boolean = this.matches(Regex("""^(?:[가-힣]{2,5}|[A-Za-z]{2,30})${'$'}"""))
 
 fun String.isLoginIdFormat(): Boolean = this.matches(Regex("""^[a-z0-9_.-]+${'$'}""")) && this.length in 5..13
 

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerification.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerification.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -186,7 +187,7 @@ fun FindPasswordVerificationImpl(
                 hint = stringResource(if (isSms) R.string.find_password_phone_number_hint else R.string.find_password_email_hint),
                 onValueChange = onVerificationMethodChange,
                 maxLength = if (isSms) PHONE_NUMBER_LENGTH else Int.MAX_VALUE,
-                visualTransformation = KRPhoneNumberVisualTransformation()
+                visualTransformation = if (isSms) KRPhoneNumberVisualTransformation() else VisualTransformation.None
             )
 
             Spacer(modifier = Modifier.width(16.dp))

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerification.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerification.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.user.ui.signup.verification
 
+import android.app.Activity
 import android.content.Intent
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -452,6 +453,7 @@ private fun PhoneNumberDuplicateMessage() {
                     .noRippleClickable {
                         val intent = Intent(context, SignInActivity::class.java)
                         context.startActivity(intent)
+                        (context as Activity).finish()
                     },
                 text = stringResource(R.string.sign_up_phone_number_already_sign_up),
                 color = KoinTheme.colors.primary500,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerificationState.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerificationState.kt
@@ -1,8 +1,7 @@
 package `in`.koreatech.koin.feature.user.ui.signup.verification
 
 import `in`.koreatech.koin.domain.model.user.Gender
-import `in`.koreatech.koin.domain.util.ext.isEnglish
-import `in`.koreatech.koin.domain.util.ext.isKorean
+import `in`.koreatech.koin.domain.util.ext.isNameFormat
 import `in`.koreatech.koin.feature.user.model.VerificationCodeState
 import `in`.koreatech.koin.feature.user.model.VerificationMethodState
 
@@ -17,13 +16,7 @@ data class SignUpVerificationState(
 )
 
 val SignUpVerificationState.isNameValid: Boolean
-    get() = if (name.isKorean()) {
-        name.length in 2..5
-    } else if (name.isEnglish()) {
-        name.length in 2..30
-    } else {
-        false
-    }
+    get() = name.isNameFormat()
 
 val SignUpVerificationState.currentStep: SignUpVerificationStep
     get() = when {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditScreen.kt
@@ -496,7 +496,7 @@ fun UserInfoPhoneNumber(
         ),
         onValueChange = onPhoneNumberChange,
         onButtonAction = onRequestVerificationCode,
-        buttonEnabled = isPhoneNumberChanged && verificationCodeState !is VerificationCodeState.Valid,
+        buttonEnabled = isPhoneNumberChanged && verificationCodeState !is VerificationCodeState.Valid && phoneNumber.isNotBlank(),
         maxLength = PHONE_NUMBER_LENGTH,
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Number,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditState.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditState.kt
@@ -75,4 +75,4 @@ private val UserInfoEditState.isNicknameCheckPassed: Boolean
     }
 
 val UserInfoEditState.canSave: Boolean
-    get() = isModified && isNameValid && isNicknameValid && isNicknameCheckPassed && isStudentNumberValid && isEmailValid && (verificationCodeState is VerificationCodeState.Valid || verificationCodeState is VerificationCodeState.None)
+    get() = isModified && isNameValid && isNicknameValid && isNicknameCheckPassed && isStudentNumberValid && isEmailValid && (verificationCodeState is VerificationCodeState.Valid || (verificationCodeState is VerificationCodeState.None && !isPhoneNumberChanged))

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditState.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditState.kt
@@ -1,8 +1,7 @@
 package `in`.koreatech.koin.feature.user.ui.userinfo
 
 import `in`.koreatech.koin.domain.model.user.UserType
-import `in`.koreatech.koin.domain.util.ext.isEnglish
-import `in`.koreatech.koin.domain.util.ext.isKorean
+import `in`.koreatech.koin.domain.util.ext.isNameFormat
 import `in`.koreatech.koin.domain.util.ext.isNicknameFormat
 import `in`.koreatech.koin.domain.util.ext.isValidEmail
 import `in`.koreatech.koin.domain.util.ext.isValidGeneralEmail
@@ -37,13 +36,7 @@ val UserInfoEditState.isNicknameChanged: Boolean
     }
 
 val UserInfoEditState.isNameValid: Boolean
-    get() = if (userState.name.isKorean()) {
-        userState.name.length in 2..5
-    } else if (userState.name.isEnglish()) {
-        userState.name.length in 2..30
-    } else {
-        false
-    }
+    get() = userState.name.isNameFormat()
 
 val UserInfoEditState.isEmailValid: Boolean
     get() = (userState.email.isNotEmpty() && (userState.email.isValidEmail() || userState.email.isValidGeneralEmail())) || userState.email.isEmpty()

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
@@ -137,7 +137,8 @@ class UserInfoEditViewModel @Inject constructor(
     fun updateNickname(nickname: String) = blockingIntent {
         reduce {
             state.copy(
-                userState = state.userState.copy(nickname = nickname), nicknameState = if (nickname.isEmpty()) {
+                userState = state.userState.copy(nickname = nickname),
+                nicknameState = if (nickname.isEmpty()) {
                     NicknameState.NicknameAvailable
                 } else {
                     NicknameState.None

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
@@ -136,7 +136,13 @@ class UserInfoEditViewModel @Inject constructor(
 
     fun updateNickname(nickname: String) = blockingIntent {
         reduce {
-            state.copy(userState = state.userState.copy(nickname = nickname), nicknameState = NicknameState.None)
+            state.copy(
+                userState = state.userState.copy(nickname = nickname), nicknameState = if (nickname.isEmpty()) {
+                    NicknameState.NicknameAvailable
+                } else {
+                    NicknameState.None
+                }
+            )
         }
     }
 

--- a/feature/user/src/main/res/values/strings.xml
+++ b/feature/user/src/main/res/values/strings.xml
@@ -206,7 +206,7 @@
 
     <string name="user_info_student_number_wrong_format">올바른 학번 양식이 아닙니다. 다시 입력해 주세요.</string>
 
-    <string name="user_info_email_wrong_format">올바른 이메일 형식이 아닙니다..</string>
+    <string name="user_info_email_wrong_format">올바른 이메일 형식이 아닙니다.</string>
 
     <string name="user_info_invalid_data_error">입력한 정보가 잘못되었습니다.</string>
     <string name="user_info_phone_number_validate_required_error">전화번호 인증이 필요합니다.</string>


### PR DESCRIPTION
close #831 

## 개요
유저팀 스프린트 QA 수정

## 작업 내용
* 닉네임이 공란일 경우, 중복 확인을 하지 않도록 수정
* 정보 수정 올바른 이메일 형식이 아닙니다 오타 수정
* 정보 수정 전화번호 미 입력 시 저장 버튼이 활성화 되는 문제 수정
* 비밀번호 찾기 -에 대해 이메일 분기처리 누락 수정
* 회원가입 시 이름에 자음만 입력해도 통과되는 문제 수정
* 전화번호가 공란이어도 인증번호 발송이 활성화되는 문제 수정
* 회원가입 -> 가입된 전화번호 -> 로그인 -> 아이디 찾기 -> 뒤로가기 시 회원가입 페이지로 돌아와지는 문제 수정
