### PR TITLE
[Koin Project][Fix] ErrorResponse dto와 API response가 일치하지 않아 발생하는 문제 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/response/ErrorResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/ErrorResponse.kt
@@ -1,14 +1,12 @@
 package `in`.koreatech.koin.data.response
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
+import com.google.gson.annotations.SerializedName
 
-@Serializable
 data class ErrorResponse(
-    @SerialName("message")
+    @SerializedName("message")
     val message: String?,
-    @SerialName("code")
+    @SerializedName("code")
     val code: String?,
-    @SerialName("errorTraceId")
+    @SerializedName("errorTraceId")
     val errorTraceId: String?
 )

--- a/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
@@ -1,12 +1,12 @@
 package `in`.koreatech.koin.data.util
 
+import com.google.gson.Gson
 import `in`.koreatech.koin.data.response.ErrorResponse
 import `in`.koreatech.koin.domain.error.KoinUnknownErrorException
-import kotlinx.serialization.json.Json
 import retrofit2.HttpException
 
 fun HttpException.getErrorResponse(): ErrorResponse {
-    return Json.decodeFromString<ErrorResponse>(response()?.errorBody()?.string() ?: "")
+    return Gson().fromJson(response()?.errorBody()?.string(), ErrorResponse::class.java)
 }
 
 fun ErrorResponse.toKoinUnknownErrorException(): KoinUnknownErrorException {


### PR DESCRIPTION
close #847 

## 개요
ErrorResponse dto와 API response가 일치하지 않아 발생하는 문제 수정

## 작업 내용
* ErrorResponse를 kotlinx.serialization 대신 gson을 사용하도록 수정했습니다.

## 추가적인 내용
* 백엔드에서 에러코드를 추가하면서 ErrorResponse와 API response가 일치하지 않는 문제가 생겼습니다.
* gson의 경우, dto와 response가 일치하지 않으면 무시를 하지만, kotlinx.serialization은 exception을 발생시킵니다.
* 이로 인해, kotlinx.serialization 대신 gson을 사용하도록 수정했습니다.