### PR TITLE
[Business][Fix] 장바구니에 다른 가게 상품이 있을 경우 담기지 않던 문제 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddScreen.kt
@@ -49,6 +49,14 @@ import `in`.koreatech.koin.feature.store.component.KoinStoreDialog
 import `in`.koreatech.koin.feature.store.component.KoinStoreProgressIndicator
 import `in`.koreatech.koin.feature.store.component.KoinStoreTopAppBar
 import `in`.koreatech.koin.feature.store.component.QuantitySelectorSection
+import `in`.koreatech.koin.feature.store.enums.CartError.DIFFERENT_SHOP_ITEM_IN_CART
+import `in`.koreatech.koin.feature.store.enums.CartError.INVALID_MENU_IN_SHOP
+import `in`.koreatech.koin.feature.store.enums.CartError.MAX_SELECTION_EXCEEDED
+import `in`.koreatech.koin.feature.store.enums.CartError.MENU_SOLD_OUT
+import `in`.koreatech.koin.feature.store.enums.CartError.MIN_SELECTION_NOT_MET
+import `in`.koreatech.koin.feature.store.enums.CartError.NONE
+import `in`.koreatech.koin.feature.store.enums.CartError.REQUIRED_OPTION_GROUP_MISSING
+import `in`.koreatech.koin.feature.store.enums.CartError.SHOP_CLOSED
 import `in`.koreatech.koin.feature.store.model.LocalShopMenuOptionGroup
 import `in`.koreatech.koin.feature.store.model.LocalShopPrice
 import `in`.koreatech.koin.feature.store.scroll.storeCollapsingToolbarConnection
@@ -86,7 +94,18 @@ fun CartAddScreen(
         KoinStoreDialog(
             message = stringResource(uiState.error.message),
             onDismissRequest = viewModel::dismissErrorDialog
-        )
+        ) {
+            when (uiState.error) {
+                DIFFERENT_SHOP_ITEM_IN_CART -> viewModel.resetCart()
+                NONE,
+                MENU_SOLD_OUT,
+                REQUIRED_OPTION_GROUP_MISSING,
+                MIN_SELECTION_NOT_MET,
+                MAX_SELECTION_EXCEEDED,
+                INVALID_MENU_IN_SHOP,
+                SHOP_CLOSED -> viewModel.dismissErrorDialog()
+            }
+        }
     }
 
     Box(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/cart/add/CartAddViewModel.kt
@@ -9,6 +9,7 @@ import `in`.koreatech.koin.domain.model.store.CartAdd
 import `in`.koreatech.koin.domain.usecase.store.AddCartItemUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetCartItemsCountUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetOrderableShopMenuUseCase
+import `in`.koreatech.koin.domain.usecase.store.ResetCartUseCase
 import `in`.koreatech.koin.feature.store.enums.CartError
 import `in`.koreatech.koin.feature.store.model.toLocalShopMenuOptionGroup
 import `in`.koreatech.koin.feature.store.model.toLocalShopPrice
@@ -26,7 +27,8 @@ class CartAddViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getOrderableShopMenuUseCase: GetOrderableShopMenuUseCase,
     private val getCartItemsCountUseCase: GetCartItemsCountUseCase,
-    private val addCartItemUseCase: AddCartItemUseCase
+    private val addCartItemUseCase: AddCartItemUseCase,
+    private val resetCartUseCase: ResetCartUseCase
 ) : ViewModel(), ContainerHost<CartAddState, CartAddSideEffect> {
     override val container = container<CartAddState, CartAddSideEffect>(CartAddState()) {
         val orderableShopId = savedStateHandle.get<Int>(ORDERABLE_SHOP_ID)
@@ -206,6 +208,24 @@ class CartAddViewModel @Inject constructor(
     fun updateQuantity(quantity: Int) = intent {
         reduce {
             state.copy(quantity = quantity)
+        }
+    }
+
+    fun resetCart() = intent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        resetCartUseCase().onSuccess {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            addCartItem() // Call add cart again
+            dismissErrorDialog()
+        }.onFailure {
+            // Should not happen
+            reduce {
+                state.copy(isLoading = false)
+            }
         }
     }
 }


### PR DESCRIPTION
issue #932 

## 개요
* 장바구니에 다른 가게 상품이 있을 경우 담기지 않던 문제 수정

## 작업 내용
* 장바구니에 다른 가게 상품이 있을 경우, 장바구니를 초기화하고 아이템을 추가하도록 수정했습니다.

## 추가적인 내용
* 코드가 좀 지저분한 것 같은데, 다른 좋은 방법 있으면 말씀 해주세요