### PR TITLE
[Campus][fix] 동아리 인스타 링크가 정상적으로 이동하지 않는 문제 해결

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -583,7 +583,7 @@ fun ClubDetail(
                                     }
                                     DETAIL_INSTAGRAM -> {
                                         val url = if (it.isValidUrlScheme()) it else it.toHttpsUrl()
-                                        linkUrl = if (url.isValidInstagramUrl()) url else url.toInstagramUrl()
+                                        linkUrl = if (url.isValidInstagramUrl()) url else url.removeUrlScheme().toInstagramUrl()
                                         onClick = { viewModel.openUrl(linkUrl) }
                                         outputText = it.toInstagramLink()
                                     }


### PR DESCRIPTION
issue #951
## 개요
- 동아리 인스타 링크가 정상적으로 이동하지 않는 문제 해결

## 작업 내용
- 동아리 인스타 정보로 아이디만 넘어올 경우
첫 번째 urlScheme 판정에서 false -> urlScheme 이 추가됨 => bcsdlab 이 https://bcsdlab 이 됨 (*이 부분이 문제)
두 번째 instagramUrl 판정에서 false -> "(인스타링크)/해당 문자열" 이 됨 => (인스타링크)/https://bcsdlab 이 됨
(인스타링크)/https://bcsdlab 는 존재하지 않는 링크 즉 정상작동하지 않음
- 해결 
인스타 링크 조정 전에 urlScheme 제거
(기본적으로 저 판정문을 들어올 때 완벽한 인스타 링크 문장 혹은 인스타 아이디만 있는 경우 2가지 뿐으로 제거해도 문제 없음)

아주 간단한거라 해외에서 해결했습니다.