### PR TITLE
[User][Fix] 정보 수정 로깅 수정

### DIFF
--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/changepassword/ChangePasswordActivity.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/changepassword/ChangePasswordActivity.kt
@@ -11,6 +11,9 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.activity.ActivityBase
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventAction
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.appbar.AppBarBase
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.feature.user.R
@@ -87,6 +90,11 @@ class ChangePasswordActivity : ActivityBase() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.isPasswordChangeSuccess.collect { isSuccessful ->
                     if (isSuccessful) {
+                        EventLogger.logClickEvent(
+                            EventAction.USER,
+                            AnalyticsConstant.Label.USER_INFO,
+                            "정보수정 완료"
+                        )
                         setResult(ChangePasswordContract.RESULT_PASSWORD_CHANGED)
                         finish()
                     } else {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
@@ -241,11 +241,6 @@ private fun SignUpGeneralUserInfoInitialStep(
                 enabled = loginId.isNotEmpty() && isLoginIdAvailable != true && isLoginIdValid,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
-                    EventLogger.logClickEvent(
-                        EventAction.USER,
-                        AnalyticsConstant.Label.CREATE_ACCOUNT,
-                        "아이디생성"
-                    )
                     checkLoginIdAvailable()
                 }
             )
@@ -359,11 +354,6 @@ private fun SignUpGeneralUserInfoNickNameEmailStep(
                 enabled = nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable != true,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
-                    EventLogger.logClickEvent(
-                        EventAction.USER,
-                        AnalyticsConstant.Label.CREATE_ACCOUNT,
-                        "닉네임생성"
-                    )
                     checkNicknameDuplicate()
                 }
             )

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralViewModel.kt
@@ -3,6 +3,9 @@ package `in`.koreatech.koin.feature.user.ui.signup.userinfo.general
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventAction
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.error.user.KoinUserException
 import `in`.koreatech.koin.domain.usecase.signup.CheckEmailDuplicateUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckLoginIdDuplicateUseCase
@@ -86,6 +89,11 @@ class SignUpGeneralViewModel @Inject constructor(
             reduce {
                 state.copy(isNicknameAvailable = true)
             }
+            EventLogger.logClickEvent(
+                EventAction.USER,
+                AnalyticsConstant.Label.CREATE_ACCOUNT,
+                "닉네임생성"
+            )
         }.onFailure {
             reduce {
                 state.copy(isNicknameAvailable = false)
@@ -106,6 +114,11 @@ class SignUpGeneralViewModel @Inject constructor(
             reduce {
                 state.copy(isLoginIdAvailable = true, isLoginIdValid = true)
             }
+            EventLogger.logClickEvent(
+                EventAction.USER,
+                AnalyticsConstant.Label.CREATE_ACCOUNT,
+                "아이디생성"
+            )
         }.onFailure {
             when (it) {
                 is KoinUserException.LoginIdInvalidException -> {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
@@ -271,11 +271,6 @@ private fun SignUpStudentUserInfoInitialStep(
                 enabled = loginId.isNotEmpty() && isLoginIdAvailable != true && isLoginIdValid,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
-                    EventLogger.logClickEvent(
-                        EventAction.USER,
-                        AnalyticsConstant.Label.CREATE_ACCOUNT,
-                        "아이디생성"
-                    )
                     checkLoginIdAvailable()
                 }
             )
@@ -440,11 +435,6 @@ private fun SignUpStudentUserInfoNickNameEmailStep(
                 enabled = nickname.isNotEmpty() && nickname.isNicknameFormat() && isNicknameAvailable != true,
                 contentPadding = PaddingValues(vertical = 6.dp, horizontal = 12.dp),
                 onClick = {
-                    EventLogger.logClickEvent(
-                        EventAction.USER,
-                        AnalyticsConstant.Label.CREATE_ACCOUNT,
-                        "닉네임생성"
-                    )
                     checkNicknameDuplicate()
                 }
             )

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentViewModel.kt
@@ -3,6 +3,9 @@ package `in`.koreatech.koin.feature.user.ui.signup.userinfo.student
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventAction
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.error.user.KoinUserException
 import `in`.koreatech.koin.domain.usecase.dept.GetDeptNamesUseCase
 import `in`.koreatech.koin.domain.usecase.signup.CheckEmailDuplicateUseCase
@@ -76,6 +79,11 @@ class SignUpStudentViewModel @Inject constructor(
             reduce {
                 state.copy(isLoginIdAvailable = true, isLoginIdValid = true)
             }
+            EventLogger.logClickEvent(
+                EventAction.USER,
+                AnalyticsConstant.Label.CREATE_ACCOUNT,
+                "아이디생성"
+            )
         }.onFailure {
             when (it) {
                 is KoinUserException.LoginIdInvalidException -> {
@@ -145,6 +153,11 @@ class SignUpStudentViewModel @Inject constructor(
             reduce {
                 state.copy(isNicknameAvailable = true)
             }
+            EventLogger.logClickEvent(
+                EventAction.USER,
+                AnalyticsConstant.Label.CREATE_ACCOUNT,
+                "닉네임생성"
+            )
         }.onFailure {
             reduce {
                 state.copy(isNicknameAvailable = false)


### PR DESCRIPTION
close #866 

## 개요
* 정보 수정 로깅 수정

## 작업 내용
* 아이디 중복일 때 아이디생성이 찍히지 않도록 수정했습니다.
* 닉네임 중복일 때 닉네임생성이 찍히지 않도록 수정했습니다.
* 비밀번호 변경 직후 정보수정 완료가 찍히지 않는 문제를 수정했습니다.
