### PR TITLE
[Campus][Fix] 동아리 TextField 에 최대 높이 제한

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -56,7 +57,7 @@ fun DetailQnaTextField(
             .spacedBy(4.dp)
     ) {
         BasicTextField(
-            modifier = Modifier,
+            modifier = Modifier.heightIn(max = 300.dp),
             value = value,
             textStyle = textStyle,
             onValueChange = {


### PR DESCRIPTION
close #839 

## 개요
* 동아리 상세 TextField 에 높이를 300dp 로 제한 > 이후 스크롤 진행

## 작업 내용
* 동아리 상세 TextField 에 높이를 300dp 로 제한하였습니다.
(maxLines 로 제한하면 폰트 크기가 커졌을 때 똑같은 오류가 발생할 수 있을 거 같아 일단 300dp 로 제한하였습니다.)

https://github.com/user-attachments/assets/943d17c1-cace-43e5-bfce-f472c2cb4b77

## 추가 논의 사항
* 최대 줄 수를 제한할까요? 줄넘김으로 255자를 모두 채우면 그것도 문제라고 생각은 합니다.