### PR TITLE
[Koin Project][Refactor] API에서 반환하는 에러 메시지를 사용하지 않도록 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/error/UserErrorHandlerImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/error/UserErrorHandlerImpl.kt
@@ -31,7 +31,7 @@ class UserErrorHandlerImpl @Inject constructor(
                 is HttpException -> {
                     when (it.code()) {
                         400 -> ErrorHandler(context.getString(R.string.error_login_incorrect))
-                        404 -> ErrorHandler(it.getErrorResponse().message ?: context.getString(R.string.error_login_user_not_found))
+                        404 -> ErrorHandler(context.getString(R.string.error_login_user_not_found))
                         else -> ErrorHandler(context.getString(R.string.error_network))
                     }
                 }
@@ -75,9 +75,9 @@ class UserErrorHandlerImpl @Inject constructor(
             when (it) {
                 is HttpException -> {
                     when (it.code()) {
-                        400 -> ErrorHandler(it.getErrorResponse().message ?: context.getString(R.string.error_nickname_format_length))
-                        404 -> ErrorHandler(it.getErrorResponse().message ?: context.getString(R.string.error_login_user_not_found))
-                        else -> ErrorHandler(it.getErrorResponse().message ?: context.getString(R.string.error_network))
+                        400 -> ErrorHandler(context.getString(R.string.error_nickname_format_length))
+                        404 -> ErrorHandler(context.getString(R.string.error_login_user_not_found))
+                        else -> ErrorHandler(context.getString(R.string.error_network))
                     }
                 }
 
@@ -93,7 +93,7 @@ class UserErrorHandlerImpl @Inject constructor(
         return throwable.handleCommonError(context) {
             when {
                 it is HttpException -> {
-                    ErrorHandler(it.getErrorResponse().message ?: context.getString(R.string.error_network))
+                    ErrorHandler(context.getString(R.string.error_network))
                 }
 
                 it is IndexOutOfBoundsException || it.message == ERROR_INVALID_STUDENT_ID -> {

--- a/data/src/main/java/in/koreatech/koin/data/repository/TimetableRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/TimetableRepositoryImpl.kt
@@ -14,7 +14,6 @@ import `in`.koreatech.koin.data.response.timetable.v3.toSemester
 import `in`.koreatech.koin.data.response.timetable.v3.toSemesters
 import `in`.koreatech.koin.data.source.datastore.TimetableDataStore
 import `in`.koreatech.koin.data.source.remote.TimetableRemoteDataSource
-import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.domain.model.timetable.Semester
 import `in`.koreatech.koin.domain.model.timetable.request.TimetableFrameCreateQuery
 import `in`.koreatech.koin.domain.model.timetable.request.TimetableFrameQuery
@@ -188,7 +187,7 @@ class TimetableRepositoryImpl @Inject constructor(
                 ).toTimetableFrame()
         }.recoverCatching {
             if (it is HttpException) {
-                throw Exception(it.getErrorResponse().message ?: "")
+                throw Exception()
             } else {
                 throw it
             }


### PR DESCRIPTION
close #837 

## 개요
* API에서 반환하는 에러 메시지를 사용하지 않도록 수정

## 작업 내용
* 백엔드 에러 코드 작업 이후, 모든 에러 메시지가 `잘못된 입력값이 포함되어 있습니다.`로 변경 될 예정입니다.
* 따라서 백엔드에서 내려주는 에러 메시지를 사용하지 않도록 수정했습니다.