### PR TITLE
[Business][Fix] 과도한 Recomposition 해결

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreTopAppBar.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreTopAppBar.kt
@@ -62,7 +62,7 @@ fun KoinStoreTopAppBar(
                     style = textStyle.copy(color = colors.titleContentColor)
                 )
             },
-            modifier = modifier.graphicsLayer {
+            modifier = Modifier.graphicsLayer {
                 alpha = overlayAlpha.value
             },
             navigationIcon = {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/util/CustomClosingToolbarScreenDefaults.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/util/CustomClosingToolbarScreenDefaults.kt
@@ -1,10 +1,14 @@
-package `in`.koreatech.feature.store.util
+package `in`.koreatech.koin.feature.store.util
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
 
 object CustomClosingToolbarScreenDefaults {
     val windowInsets: WindowInsets
@@ -14,3 +18,16 @@ object CustomClosingToolbarScreenDefaults {
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Top
             )
 }
+
+@Stable
+fun Modifier.customCollapsingToolbarContent(
+    maxToolbarHeight: Dp,
+    currentToolbarHeight: Dp,
+    overlayAlpha: Float
+) = this.then(
+    Modifier.graphicsLayer {
+        clip = true
+        translationY = -(maxToolbarHeight.toPx() - currentToolbarHeight.toPx())
+        alpha = 1f - overlayAlpha
+    }
+)

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.colorResource
@@ -46,6 +45,7 @@ import `in`.koreatech.koin.feature.store.component.menuListSection
 import `in`.koreatech.koin.feature.store.scroll.storeCollapsingToolbarConnection
 import `in`.koreatech.koin.feature.store.state.collapseToolbar
 import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
+import `in`.koreatech.koin.feature.store.util.customCollapsingToolbarContent
 import `in`.koreatech.koin.feature.store.viewmodel.StoreDetailViewModel
 import kotlin.math.roundToInt
 import kotlinx.coroutines.CoroutineScope
@@ -197,11 +197,11 @@ fun StoreDetailScreen(
                 modifier = Modifier
                     .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
                     .fillMaxWidth()
-                    .graphicsLayer {
-                        clip = true
-                        translationY = -(rememberState.toolbarMaxHeight.toPx() - currentToolbarHeightDp.value.toPx())
-                        alpha = 1f - overlayAlpha.value
-                    },
+                    .customCollapsingToolbarContent(
+                        maxToolbarHeight = rememberState.toolbarMaxHeight,
+                        currentToolbarHeight = currentToolbarHeightDp.value,
+                        overlayAlpha = overlayAlpha.value
+                    ),
                 imageUrls = uiState.store.imageUrls ?: emptyList(),
                 pagerState = pagerState
             )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
@@ -88,7 +88,7 @@ fun StoreDetailScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .navigationBarsPadding()
-                .padding(bottom = rememberState.toolbarMinHeight * 2)
+                .padding(bottom = rememberState.toolbarMinHeight + statusBarHeight)
                 .offset {
                     IntOffset(
                         0,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/StoreDetailScreen.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.heightIn
@@ -11,6 +13,7 @@ import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -73,6 +76,7 @@ fun StoreDetailScreen(
         minHeightPx = rememberState.minHeightPx
     )
     val currentToolbarHeightDp = rememberState.currentToolbarHeightDp()
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
     val coroutineScope = rememberCoroutineScope()
     Box(
         modifier = Modifier
@@ -88,7 +92,7 @@ fun StoreDetailScreen(
                 .offset {
                     IntOffset(
                         0,
-                        currentToolbarHeightDp.value.toPx().roundToInt() + rememberState.toolbarMinHeight.toPx().roundToInt()
+                        currentToolbarHeightDp.value.toPx().roundToInt() + statusBarHeight.toPx().roundToInt()
                     )
                 },
             state = rememberState.listState
@@ -191,7 +195,7 @@ fun StoreDetailScreen(
         ) {
             StoreDetailImage(
                 modifier = Modifier
-                    .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMinHeight + rememberState.toolbarMaxHeight)
+                    .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
                     .fillMaxWidth()
                     .graphicsLayer {
                         clip = true

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
@@ -54,7 +54,6 @@ import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
 import kotlin.math.roundToInt
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
-import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
@@ -119,7 +119,7 @@ fun CartAddScreen(
                 onSelectedOptionGroup = viewModel::updateSelectedOptionGroup,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(bottom = rememberState.toolbarMinHeight * 2)
+                    .padding(bottom = rememberState.toolbarMinHeight + statusBarHeight)
                     .offset {
                         IntOffset(
                             0,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
@@ -51,6 +51,7 @@ import `in`.koreatech.koin.feature.store.model.LocalShopMenuOptionGroup
 import `in`.koreatech.koin.feature.store.model.LocalShopPrice
 import `in`.koreatech.koin.feature.store.scroll.storeCollapsingToolbarConnection
 import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
+import `in`.koreatech.koin.feature.store.util.customCollapsingToolbarContent
 import kotlin.math.roundToInt
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -172,10 +173,11 @@ fun CartAddScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
-                        .graphicsLayer {
-                            clip = true
-                            translationY = -(rememberState.toolbarMaxHeight.toPx() - currentToolbarHeightDp.value.toPx())
-                        }
+                        .customCollapsingToolbarContent(
+                            maxToolbarHeight = rememberState.toolbarMaxHeight,
+                            currentToolbarHeight = currentToolbarHeightDp.value,
+                            overlayAlpha = overlayAlpha.value
+                        )
                         .zIndex(1f)
                 ) {
                     Image(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,6 +14,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
@@ -51,6 +54,7 @@ import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
 import kotlin.math.roundToInt
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
+import timber.log.Timber
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -76,6 +80,7 @@ fun CartAddScreen(
         minHeightPx = rememberState.minHeightPx
     )
     val currentToolbarHeightDp = rememberState.currentToolbarHeightDp()
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
 
     if (uiState.showErrorDialog) {
         KoinStoreDialog(
@@ -118,7 +123,7 @@ fun CartAddScreen(
                     .offset {
                         IntOffset(
                             0,
-                            currentToolbarHeightDp.value.toPx().roundToInt() + rememberState.toolbarMinHeight.toPx().roundToInt()
+                            currentToolbarHeightDp.value.toPx().roundToInt() + statusBarHeight.toPx().roundToInt()
                         )
                     }
             )
@@ -167,7 +172,7 @@ fun CartAddScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMinHeight + rememberState.toolbarMaxHeight)
+                        .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
                         .graphicsLayer {
                             clip = true
                             translationY = -(rememberState.toolbarMaxHeight.toPx() - currentToolbarHeightDp.value.toPx())

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
@@ -119,7 +119,7 @@ fun CartEditScreen(
                 onSelectedOptionGroup = viewModel::updateSelectedOptionGroup,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(bottom = rememberState.toolbarMinHeight * 2)
+                    .padding(bottom = rememberState.toolbarMinHeight + statusBarHeight)
                     .offset {
                         IntOffset(
                             0,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
@@ -52,6 +52,7 @@ import `in`.koreatech.koin.feature.store.model.LocalShopMenuOptionGroup
 import `in`.koreatech.koin.feature.store.model.LocalShopPrice
 import `in`.koreatech.koin.feature.store.scroll.storeCollapsingToolbarConnection
 import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
+import `in`.koreatech.koin.feature.store.util.customCollapsingToolbarContent
 import kotlin.math.roundToInt
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -173,10 +174,11 @@ fun CartEditScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
-                        .graphicsLayer {
-                            clip = true
-                            translationY = -(rememberState.toolbarMaxHeight.toPx() - currentToolbarHeightDp.value.toPx())
-                        }
+                        .customCollapsingToolbarContent(
+                            maxToolbarHeight = rememberState.toolbarMaxHeight,
+                            currentToolbarHeight = currentToolbarHeightDp.value,
+                            overlayAlpha = overlayAlpha.value
+                        )
                         .zIndex(1f)
                 ) {
                     Image(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/edit/CartEditScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -12,6 +14,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
@@ -77,6 +80,7 @@ fun CartEditScreen(
         minHeightPx = rememberState.minHeightPx
     )
     val currentToolbarHeightDp = rememberState.currentToolbarHeightDp()
+    val statusBarHeight = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
 
     if (uiState.showErrorDialog) {
         KoinStoreDialog(
@@ -119,7 +123,7 @@ fun CartEditScreen(
                     .offset {
                         IntOffset(
                             0,
-                            currentToolbarHeightDp.value.toPx().roundToInt() + rememberState.toolbarMinHeight.toPx().roundToInt()
+                            currentToolbarHeightDp.value.toPx().roundToInt() + statusBarHeight.toPx().roundToInt()
                         )
                     }
             )
@@ -168,7 +172,7 @@ fun CartEditScreen(
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMinHeight + rememberState.toolbarMaxHeight)
+                        .heightIn(rememberState.toolbarMinHeight, rememberState.toolbarMaxHeight + statusBarHeight)
                         .graphicsLayer {
                             clip = true
                             translationY = -(rememberState.toolbarMaxHeight.toPx() - currentToolbarHeightDp.value.toPx())


### PR DESCRIPTION
issue #932 

## 개요
* 과도한 Recomposition 해결

## 작업 내용
* `CustomCollapsingToolbarState`를 리팩토링 했습니다. 변경 사항은 다음과 같습니다
  *  `progress()` 및 `currentToolbarHeightDp()` 함수를 `CustomCollapsingToolbarState`의 멤버 함수로 변경했습니다.
  * `progress()` 및 `currentToolbarHeightDp()`의 반환 타입을 `State<*>`로 수정했습니다. 일반 값으로 반환 할 경우 Recomposition을 발생시킵니다.
  * `@Immutable` 어노테이션을 추가했습니다. `CustomCollapsingToolbarState`는 불변입니다.
  * `toolbarHeightPx` 및 `minHeightPx`를 불변으로 변경했습니다. 해당 값들은 생성 이후에 변경될 필요가 없으며, 변경 시 Recomposition을 발생시킵니다.
* `KoinStoreTopAppBar`를 수정했습니다
  * `overlayAlpha`를 추가했습니다. 1f일 경우 collapse된 toolbar가, 0f일 경우 expanded된 toolbar가 보여집니다.
  * expanded 상태의 toolbar 색상을 위한 `expandedColors`를 추가했습니다. 기본값을 투명 배경에 하얀색 아이콘 색상입니다.
  * expanded 상태에서 보여야 하는 content를 위해 `content`를 추가했습니다.
* `CartAddScreen`, `CartEditScreen` 및 `StoreDetailScreen`을 수정했습니다.
  * `padding` 및 `height` 대신 `offset`을 사용해 위치를 설정하도록 수정했습니다. offset을 사용하면 recomposition을 발생시키지 않습니다.
  * 색상의 alpha값을 조정하는 대신, `graphicsLayer`를 사용해 alpha 값을 선언하였습니다. 색상이 변경될 때 발생하던 recomposition을 수정했습니다.
  * `heightIn`을 사용해 toolbar 내부 content의 크기가 범위 내에서 유동적으로 변경될 수 있도록 수정했습니다.
    * 최소 높이는 `toolbarMinHeight`입니다.
    * 최대 높이는 `statusbarheight` + `toolbarMaxHeight`입니다.
  * toolbar 하단의 content들의 offset은 0, `currentToolbarHeightDp` + `statusbarheight`입니다.
    * `currentToolbarHeightDp` 현재 toolbar의 크기를 나타냅니다. 
  * toolbar 하단의 content들에 offset과 동일한 크기의 하단 padding을 추가했습니다.
    * offset을 사용하면 content들이 아래로 밀려 systemui와 겹치는 문제가 발생합니다. 이를 수정하기 위함입니다.

## 추가적인 내용
* 리뷰하다 궁금한 점 생기면 말씀 해주세요