### PR TITLE
[Business][Feature] 상점 API DTO 통일 및 캐싱 적용

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/StoreApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/StoreApi.kt
@@ -101,6 +101,13 @@ interface StoreApi {
         @Query("minimum_order_amount") minimumOrderAmount: Int?
     ): List<ShopResponse>
 
+    @GET(URLConstant.SHOPS.SHOPS_V2)
+    suspend fun getNearbyShops(
+        @Query("sorter") sorter: String,
+        @Query("filter") filter: List<String>?,
+        @Query("query") query: String?
+    ): StoreResponse
+
     @GET("/order/shop/{orderableShopId}/summary")
     suspend fun getOrderableShopSummary(
         @Path("orderableShopId") shopId: Int

--- a/data/src/main/java/in/koreatech/koin/data/di/repository/RepositoryModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/repository/RepositoryModule.kt
@@ -31,6 +31,7 @@ import `in`.koreatech.koin.data.source.local.ArticleLocalDataSource
 import `in`.koreatech.koin.data.source.local.BannerLocalDataSource
 import `in`.koreatech.koin.data.source.local.DeptLocalDataSource
 import `in`.koreatech.koin.data.source.local.SignupTermsLocalDataSource
+import `in`.koreatech.koin.data.source.local.StoreLocalDataSource
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.source.local.UploadImageLocalDataSource
 import `in`.koreatech.koin.data.source.local.UserLocalDataSource
@@ -174,8 +175,8 @@ object RepositoryModule {
 
     @Provides
     @Singleton
-    fun provideStoreRepository(storeRemoteDataSource: StoreRemoteDataSource): StoreRepository {
-        return StoreRepositoryImpl(storeRemoteDataSource)
+    fun provideStoreRepository(storeRemoteDataSource: StoreRemoteDataSource, storeLocalDataSource: StoreLocalDataSource): StoreRepository {
+        return StoreRepositoryImpl(storeRemoteDataSource, storeLocalDataSource)
     }
 
     @Provides

--- a/data/src/main/java/in/koreatech/koin/data/di/source/LocalDataSourceModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/source/LocalDataSourceModule.kt
@@ -11,6 +11,7 @@ import `in`.koreatech.koin.data.source.datastore.ArticleDataStore
 import `in`.koreatech.koin.data.source.local.ArticleLocalDataSource
 import `in`.koreatech.koin.data.source.local.DeptLocalDataSource
 import `in`.koreatech.koin.data.source.local.SignupTermsLocalDataSource
+import `in`.koreatech.koin.data.source.local.StoreLocalDataSource
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.source.local.UserLocalDataSource
 import `in`.koreatech.koin.data.source.local.VersionLocalDataSource
@@ -66,5 +67,11 @@ object LocalDataSourceModule {
     @Singleton
     fun provideArticleLocalDataSource(articleDataStore: ArticleDataStore): ArticleLocalDataSource {
         return ArticleLocalDataSource(articleDataStore)
+    }
+
+    @Provides
+    @Singleton
+    fun provideStoreLocalDataSource(): StoreLocalDataSource {
+        return StoreLocalDataSource()
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
@@ -71,7 +71,10 @@ import `in`.koreatech.koin.domain.model.store.StoreReviewContent
 import `in`.koreatech.koin.domain.model.store.StoreReviewStatistics
 import `in`.koreatech.koin.domain.model.store.StoreWithMenu
 import `in`.koreatech.koin.domain.util.DateFormatUtil
+import `in`.koreatech.koin.domain.util.ext.HHMM
 import `in`.koreatech.koin.domain.util.ext.localDayOfWeekName
+import `in`.koreatech.koin.domain.util.ext.localTimeNow
+import java.time.LocalTime
 
 fun StoreItemResponse.toStore(): Store =
     Store(
@@ -399,6 +402,47 @@ fun ShopResponse.toShop() = Shop(
     },
     openStatus = openStatus
 )
+
+fun StoreItemResponse.toShop() = Shop(
+    shopId = uid ?: 0,
+    orderableShopId = 0, // Legacy store API does not have orderableShopId
+    name = name ?: "",
+    isDeliveryAvailable = isDeliveryOk ?: false,
+    isTakeoutAvailable = isBankOk ?: false,
+    serviceEvent = isEvent ?: false,
+    minimumOrderAmount = 0, // Legacy store API does not have minimumOrderAmount
+    ratingAverage = averageRate,
+    reviewCount = reviewCount,
+    minimumDeliveryTip = 0, // Legacy store API does not have minimumDeliveryTip
+    maximumDeliveryTip = 0, // Legacy store API does not have maximumDeliveryTip
+    isOpen = isOpen ?: false,
+    categoryIds = categoryIds,
+    imageUrls = emptyList(),
+    open = open?.map {
+        Shop.OrderStoreShopsOpen(
+            dayOfWeek = DateFormatUtil.dayOfWeekToIndex(it.dayOfWeek ?: ""),
+            closed = it.closed ?: false,
+            openTime = it.openTime ?: "00:00",
+            closeTime = it.closeTime ?: "00:00"
+        )
+    }.orEmpty(),
+    openStatus = open?.filter { it.dayOfWeek == localDayOfWeekName }?.getOrNull(0)?.toOpenStatus() ?: "CLOSED"
+)
+
+fun StoreItemResponse.OpenResponseDTO.toOpenStatus(): String {
+    return if (closed == true) {
+        val closeTime = LocalTime.parse(closeTime)
+        val currentTime = LocalTime.parse(localTimeNow.HHMM)
+
+        if (closeTime.isBefore(currentTime)) {
+            "CLOSED"
+        } else {
+            "PREPARING"
+        }
+    } else {
+        "OPERATING"
+    }
+}
 
 fun ShopSummaryResponse.toShopSummary() = ShopSummary(
     shopId = shopId,

--- a/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
@@ -89,8 +89,7 @@ fun StoreItemResponse.toStore(): Store =
         isOpen = isOpen ?: false,
         averageRate = averageRate ?: 0.0,
         reviewCount = reviewCount ?: 0,
-        open =
-        open?.filter { it.dayOfWeek == localDayOfWeekName }?.map {
+        open = open?.filter { it.dayOfWeek == localDayOfWeekName }?.map {
             Store.OpenData(
                 dayOfWeek = it.dayOfWeek ?: "",
                 closed = it.closed ?: false,
@@ -134,8 +133,7 @@ fun StoreItemWithMenusResponse.toStoreWithMenu(): StoreWithMenu =
         isBankOk = isBankOk ?: false,
         updateAt = updateAt,
         isEvent = isEvent ?: false,
-        open =
-        open?.filter { it.dayOfWeek == localDayOfWeekName }?.map {
+        open = open?.filter { it.dayOfWeek == localDayOfWeekName }?.map {
             Store.OpenData(
                 dayOfWeek = it.dayOfWeek ?: "",
                 closed = it.closed ?: false,
@@ -361,8 +359,7 @@ fun BenefitCategoryListResponse.toStoreBenefitCategory(): BenefitCategoryList =
 
 fun ShopRelatedListResponse.toShopSearchRelatedList(): ShopSearchRelatedList =
     ShopSearchRelatedList(
-        keywords =
-        keywords.map {
+        keywords = keywords.map {
             ShopSearchRelated(
                 keyword = it.keyword ?: "",
                 shopIds = it.shopIds ?: emptyList(),

--- a/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
@@ -49,6 +49,7 @@ import `in`.koreatech.koin.domain.model.store.CartItemEdit
 import `in`.koreatech.koin.domain.model.store.CartPaymentSummary
 import `in`.koreatech.koin.domain.model.store.CartSummary
 import `in`.koreatech.koin.domain.model.store.LegacyShopMenus
+import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.domain.model.store.Shop
 import `in`.koreatech.koin.domain.model.store.ShopDeliveryAvailable
 import `in`.koreatech.koin.domain.model.store.ShopDetail
@@ -377,70 +378,92 @@ fun OwnerGetStoreResponse.toOwnerGetStore(): OwnerGetStore =
         isEvent = isEvent ?: false
     )
 
-fun ShopResponse.toShop() = Shop(
-    shopId = shopId,
-    orderableShopId = orderableShopId,
-    name = name,
-    isDeliveryAvailable = isDeliveryAvailable,
-    isTakeoutAvailable = isTakeoutAvailable,
-    serviceEvent = serviceEvent,
-    minimumOrderAmount = minimumOrderAmount,
-    ratingAverage = ratingAverage,
-    reviewCount = reviewCount,
-    minimumDeliveryTip = minimumDeliveryTip,
-    maximumDeliveryTip = maximumDeliveryTip,
-    isOpen = isOpen,
-    categoryIds = categoryIds,
-    imageUrls = imageUrls,
-    open = open.map {
-        Shop.OrderStoreShopsOpen(
-            dayOfWeek = DateFormatUtil.dayOfWeekToIndex(it.dayOfWeek),
-            closed = it.closed,
-            openTime = it.openTime,
-            closeTime = it.closeTime
-        )
-    },
-    openStatus = openStatus
-)
+fun ShopResponse.toShop(): Shop {
+    val convertedOpenStatus = open.filter { it.dayOfWeek == localDayOfWeekName }[0].toOpenStatus()
 
-fun StoreItemResponse.toShop() = Shop(
-    shopId = uid ?: 0,
-    orderableShopId = 0, // Legacy store API does not have orderableShopId
-    name = name ?: "",
-    isDeliveryAvailable = isDeliveryOk ?: false,
-    isTakeoutAvailable = isBankOk ?: false,
-    serviceEvent = isEvent ?: false,
-    minimumOrderAmount = 0, // Legacy store API does not have minimumOrderAmount
-    ratingAverage = averageRate,
-    reviewCount = reviewCount,
-    minimumDeliveryTip = 0, // Legacy store API does not have minimumDeliveryTip
-    maximumDeliveryTip = 0, // Legacy store API does not have maximumDeliveryTip
-    isOpen = isOpen ?: false,
-    categoryIds = categoryIds,
-    imageUrls = emptyList(),
-    open = open?.map {
-        Shop.OrderStoreShopsOpen(
-            dayOfWeek = DateFormatUtil.dayOfWeekToIndex(it.dayOfWeek ?: ""),
-            closed = it.closed ?: false,
-            openTime = it.openTime ?: "00:00",
-            closeTime = it.closeTime ?: "00:00"
-        )
-    }.orEmpty(),
-    openStatus = open?.filter { it.dayOfWeek == localDayOfWeekName }?.getOrNull(0)?.toOpenStatus() ?: "CLOSED"
-)
+    return Shop(
+        shopId = shopId,
+        orderableShopId = orderableShopId,
+        name = name,
+        isDeliveryAvailable = isDeliveryAvailable,
+        isTakeoutAvailable = isTakeoutAvailable,
+        serviceEvent = serviceEvent,
+        minimumOrderAmount = minimumOrderAmount,
+        ratingAverage = ratingAverage,
+        reviewCount = reviewCount,
+        minimumDeliveryTip = minimumDeliveryTip,
+        maximumDeliveryTip = maximumDeliveryTip,
+        isOpen = convertedOpenStatus == OpenStatus.OPERATING,
+        categoryIds = categoryIds,
+        imageUrls = imageUrls,
+        open = open.map {
+            Shop.OrderStoreShopsOpen(
+                dayOfWeek = DateFormatUtil.dayOfWeekToIndex(it.dayOfWeek),
+                closed = it.closed,
+                openTime = it.openTime,
+                closeTime = it.closeTime
+            )
+        },
+        openStatus = convertedOpenStatus
+    )
+}
 
-fun StoreItemResponse.OpenResponseDTO.toOpenStatus(): String {
+fun StoreItemResponse.toShop(): Shop {
+    val convertedOpenStatus = open?.filter { it.dayOfWeek == localDayOfWeekName }?.getOrNull(0)?.toOpenStatus() ?: OpenStatus.CLOSED
+    return Shop(
+        shopId = uid ?: 0,
+        orderableShopId = 0, // Legacy store API does not have orderableShopId
+        name = name ?: "",
+        isDeliveryAvailable = isDeliveryOk ?: false,
+        isTakeoutAvailable = isBankOk ?: false,
+        serviceEvent = isEvent ?: false,
+        minimumOrderAmount = 0, // Legacy store API does not have minimumOrderAmount
+        ratingAverage = averageRate,
+        reviewCount = reviewCount,
+        minimumDeliveryTip = 0, // Legacy store API does not have minimumDeliveryTip
+        maximumDeliveryTip = 0, // Legacy store API does not have maximumDeliveryTip
+        isOpen = convertedOpenStatus == OpenStatus.OPERATING,
+        categoryIds = categoryIds,
+        imageUrls = emptyList(),
+        open = open?.map {
+            Shop.OrderStoreShopsOpen(
+                dayOfWeek = DateFormatUtil.dayOfWeekToIndex(it.dayOfWeek ?: ""),
+                closed = it.closed ?: false,
+                openTime = it.openTime ?: "00:00",
+                closeTime = it.closeTime ?: "00:00"
+            )
+        }.orEmpty(),
+        openStatus = convertedOpenStatus
+    )
+}
+
+fun StoreItemResponse.OpenResponseDTO.toOpenStatus(): OpenStatus {
     return if (closed == true) {
         val closeTime = LocalTime.parse(closeTime)
         val currentTime = LocalTime.parse(localTimeNow.HHMM)
 
         if (closeTime.isBefore(currentTime)) {
-            "CLOSED"
+            OpenStatus.CLOSED
         } else {
-            "PREPARING"
+            OpenStatus.PREPARING
         }
     } else {
-        "OPERATING"
+        OpenStatus.OPERATING
+    }
+}
+
+fun ShopResponse.OrderStoreShopsOpenResponse.toOpenStatus(): OpenStatus {
+    return if (closed) {
+        val closeTime = LocalTime.parse(closeTime)
+        val currentTime = LocalTime.parse(localTimeNow.HHMM)
+
+        if (closeTime.isBefore(currentTime)) {
+            OpenStatus.CLOSED
+        } else {
+            OpenStatus.PREPARING
+        }
+    } else {
+        OpenStatus.OPERATING
     }
 }
 

--- a/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/StoreMapper.kt
@@ -379,7 +379,7 @@ fun OwnerGetStoreResponse.toOwnerGetStore(): OwnerGetStore =
     )
 
 fun ShopResponse.toShop(): Shop {
-    val convertedOpenStatus = open.filter { it.dayOfWeek == localDayOfWeekName }[0].toOpenStatus()
+    val convertedOpenStatus = open.first { it.dayOfWeek == localDayOfWeekName }.toOpenStatus()
 
     return Shop(
         shopId = shopId,
@@ -409,7 +409,7 @@ fun ShopResponse.toShop(): Shop {
 }
 
 fun StoreItemResponse.toShop(): Shop {
-    val convertedOpenStatus = open?.filter { it.dayOfWeek == localDayOfWeekName }?.getOrNull(0)?.toOpenStatus() ?: OpenStatus.CLOSED
+    val convertedOpenStatus = open?.firstOrNull { it.dayOfWeek == localDayOfWeekName }?.toOpenStatus() ?: OpenStatus.CLOSED
     return Shop(
         shopId = uid ?: 0,
         orderableShopId = 0, // Legacy store API does not have orderableShopId

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -204,9 +204,31 @@ class StoreRepositoryImpl @Inject constructor(
         return storeRemoteDataSource.getShopSearchRelated(query).toShopSearchRelatedList()
     }
 
-    override suspend fun getOrderableShops(sorter: String?, filter: List<String>?, minimumOrderAmount: Int?): Result<List<Shop>> {
+    override suspend fun getOrderableShops(sorter: StoreSorter, filter: List<String>?, minimumOrderAmount: Int?): Result<List<Shop>> {
         return runCatching {
-            storeRemoteDataSource.getOrderableShops(sorter, filter, minimumOrderAmount).map { it.toShop() }
+            storeRemoteDataSource.getOrderableShops(sorter.name, filter, minimumOrderAmount).map { it.toShop() }
+        }.onFailure { e ->
+            return Result.failure(
+                when (e) {
+                    is HttpException -> {
+                        when (e.code()) {
+                            404 -> KoinStoreException.ShopNotFoundException()
+                            else -> e.getErrorResponse().toKoinUnknownErrorException()
+                        }
+                    }
+
+                    else -> e
+                }
+            )
+        }
+    }
+
+    override suspend fun getNearbyShops(sorter: StoreSorter, isOperating: Boolean): Result<List<Shop>> {
+        return runCatching {
+            storeRemoteDataSource.getNearbyShops(
+                sorter = sorter.name,
+                filter = listOfNotNull(if (isOperating) "OPEN" else null)
+            ).shops.map { it.toShop() }
         }.onFailure { e ->
             return Result.failure(
                 when (e) {

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -24,6 +24,7 @@ import `in`.koreatech.koin.data.mapper.toStoreMenu
 import `in`.koreatech.koin.data.mapper.toStoreReview
 import `in`.koreatech.koin.data.mapper.toStoreWithMenu
 import `in`.koreatech.koin.data.request.user.ReviewRequest
+import `in`.koreatech.koin.data.source.local.StoreLocalDataSource
 import `in`.koreatech.koin.data.source.remote.StoreRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
@@ -60,11 +61,11 @@ import javax.inject.Inject
 import retrofit2.HttpException
 
 class StoreRepositoryImpl @Inject constructor(
-    private val storeRemoteDataSource: StoreRemoteDataSource
+    private val storeRemoteDataSource: StoreRemoteDataSource,
+    private val storeLocalDataSource: StoreLocalDataSource
 ) : StoreRepository {
     private var stores: List<Store>? = null
     private var storeEvents: List<StoreEvent>? = null
-    private var storeCategories: List<StoreCategories>? = null
 
     override suspend fun getStores(
         storeSorter: StoreSorter?,
@@ -98,12 +99,13 @@ class StoreRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getStoreCategories(): List<StoreCategories> {
-        if (storeCategories == null) {
-            storeCategories =
-                storeRemoteDataSource.getStoreCategories().map { it.toStoreCategories() }
+        return storeLocalDataSource.getCachedStoreCategories().let { cachedCategories ->
+            cachedCategories?.map { it.toStoreCategories() } ?: run {
+                storeRemoteDataSource.getStoreCategories().also {
+                    storeLocalDataSource.setCachedStoreCategories(it)
+                }.map { it.toStoreCategories() }
+            }
         }
-
-        return storeCategories!!
     }
 
     override suspend fun getStoreWithMenu(storeId: Int): StoreWithMenu {

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -229,7 +229,7 @@ class StoreRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun getNearbyShops(sorter: StoreSorter, isOperating: Boolean): Result<List<Shop>> {
+    override suspend fun getNearbyShops(): Result<List<Shop>> {
         return runCatching {
             storeLocalDataSource.getCachedNearbyShops() ?: storeRemoteDataSource.getNearbyShops().shops.map {
                 it.toShop()

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -206,9 +206,13 @@ class StoreRepositoryImpl @Inject constructor(
         return storeRemoteDataSource.getShopSearchRelated(query).toShopSearchRelatedList()
     }
 
-    override suspend fun getOrderableShops(sorter: StoreSorter, filter: List<String>?, minimumOrderAmount: Int?): Result<List<Shop>> {
+    override suspend fun getOrderableShops(): Result<List<Shop>> {
         return runCatching {
-            storeRemoteDataSource.getOrderableShops(sorter.name, filter, minimumOrderAmount).map { it.toShop() }
+            storeLocalDataSource.getCachedShops() ?: storeRemoteDataSource.getOrderableShops().map {
+                it.toShop()
+            }.also {
+                storeLocalDataSource.setCachedShops(it)
+            }
         }.onFailure { e ->
             return Result.failure(
                 when (e) {
@@ -227,10 +231,11 @@ class StoreRepositoryImpl @Inject constructor(
 
     override suspend fun getNearbyShops(sorter: StoreSorter, isOperating: Boolean): Result<List<Shop>> {
         return runCatching {
-            storeRemoteDataSource.getNearbyShops(
-                sorter = sorter.name,
-                filter = listOfNotNull(if (isOperating) "OPEN" else null)
-            ).shops.map { it.toShop() }
+            storeLocalDataSource.getCachedNearbyShops() ?: storeRemoteDataSource.getNearbyShops().shops.map {
+                it.toShop()
+            }.also {
+                storeLocalDataSource.setCachedNearbyShops(it)
+            }
         }.onFailure { e ->
             return Result.failure(
                 when (e) {

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -208,10 +208,10 @@ class StoreRepositoryImpl @Inject constructor(
 
     override suspend fun getOrderableShops(): Result<List<Shop>> {
         return runCatching {
-            storeLocalDataSource.getCachedShops() ?: storeRemoteDataSource.getOrderableShops().map {
-                it.toShop()
-            }.also {
+            storeLocalDataSource.getCachedShops()?.map { it.toShop() } ?: storeRemoteDataSource.getOrderableShops().also {
                 storeLocalDataSource.setCachedShops(it)
+            }.map {
+                it.toShop()
             }
         }.onFailure { e ->
             return Result.failure(
@@ -231,10 +231,10 @@ class StoreRepositoryImpl @Inject constructor(
 
     override suspend fun getNearbyShops(): Result<List<Shop>> {
         return runCatching {
-            storeLocalDataSource.getCachedNearbyShops() ?: storeRemoteDataSource.getNearbyShops().shops.map {
-                it.toShop()
-            }.also {
+            storeLocalDataSource.getCachedNearbyShops()?.map { it.toShop() } ?: storeRemoteDataSource.getNearbyShops().shops.also {
                 storeLocalDataSource.setCachedNearbyShops(it)
+            }.map {
+                it.toShop()
             }
         }.onFailure { e ->
             return Result.failure(

--- a/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
@@ -1,10 +1,13 @@
 package `in`.koreatech.koin.data.source.local
 
 import `in`.koreatech.koin.data.response.store.StoreCategoriesItemResponse
+import `in`.koreatech.koin.domain.model.store.Shop
 import javax.inject.Inject
 
 class StoreLocalDataSource @Inject constructor() {
     private var storeCategories: List<StoreCategoriesItemResponse> = emptyList()
+    private var shops: List<Shop> = emptyList()
+    private var nearbyShops: List<Shop> = emptyList()
 
     fun setCachedStoreCategories(storeCategories: List<StoreCategoriesItemResponse>) {
         this.storeCategories = storeCategories
@@ -12,5 +15,21 @@ class StoreLocalDataSource @Inject constructor() {
 
     fun getCachedStoreCategories(): List<StoreCategoriesItemResponse>? {
         return this.storeCategories.ifEmpty { null }
+    }
+
+    fun setCachedShops(shops: List<Shop>) {
+        this.shops = shops
+    }
+
+    fun getCachedShops(): List<Shop>? {
+        return this.shops.ifEmpty { null }
+    }
+
+    fun setCachedNearbyShops(nearbyShops: List<Shop>) {
+        this.nearbyShops = nearbyShops
+    }
+
+    fun getCachedNearbyShops(): List<Shop>? {
+        return this.nearbyShops.ifEmpty { null }
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
@@ -1,13 +1,14 @@
 package `in`.koreatech.koin.data.source.local
 
+import `in`.koreatech.koin.data.response.store.ShopResponse
 import `in`.koreatech.koin.data.response.store.StoreCategoriesItemResponse
-import `in`.koreatech.koin.domain.model.store.Shop
+import `in`.koreatech.koin.data.response.store.StoreItemResponse
 import javax.inject.Inject
 
 class StoreLocalDataSource @Inject constructor() {
     private var storeCategories: List<StoreCategoriesItemResponse> = emptyList()
-    private var shops: List<Shop> = emptyList()
-    private var nearbyShops: List<Shop> = emptyList()
+    private var shops: List<ShopResponse> = emptyList()
+    private var nearbyShops: List<StoreItemResponse> = emptyList()
 
     fun setCachedStoreCategories(storeCategories: List<StoreCategoriesItemResponse>) {
         this.storeCategories = storeCategories
@@ -17,19 +18,19 @@ class StoreLocalDataSource @Inject constructor() {
         return this.storeCategories.ifEmpty { null }
     }
 
-    fun setCachedShops(shops: List<Shop>) {
+    fun setCachedShops(shops: List<ShopResponse>) {
         this.shops = shops
     }
 
-    fun getCachedShops(): List<Shop>? {
+    fun getCachedShops(): List<ShopResponse>? {
         return this.shops.ifEmpty { null }
     }
 
-    fun setCachedNearbyShops(nearbyShops: List<Shop>) {
+    fun setCachedNearbyShops(nearbyShops: List<StoreItemResponse>) {
         this.nearbyShops = nearbyShops
     }
 
-    fun getCachedNearbyShops(): List<Shop>? {
+    fun getCachedNearbyShops(): List<StoreItemResponse>? {
         return this.nearbyShops.ifEmpty { null }
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
@@ -1,0 +1,16 @@
+package `in`.koreatech.koin.data.source.local
+
+import `in`.koreatech.koin.data.response.store.StoreCategoriesItemResponse
+import javax.inject.Inject
+
+class StoreLocalDataSource @Inject constructor() {
+    private var storeCategories: List<StoreCategoriesItemResponse> = emptyList()
+
+    fun setCachedStoreCategories(storeCategories: List<StoreCategoriesItemResponse>) {
+        this.storeCategories = storeCategories
+    }
+
+    fun getCachedStoreCategories(): List<StoreCategoriesItemResponse>? {
+        return this.storeCategories.ifEmpty { null }
+    }
+}

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/StoreRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/StoreRemoteDataSource.kt
@@ -29,6 +29,7 @@ import `in`.koreatech.koin.data.response.store.StoreItemResponse
 import `in`.koreatech.koin.data.response.store.StoreItemWithMenusResponse
 import `in`.koreatech.koin.data.response.store.StoreMenuCategoryResponse
 import `in`.koreatech.koin.data.response.store.StoreMenuResponse
+import `in`.koreatech.koin.data.response.store.StoreResponse
 import `in`.koreatech.koin.data.response.store.StoreReviewResponse
 import `in`.koreatech.koin.domain.model.store.StoreReport
 import `in`.koreatech.koin.domain.model.store.StoreSorter
@@ -158,6 +159,14 @@ class StoreRemoteDataSource @Inject constructor(
         minimumOrderAmount: Int?
     ): List<ShopResponse> {
         return storeApi.getOrderableShops(sorter, filter, minimumOrderAmount)
+    }
+
+    suspend fun getNearbyShops(
+        sorter: String = StoreSorter.NONE.name,
+        filter: List<String>? = null,
+        query: String? = null
+    ): StoreResponse {
+        return storeApi.getNearbyShops(sorter, filter, query)
     }
 
     suspend fun getOrderableShopSummary(shopId: Int): ShopSummaryResponse {

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/StoreRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/StoreRemoteDataSource.kt
@@ -154,9 +154,9 @@ class StoreRemoteDataSource @Inject constructor(
     }
 
     suspend fun getOrderableShops(
-        sorter: String?,
-        filter: List<String>?,
-        minimumOrderAmount: Int?
+        sorter: String? = StoreSorter.NONE.name,
+        filter: List<String>? = null,
+        minimumOrderAmount: Int? = null
     ): List<ShopResponse> {
         return storeApi.getOrderableShops(sorter, filter, minimumOrderAmount)
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/store/OpenStatus.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/store/OpenStatus.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.domain.model.store
+
+enum class OpenStatus {
+    OPERATING,
+    PREPARING,
+    CLOSED
+}
+
+fun OpenStatus.isOpen(): Boolean {
+    return this == OpenStatus.OPERATING
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/model/store/Shop.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/store/Shop.kt
@@ -16,7 +16,7 @@ data class Shop(
     val categoryIds: List<Int>,
     val imageUrls: List<String>,
     val open: List<OrderStoreShopsOpen>,
-    val openStatus: String
+    val openStatus: OpenStatus
 ) {
     data class OrderStoreShopsOpen(
         val dayOfWeek: Int,

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
@@ -81,9 +81,14 @@ interface StoreRepository {
     suspend fun getShopSearchRelatedList(query: String): ShopSearchRelatedList
 
     suspend fun getOrderableShops(
-        sorter: String?,
+        sorter: StoreSorter = StoreSorter.NONE,
         filter: List<String>?,
         minimumOrderAmount: Int?
+    ): Result<List<Shop>>
+
+    suspend fun getNearbyShops(
+        sorter: StoreSorter = StoreSorter.NONE,
+        isOperating: Boolean = true
     ): Result<List<Shop>>
 
     suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary>

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
@@ -80,11 +80,7 @@ interface StoreRepository {
 
     suspend fun getShopSearchRelatedList(query: String): ShopSearchRelatedList
 
-    suspend fun getOrderableShops(
-        sorter: StoreSorter = StoreSorter.NONE,
-        filter: List<String>?,
-        minimumOrderAmount: Int?
-    ): Result<List<Shop>>
+    suspend fun getOrderableShops(): Result<List<Shop>>
 
     suspend fun getNearbyShops(
         sorter: StoreSorter = StoreSorter.NONE,

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/StoreRepository.kt
@@ -82,10 +82,7 @@ interface StoreRepository {
 
     suspend fun getOrderableShops(): Result<List<Shop>>
 
-    suspend fun getNearbyShops(
-        sorter: StoreSorter = StoreSorter.NONE,
-        isOperating: Boolean = true
-    ): Result<List<Shop>>
+    suspend fun getNearbyShops(): Result<List<Shop>>
 
     suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary>
 

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
@@ -14,9 +14,22 @@ class GetNearbyShopUseCase @Inject constructor(
         categoryId: Int = 1
     ): Result<List<Shop>> {
         return runCatching {
-            storeRepository.getNearbyShops(sorter, isOperating).getOrThrow().filter { it.categoryIds.contains(categoryId) }
+            storeRepository.getNearbyShops(sorter, isOperating).getOrThrow()
+                .filter { it.categoryIds.contains(categoryId) }
+                .filter { if (isOperating) it.isOpen else true }
+                .orderByStoreSorter(sorter)
         }.onFailure {
             return Result.failure(it)
         }
+    }
+}
+
+private fun List<Shop>.orderByStoreSorter(
+    storeSorter: StoreSorter
+): List<Shop> {
+    return when (storeSorter) {
+        StoreSorter.NONE -> this
+        StoreSorter.COUNT -> sortedByDescending { it.reviewCount }
+        StoreSorter.RATING -> sortedByDescending { it.ratingAverage }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
@@ -5,17 +5,16 @@ import `in`.koreatech.koin.domain.model.store.StoreSorter
 import `in`.koreatech.koin.domain.repository.StoreRepository
 import javax.inject.Inject
 
-class GetOrderableShopsUseCase @Inject constructor(
+class GetNearbyShopUseCase @Inject constructor(
     private val storeRepository: StoreRepository
 ) {
     suspend operator fun invoke(
         sorter: StoreSorter = StoreSorter.NONE,
-        filter: List<String>? = null,
-        minimumOrderAmount: Int? = null,
+        isOperating: Boolean = true,
         categoryId: Int = 1
     ): Result<List<Shop>> {
         return runCatching {
-            storeRepository.getOrderableShops(sorter, filter, minimumOrderAmount).getOrThrow().filter { it.categoryIds.contains(categoryId) }
+            storeRepository.getNearbyShops(sorter, isOperating).getOrThrow().filter { it.categoryIds.contains(categoryId) }
         }.onFailure {
             return Result.failure(it)
         }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetNearbyShopUseCase.kt
@@ -14,7 +14,7 @@ class GetNearbyShopUseCase @Inject constructor(
         categoryId: Int = 1
     ): Result<List<Shop>> {
         return runCatching {
-            storeRepository.getNearbyShops(sorter, isOperating).getOrThrow()
+            storeRepository.getNearbyShops().getOrThrow()
                 .filter { it.categoryIds.contains(categoryId) }
                 .filter { if (isOperating) it.isOpen else true }
                 .orderByStoreSorter(sorter)

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCase.kt
@@ -15,9 +15,46 @@ class GetOrderableShopsUseCase @Inject constructor(
         categoryId: Int = 1
     ): Result<List<Shop>> {
         return runCatching {
-            storeRepository.getOrderableShops(sorter, filter, minimumOrderAmount).getOrThrow().filter { it.categoryIds.contains(categoryId) }
+            storeRepository.getOrderableShops().getOrThrow()
+                .filter { it.categoryIds.contains(categoryId) }
+                .filter { it.minimumOrderAmount <= (minimumOrderAmount ?: Int.MAX_VALUE) }
+                .filterByStoreFilter(filter)
+                .orderByStoreSorter(sorter)
         }.onFailure {
             return Result.failure(it)
+        }
+    }
+}
+
+private fun List<Shop>.orderByStoreSorter(
+    storeSorter: StoreSorter
+): List<Shop> {
+    return when (storeSorter) {
+        StoreSorter.NONE -> this
+        StoreSorter.COUNT -> sortedByDescending { it.reviewCount }
+        StoreSorter.RATING -> sortedByDescending { it.ratingAverage }
+    }
+}
+
+private fun List<Shop>.filterByStoreFilter(
+    filter: List<String>?
+): List<Shop> {
+    return if (filter.isNullOrEmpty()) {
+        this
+    } else {
+        val isOpen = filter.contains("IS_OPEN")
+        val isDeliveryAvailable = filter.contains("DELIVERY_AVAILABLE")
+        val isTakeoutAvailable = filter.contains("TAKEOUT_AVAILABLE")
+        val isFreeDeliveryTip = filter.contains("FREE_DELIVERY_TIP")
+
+        this.filter {
+            if (isOpen) it.isOpen else true
+        }.filter {
+            if (isDeliveryAvailable) it.isDeliveryAvailable else true
+        }.filter {
+            if (isTakeoutAvailable) it.isTakeoutAvailable else true
+        }.filter {
+            if (isFreeDeliveryTip) it.maximumDeliveryTip == 0 else true
         }
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.feature.store.model
 
 import android.os.Parcelable
+import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.domain.model.store.Shop
 import `in`.koreatech.koin.feature.store.enums.FilterBadge
 import kotlinx.parcelize.Parcelize
@@ -20,7 +21,7 @@ data class LocalShop(
     val categoryIds: List<Int>,
     val imageUrls: List<String>,
     val open: List<LocalOrderStoreShopsOpen>,
-    val openStatus: String
+    val openStatus: OpenStatus
 ) : Parcelable {
     @Parcelize
     data class LocalOrderStoreShopsOpen(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
@@ -2,12 +2,7 @@ package `in`.koreatech.koin.feature.store.model
 
 import android.os.Parcelable
 import `in`.koreatech.koin.domain.model.store.Shop
-import `in`.koreatech.koin.domain.model.store.Store
-import `in`.koreatech.koin.domain.util.DateFormatUtil
-import `in`.koreatech.koin.domain.util.ext.HHMM
-import `in`.koreatech.koin.domain.util.ext.localTimeNow
 import `in`.koreatech.koin.feature.store.enums.FilterBadge
-import java.time.LocalTime
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -62,50 +57,6 @@ internal fun Shop.toLocalShop(): LocalShop {
 internal fun Shop.OrderStoreShopsOpen.toLocalOrderStoreShopsOpen(): LocalShop.LocalOrderStoreShopsOpen {
     return LocalShop.LocalOrderStoreShopsOpen(
         dayOfWeek = dayOfWeek,
-        closed = closed,
-        openTime = openTime,
-        closeTime = closeTime
-    )
-}
-
-internal fun Store.toLocalShop(): LocalShop {
-    return LocalShop(
-        shopId = uid,
-        orderableShopId = uid,
-        name = name,
-        filterBadgeList = emptyList(),
-        minimumOrderAmount = 0,
-        ratingAverage = averageRate,
-        reviewCount = reviewCount,
-        minimumDeliveryTip = 0,
-        maximumDeliveryTip = 0,
-        isOpen = isOpen,
-        categoryIds = categoryIds,
-        imageUrls = emptyList(),
-        open = listOf(open.toLocalOrderStoreShopsOpen()),
-        openStatus = open.toOpenStatus()
-    )
-}
-
-// Old Api doesn't return open status, so we need to calculate it manually
-internal fun Store.OpenData.toOpenStatus(): String {
-    return if (closed) {
-        val closeTime = LocalTime.parse(closeTime)
-        val currentTime = LocalTime.parse(localTimeNow.HHMM)
-
-        if (closeTime.isBefore(currentTime)) {
-            "CLOSED"
-        } else {
-            "PREPARING"
-        }
-    } else {
-        "OPERATING"
-    }
-}
-
-internal fun Store.OpenData.toLocalOrderStoreShopsOpen(): LocalShop.LocalOrderStoreShopsOpen {
-    return LocalShop.LocalOrderStoreShopsOpen(
-        dayOfWeek = DateFormatUtil.dayOfWeekToIndex(dayOfWeek),
         closed = closed,
         openTime = openTime,
         closeTime = closeTime

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
@@ -48,6 +48,7 @@ import coil.compose.rememberAsyncImagePainter
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.feature.store.R
 import `in`.koreatech.koin.feature.store.component.KoinStoreCard
 import `in`.koreatech.koin.feature.store.component.KoinStoreCategoryItem
@@ -418,7 +419,7 @@ private fun StoreHomeScreenPreview() {
                             closeTime = "21:00"
                         )
                     ),
-                    openStatus = "OPEN"
+                    openStatus = OpenStatus.OPERATING
                 )
             ),
             storeCategories = listOf(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
@@ -7,6 +7,7 @@ import `in`.koreatech.koin.domain.usecase.store.GetStoreCategoriesUseCase
 import `in`.koreatech.koin.feature.store.enums.MinimumPriceOption
 import `in`.koreatech.koin.feature.store.enums.OrderOption
 import `in`.koreatech.koin.feature.store.enums.StoreFilter
+import `in`.koreatech.koin.feature.store.enums.toStoreSorter
 import `in`.koreatech.koin.feature.store.model.toLocalShop
 import `in`.koreatech.koin.feature.store.model.toLocalStoreCategories
 import javax.inject.Inject
@@ -42,7 +43,7 @@ class StoreHomeViewModel @Inject constructor(
             )
         }
         getOrderableShopsUseCase(
-            sorter = state.selectedOrderOption.name,
+            sorter = state.selectedOrderOption.toStoreSorter(),
             filter = state.selectedStoreFilter.map { it.name },
             categoryId = state.categoryId,
             minimumOrderAmount = state.selectedMinimumPriceOption.price

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
@@ -48,6 +48,7 @@ import coil.compose.rememberAsyncImagePainter
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.feature.store.R
 import `in`.koreatech.koin.feature.store.component.KoinStoreCard
 import `in`.koreatech.koin.feature.store.component.KoinStoreCategoryItem
@@ -410,7 +411,7 @@ private fun StoreHomeScreenPreview() {
                             closeTime = "21:00"
                         )
                     ),
-                    openStatus = "OPEN"
+                    openStatus = OpenStatus.OPERATING
                 )
             ),
             storeCategories = listOf(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
@@ -2,9 +2,8 @@ package `in`.koreatech.koin.feature.store.view.main.nearby
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.model.store.StoreCategories
+import `in`.koreatech.koin.domain.usecase.store.GetNearbyShopUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetStoreCategoriesUseCase
-import `in`.koreatech.koin.domain.usecase.store.GetStoresUseCase
 import `in`.koreatech.koin.feature.store.enums.MinimumPriceOption
 import `in`.koreatech.koin.feature.store.enums.OrderOption
 import `in`.koreatech.koin.feature.store.enums.StoreFilter
@@ -21,7 +20,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class StoreNearbyViewModel @Inject constructor(
     private val getStoreCategoriesUseCase: GetStoreCategoriesUseCase,
-    private val getStoresUseCase: GetStoresUseCase
+    private val getNearbyShopUseCase: GetNearbyShopUseCase
 ) : ViewModel(), ContainerHost<StoreNearbyState, StoreNearbySideEffect> {
     override val container = container<StoreNearbyState, StoreNearbySideEffect>(StoreNearbyState())
 
@@ -43,14 +42,20 @@ class StoreNearbyViewModel @Inject constructor(
                 isLoading = true
             )
         }
-        getStoresUseCase(
-            category = StoreCategories(state.categoryId, "", ""),
-            storeSorter = state.selectedOrderOption.toStoreSorter(),
+        getNearbyShopUseCase(
+            categoryId = state.categoryId,
+            sorter = state.selectedOrderOption.toStoreSorter(),
             isOperating = StoreFilter.IS_OPEN in state.selectedStoreFilter
-        ).let {
+        ).onSuccess {
             reduce {
                 state.copy(
                     orderableShops = it.map { it.toLocalShop() },
+                    isLoading = false
+                )
+            }
+        }.onFailure {
+            reduce {
+                state.copy(
                     isLoading = false
                 )
             }


### PR DESCRIPTION
issue #713 

## 개요
* 상점 API DTO 통일 및 캐싱 적용

## 작업 내용
* 신규 상점 API와 v2 API의 구조를 최대한 통일했습니다.
* `StoreLocalDataSource`를 추가했습니다.
* 상점 카테고리 캐싱을 `StoreLocalDataSoruce`로 이동했습니다.
* 상점 목록 캐싱을 적용했습니다. 최초 요청 시 모든 상점을 받아온 후, UseCase에서 필터링을 적용합니다.
* `GetNearbyShopsUseCase`를 추가했습니다. v2 API를 사용하지만 Result를 적용했습니다.
* 상점 `isOpen` 및 `openStatus`를 직접 계산하도록 수정했습니다.