### PR TITLE
[Campus][Fix] 동아리 검색 로직 수정

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSearchBar.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSearchBar.kt
@@ -162,12 +162,12 @@ fun KoinClubSearchBar(
                 suggestions.forEach {
                     Row(
                         modifier = Modifier
-                            .padding(8.dp)
                             .fillMaxWidth()
                             .clickable {
                                 onSearch(it)
                                 focusManager.clearFocus()
                             }
+                            .padding(8.dp)
                     ) {
                         BasicText(
                             text = it,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSearchBar.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSearchBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -163,6 +164,10 @@ fun KoinClubSearchBar(
                         modifier = Modifier
                             .padding(8.dp)
                             .fillMaxWidth()
+                            .clickable {
+                                onSearch(it)
+                                focusManager.clearFocus()
+                            }
                     ) {
                         BasicText(
                             text = it,
@@ -176,8 +181,7 @@ fun KoinClubSearchBar(
                         Image(
                             modifier = Modifier
                                 .noRippleClickable {
-                                    onSearch(it)
-                                    focusManager.clearFocus()
+                                    onValueChange(it)
                                 }
                                 .padding(1.dp)
                                 .size(16.dp),

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
@@ -24,6 +24,8 @@ import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
@@ -41,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -338,7 +341,13 @@ fun ClubListScreenImpl(
                 onDismiss = {
                     onExpandedSearchBarChange(false)
                 },
-                onSearch = onSearch
+                onSearch = onSearch,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(
+                    onSearch = {
+                        onSearch(searchKeyword)
+                    }
+                )
             )
         }
 


### PR DESCRIPTION
close #911 

## 개요
* 동아리 검색 로직 수정

## 작업 내용
* 동아리 검색 시 결과를 선택하면 검색이 되도록 수정했습니다.
* 검색 결과 우측의 화살표 아이콘을 선택하면 입력 값이 해당 결과로 변경되도록 수정했습니다.
* KeyboardAction 및 KeyboardOption을 설정했습니다.