### PR TITLE
[Business][Fix] 상점 메인에서 장바구니 아이템 갯수를 표시하도록 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.feature.store.view.main.home
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -23,10 +25,12 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -40,6 +44,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -110,12 +115,36 @@ fun StoreHomeScreen(
                 onBackPressed()
             },
             actions = {
-                IconButton(onClick = navigateToCart) {
-                    Icon(
-                        modifier = Modifier.size(25.dp),
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_shopping_cart),
-                        contentDescription = null
-                    )
+                Box(contentAlignment = Alignment.TopEnd) {
+                    IconButton(onClick = {
+                        navigateToCart()
+                    }) {
+                        Icon(
+                            modifier = Modifier.size(25.dp),
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_shopping_cart),
+                            contentDescription = null
+                        )
+                    }
+                    if (uiState.cartItemCount > 0) {
+                        Box(
+                            modifier = Modifier
+                                .offset(x = (-5).dp, y = 5.dp)
+                                .size(16.dp)
+                                .background(RebrandKoinTheme.colors.primary500, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "${uiState.cartItemCount}",
+                                style = RebrandKoinTheme.typography.medium12.copy(
+                                    color = RebrandKoinTheme.colors.neutral0,
+                                    lineHeightStyle = LineHeightStyle(
+                                        trim = LineHeightStyle.Trim.Both,
+                                        alignment = LineHeightStyle.Alignment.Center
+                                    )
+                                )
+                            )
+                        }
+                    }
                 }
             },
             colors = TopAppBarDefaults.centerAlignedTopAppBarColors(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeState.kt
@@ -15,5 +15,6 @@ data class StoreHomeState(
     val showMinimumPriceOptions: Boolean = false,
     val selectedOrderOption: OrderOption = OrderOption.NONE,
     val selectedStoreFilter: List<StoreFilter> = listOf(StoreFilter.IS_OPEN),
-    val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL
+    val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL,
+    val cartItemCount: Int = 0
 )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.feature.store.view.main.home
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.usecase.store.GetCartItemsCountUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetOrderableShopsUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetStoreCategoriesUseCase
 import `in`.koreatech.koin.feature.store.enums.MinimumPriceOption
@@ -19,11 +20,13 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class StoreHomeViewModel @Inject constructor(
     private val getStoreCategoriesUseCase: GetStoreCategoriesUseCase,
+    private val getCartItemsCountUseCase: GetCartItemsCountUseCase,
     private val getOrderableShopsUseCase: GetOrderableShopsUseCase
 ) : ViewModel(), ContainerHost<StoreHomeState, StoreHomeSideEffect> {
     override val container = container<StoreHomeState, StoreHomeSideEffect>(StoreHomeState())
 
     init {
+        getCartItemsCount()
         intent {
             getStoreCategoriesUseCase().let {
                 reduce {
@@ -31,6 +34,21 @@ class StoreHomeViewModel @Inject constructor(
                         storeCategories = it.map { it.toLocalStoreCategories() }
                     )
                 }
+            }
+        }
+    }
+
+    private fun getCartItemsCount() = intent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        getCartItemsCountUseCase().onSuccess { count ->
+            reduce {
+                state.copy(cartItemCount = count.totalQuantity, isLoading = false)
+            }
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
             }
         }
     }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.feature.store.view.main.nearby
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -22,10 +24,12 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,6 +43,7 @@ import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -100,12 +105,36 @@ fun StoreNearbyScreen(
                 onBackPressed()
             },
             actions = {
-                IconButton(onClick = navigateToCart) {
-                    Icon(
-                        modifier = Modifier.size(25.dp),
-                        imageVector = ImageVector.vectorResource(id = R.drawable.ic_shopping_cart),
-                        contentDescription = null
-                    )
+                Box(contentAlignment = Alignment.TopEnd) {
+                    IconButton(onClick = {
+                        navigateToCart()
+                    }) {
+                        Icon(
+                            modifier = Modifier.size(25.dp),
+                            imageVector = ImageVector.vectorResource(id = R.drawable.ic_shopping_cart),
+                            contentDescription = null
+                        )
+                    }
+                    if (uiState.cartItemCount > 0) {
+                        Box(
+                            modifier = Modifier
+                                .offset(x = (-5).dp, y = 5.dp)
+                                .size(16.dp)
+                                .background(RebrandKoinTheme.colors.primary500, CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "${uiState.cartItemCount}",
+                                style = RebrandKoinTheme.typography.medium12.copy(
+                                    color = RebrandKoinTheme.colors.neutral0,
+                                    lineHeightStyle = LineHeightStyle(
+                                        trim = LineHeightStyle.Trim.Both,
+                                        alignment = LineHeightStyle.Alignment.Center
+                                    )
+                                )
+                            )
+                        }
+                    }
                 }
             },
             colors = TopAppBarDefaults.centerAlignedTopAppBarColors(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyState.kt
@@ -17,5 +17,6 @@ data class StoreNearbyState(
     val showMinimumPriceOptions: Boolean = false,
     val selectedOrderOption: OrderOption = OrderOption.NONE,
     val selectedStoreFilter: List<StoreFilter> = listOf(StoreFilter.IS_OPEN),
-    val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL
+    val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL,
+    val cartItemCount: Int = 0
 )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.feature.store.view.main.nearby
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.usecase.store.GetCartItemsCountUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetNearbyShopUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetStoreCategoriesUseCase
 import `in`.koreatech.koin.feature.store.enums.MinimumPriceOption
@@ -20,11 +21,13 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class StoreNearbyViewModel @Inject constructor(
     private val getStoreCategoriesUseCase: GetStoreCategoriesUseCase,
+    private val getCartItemsCountUseCase: GetCartItemsCountUseCase,
     private val getNearbyShopUseCase: GetNearbyShopUseCase
 ) : ViewModel(), ContainerHost<StoreNearbyState, StoreNearbySideEffect> {
     override val container = container<StoreNearbyState, StoreNearbySideEffect>(StoreNearbyState())
 
     init {
+        getCartItemsCount()
         intent {
             getStoreCategoriesUseCase().let {
                 reduce {
@@ -32,6 +35,21 @@ class StoreNearbyViewModel @Inject constructor(
                         storeCategories = it.map { it.toLocalStoreCategories() }
                     )
                 }
+            }
+        }
+    }
+
+    private fun getCartItemsCount() = intent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        getCartItemsCountUseCase().onSuccess { count ->
+            reduce {
+                state.copy(cartItemCount = count.totalQuantity, isLoading = false)
+            }
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
             }
         }
     }


### PR DESCRIPTION
issue #932 

## 개요
* 상점 메인에서 장바구니 아이템 갯수를 표시하도록 수정

## 작업 내용
* 상점 메인화면 Toolbar에 장바구니 아이템 갯수를 표시하도록 수정했습니다.

## 추가적인 내용
* 저거 많이 쓰이는데 별도의 Composable로 분리할까요