### PR TITLE
[Koin Project][Refactor] core:navigation 모듈 리팩토링

### DIFF
--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
@@ -6,14 +6,9 @@ import android.content.Intent
 interface Navigator {
     fun navigateToSplash(
         context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        targetBoardId: Pair<String, Any?> = Pair("", 0),
-        targetArticleId: Pair<String, Any?> = Pair("", 0),
-        targetChatId: Pair<String, Any?> = Pair("", 0),
-        targetClubId: Pair<String, Any?> = Pair("", 0),
-        targetEventId: Pair<String, Any?> = Pair("", 0),
         type: Pair<String, Any?> = Pair("", ""),
-        navType: Pair<String, Any?> = Pair("", "")
+        navType: Pair<String, Any?> = Pair("", ""),
+        vararg args: Pair<String, Any?>
     ): Intent
 
     fun navigateTo(

--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
@@ -16,59 +16,9 @@ interface Navigator {
         navType: Pair<String, Any?> = Pair("", "")
     ): Intent
 
-    fun navigateToMain(
+    fun navigateTo(
         context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        targetBoardId: Pair<String, Any?> = Pair("", 0),
-        targetArticleId: Pair<String, Any?> = Pair("", 0),
-        targetChatId: Pair<String, Any?> = Pair("", 0),
-        targetClubId: Pair<String, Any?> = Pair("", 0),
-        targetEventId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToShop(
-        context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToDinging(
-        context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToArticle(
-        context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        targetBoardId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToArticleLostAndFound(
-        context: Context,
-        targetId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToChat(
-        context: Context,
-        targetArticleId: Pair<String, Any?> = Pair("", 0),
-        targetChatId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToClubRecruitment(
-        context: Context,
-        targetClubId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
-    ): Intent
-
-    fun navigateToClub(
-        context: Context,
-        targetClubId: Pair<String, Any?> = Pair("", 0),
-        targetEventId: Pair<String, Any?> = Pair("", 0),
-        type: Pair<String, Any?> = Pair("", "")
+        type: Pair<String, String?> = Pair("", ""), // SchemeType
+        vararg args: Pair<String, Any?> // Extra IDs
     ): Intent
 }

--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/NavigatorType.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/NavigatorType.kt
@@ -6,14 +6,3 @@ enum class NavigatorType(
     MAIN("main"),
     DETAIL("detail")
 }
-
-enum class SchemeType(
-    val type: String
-) {
-    SHOP("shop"),
-    DINING("dining"),
-    ARTICLE("keyword"),
-    CHAT("chat"),
-    CLUB_RECRUIT("club-recruitment"),
-    CLUB("club")
-}

--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/utils/Extensions.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/utils/Extensions.kt
@@ -10,6 +10,11 @@ inline fun <reified T : Activity> Context.buildIntent(vararg argument: Pair<Stri
         putExtras(bundleOf(*argument))
     }
 
+fun Context.buildIntent(className: Class<*>, vararg argument: Pair<String, Any?>) =
+    Intent(this, className).apply {
+        putExtras(bundleOf(*argument))
+    }
+
 inline fun <reified T : Activity> Context.goToActivity(vararg argument: Pair<String, Any?>) {
     startActivity(buildIntent<T>(*argument))
 }

--- a/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
@@ -12,25 +12,11 @@ import kotlin.jvm.java
 class NavigatorImpl @Inject constructor() : Navigator {
     override fun navigateToSplash(
         context: Context,
-        targetId: Pair<String, Any?>,
-        targetBoardId: Pair<String, Any?>,
-        targetArticleId: Pair<String, Any?>,
-        targetChatId: Pair<String, Any?>,
-        targetClubId: Pair<String, Any?>,
-        targetEventId: Pair<String, Any?>,
         type: Pair<String, Any?>,
-        navType: Pair<String, Any?>
+        navType: Pair<String, Any?>,
+        vararg args: Pair<String, Any?>
     ): Intent {
-        val intent = context.buildIntent<SplashActivity>(
-            targetId,
-            targetBoardId,
-            targetArticleId,
-            targetChatId,
-            targetClubId,
-            targetEventId,
-            type,
-            navType
-        )
+        val intent = context.buildIntent<SplashActivity>(type, navType, *args)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         return intent
     }

--- a/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
@@ -3,16 +3,11 @@ package `in`.koreatech.koin.navigation
 import android.content.Context
 import android.content.Intent
 import `in`.koreatech.koin.core.navigation.Navigator
-import `in`.koreatech.koin.core.navigation.utils.EXTRA_BOARD_ID
 import `in`.koreatech.koin.core.navigation.utils.buildIntent
-import `in`.koreatech.koin.feature.chat.ui.room.ChatRoomActivity
-import `in`.koreatech.koin.feature.club.ui.ClubActivity
-import `in`.koreatech.koin.ui.article.ArticleActivity
-import `in`.koreatech.koin.ui.dining.DiningActivity
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.splash.SplashActivity
-import `in`.koreatech.koin.ui.store.activity.StoreActivity
 import javax.inject.Inject
+import kotlin.jvm.java
 
 class NavigatorImpl @Inject constructor() : Navigator {
     override fun navigateToSplash(
@@ -40,102 +35,13 @@ class NavigatorImpl @Inject constructor() : Navigator {
         return intent
     }
 
-    override fun navigateToMain(
+    override fun navigateTo(
         context: Context,
-        targetId: Pair<String, Any?>,
-        targetBoardId: Pair<String, Any?>,
-        targetArticleId: Pair<String, Any?>,
-        targetChatId: Pair<String, Any?>,
-        targetClubId: Pair<String, Any?>,
-        targetEventId: Pair<String, Any?>,
-        type: Pair<String, Any?>
+        type: Pair<String, String?>,
+        vararg args: Pair<String, Any?>
     ): Intent {
-        val intent = context.buildIntent<MainActivity>(
-            targetId,
-            targetBoardId,
-            targetArticleId,
-            targetChatId,
-            targetClubId,
-            targetEventId,
-            type
-        )
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToShop(
-        context: Context,
-        targetId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<StoreActivity>(targetId, type)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToDinging(
-        context: Context,
-        targetId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<DiningActivity>(targetId, type)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToArticle(
-        context: Context,
-        targetId: Pair<String, Any?>,
-        targetBoardId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<ArticleActivity>(targetId, targetBoardId, type)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToArticleLostAndFound(
-        context: Context,
-        targetId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<ArticleActivity>(
-            targetId,
-            Pair(EXTRA_BOARD_ID, 14),
-            type
-        )
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToChat(
-        context: Context,
-        targetArticleId: Pair<String, Any?>,
-        targetChatId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<ChatRoomActivity>(targetArticleId, targetChatId, type)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToClubRecruitment(
-        context: Context,
-        targetClubId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<ClubActivity>(targetClubId, type)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        return intent
-    }
-
-    override fun navigateToClub(
-        context: Context,
-        targetClubId: Pair<String, Any?>,
-        targetEventId: Pair<String, Any?>,
-        type: Pair<String, Any?>
-    ): Intent {
-        val intent = context.buildIntent<ClubActivity>(targetClubId, targetEventId, type)
+        val className = SchemeType.fromType(type.second)?.className ?: return context.buildIntent(MainActivity::class.java)
+        val intent = context.buildIntent(className, type, *args)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         return intent
     }

--- a/koin/src/main/java/in/koreatech/koin/navigation/SchemeType.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/SchemeType.kt
@@ -1,12 +1,25 @@
 package `in`.koreatech.koin.navigation
 
+import `in`.koreatech.koin.feature.chat.ui.room.ChatRoomActivity
+import `in`.koreatech.koin.feature.club.ui.ClubActivity
+import `in`.koreatech.koin.ui.article.ArticleActivity
+import `in`.koreatech.koin.ui.dining.DiningActivity
+import `in`.koreatech.koin.ui.store.activity.StoreActivity
+
 enum class SchemeType(
-    val type: String
+    val type: String,
+    val className: Class<*>
 ) {
-    SHOP("shop"),
-    DINING("dining"),
-    ARTICLE("keyword"),
-    CHAT("chat"),
-    CLUB_RECRUIT("club-recruitment"),
-    CLUB("club")
+    SHOP("shop", StoreActivity::class.java),
+    DINING("dining", DiningActivity::class.java),
+    ARTICLE("keyword", ArticleActivity::class.java),
+    CHAT("chat", ChatRoomActivity::class.java),
+    CLUB_RECRUIT("club-recruitment", ClubActivity::class.java),
+    CLUB("club", ClubActivity::class.java);
+
+    companion object {
+        fun fromType(type: String?): SchemeType? {
+            return entries.find { it.type == type }
+        }
+    }
 }

--- a/koin/src/main/java/in/koreatech/koin/navigation/SchemeType.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/SchemeType.kt
@@ -1,0 +1,12 @@
+package `in`.koreatech.koin.navigation
+
+enum class SchemeType(
+    val type: String
+) {
+    SHOP("shop"),
+    DINING("dining"),
+    ARTICLE("keyword"),
+    CHAT("chat"),
+    CLUB_RECRUIT("club-recruitment"),
+    CLUB("club")
+}

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -40,7 +40,6 @@ import `in`.koreatech.koin.core.analytics.EventExtra
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.analytics.EventUtils
 import `in`.koreatech.koin.core.navigation.Navigator
-import `in`.koreatech.koin.core.navigation.SchemeType
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_ARTICLE_ID
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_BOARD_ID
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_CHAT_ROOM_ID
@@ -430,84 +429,18 @@ class MainActivity : KoinNavigationDrawerTimeActivity() {
         val targetEventId = intent.getIntExtra(EXTRA_EVENT_ID, -1)
         val type = intent.getStringExtra(EXTRA_TYPE) ?: ""
 
-        when (type) {
-            SchemeType.SHOP.type -> {
-                val intent =
-                    navigator.navigateToShop(
-                        context = this,
-                        targetId = Pair(EXTRA_ID, targetId),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            SchemeType.DINING.type -> {
-                val intent =
-                    navigator.navigateToDinging(
-                        context = this,
-                        targetId = Pair(EXTRA_ID, targetId),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            SchemeType.ARTICLE.type -> {
-                val intent =
-                    navigator.navigateToArticle(
-                        context = this,
-                        targetId = Pair(EXTRA_ID, targetId),
-                        targetBoardId = Pair(EXTRA_BOARD_ID, targetBoardId),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            SchemeType.CHAT.type -> {
-                val intent =
-                    navigator.navigateToChat(
-                        context = this,
-                        targetArticleId = Pair(EXTRA_ARTICLE_ID, targetArticleId),
-                        targetChatId = Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            SchemeType.CLUB_RECRUIT.type -> {
-                val intent =
-                    navigator.navigateToClubRecruitment(
-                        context = this,
-                        targetClubId = Pair(
-                            EXTRA_CLUB_ID,
-                            targetId
-                        ),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            SchemeType.CLUB.type -> {
-                val intent =
-                    navigator.navigateToClub(
-                        context = this,
-                        targetClubId = Pair(
-                            EXTRA_CLUB_ID,
-                            targetClubId
-                        ),
-                        targetEventId = Pair(
-                            EXTRA_EVENT_ID,
-                            targetEventId
-                        ),
-                        type = Pair(EXTRA_TYPE, type)
-                    )
-                startActivity(intent)
-            }
-
-            else -> {
-                // Banner shouldn't popup on other page
-                initBanner()
-            }
-        }
+        navigator.navigateTo(
+            context = this,
+            type = Pair(EXTRA_TYPE, type),
+            *arrayOf(
+                Pair(EXTRA_ID, targetId),
+                Pair(EXTRA_BOARD_ID, targetBoardId),
+                Pair(EXTRA_ARTICLE_ID, targetArticleId),
+                Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
+                Pair(EXTRA_CLUB_ID, targetClubId),
+                Pair(EXTRA_EVENT_ID, targetEventId)
+            )
+        )
     }
 
     private fun initArticleBannerABTest() {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -60,6 +60,7 @@ import `in`.koreatech.koin.domain.model.store.StoreCategories
 import `in`.koreatech.koin.feature.banner.ui.BannerActivity
 import `in`.koreatech.koin.feature.club.ui.MainClubWidgetA
 import `in`.koreatech.koin.feature.club.ui.MainClubWidgetB
+import `in`.koreatech.koin.navigation.SchemeType
 import `in`.koreatech.koin.ui.article.ArticleActivity
 import `in`.koreatech.koin.ui.dining.DiningActivity
 import `in`.koreatech.koin.ui.main.adapter.ArticleMainAdapter
@@ -429,18 +430,32 @@ class MainActivity : KoinNavigationDrawerTimeActivity() {
         val targetEventId = intent.getIntExtra(EXTRA_EVENT_ID, -1)
         val type = intent.getStringExtra(EXTRA_TYPE) ?: ""
 
-        navigator.navigateTo(
-            context = this,
-            type = Pair(EXTRA_TYPE, type),
-            *arrayOf(
-                Pair(EXTRA_ID, targetId),
-                Pair(EXTRA_BOARD_ID, targetBoardId),
-                Pair(EXTRA_ARTICLE_ID, targetArticleId),
-                Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
-                Pair(EXTRA_CLUB_ID, targetClubId),
-                Pair(EXTRA_EVENT_ID, targetEventId)
-            )
-        )
+        when (type) {
+            SchemeType.SHOP.type,
+            SchemeType.DINING.type,
+            SchemeType.ARTICLE.type,
+            SchemeType.CHAT.type,
+            SchemeType.CLUB_RECRUIT.type,
+            SchemeType.CLUB.type -> {
+                navigator.navigateTo(
+                    context = this,
+                    type = Pair(EXTRA_TYPE, type),
+                    *arrayOf(
+                        Pair(EXTRA_ID, targetId),
+                        Pair(EXTRA_BOARD_ID, targetBoardId),
+                        Pair(EXTRA_ARTICLE_ID, targetArticleId),
+                        Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
+                        Pair(EXTRA_CLUB_ID, targetClubId),
+                        Pair(EXTRA_EVENT_ID, targetEventId)
+                    )
+                )
+            }
+
+            else -> {
+                // Banner shouldn't popup on other page
+                initBanner()
+            }
+        }
     }
 
     private fun initArticleBannerABTest() {

--- a/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
@@ -84,26 +84,9 @@ class SchemeActivity : ActivityBase() {
                     val intent =
                         navigator.navigateToSplash(
                             context = this,
-                            targetId = Pair(EXTRA_ID, getIdFromUrl(url ?: "")),
-                            targetBoardId = Pair(EXTRA_BOARD_ID, getBoardIdFromUrl(url ?: "")),
-                            targetArticleId = Pair(
-                                EXTRA_ARTICLE_ID,
-                                getArticleIdFromUrl(url ?: "")
-                            ),
-                            targetChatId = Pair(
-                                EXTRA_CHAT_ROOM_ID,
-                                getChatRoomIdFromUrl(url ?: "")
-                            ),
-                            targetClubId = Pair(
-                                EXTRA_CLUB_ID,
-                                getClubIdFromUrl(url ?: "")
-                            ),
-                            targetEventId = Pair(
-                                EXTRA_EVENT_ID,
-                                getEventIdFromUrl(url ?: "")
-                            ),
                             type = Pair(EXTRA_TYPE, url?.toHost()),
-                            navType = Pair(EXTRA_NAV_TYPE, NavigatorType.MAIN.type)
+                            navType = Pair(EXTRA_NAV_TYPE, NavigatorType.MAIN.type),
+                            *(getExtraIds(url ?: "").toTypedArray())
                         )
                     navigateToActivity(intent)
                 }

--- a/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
@@ -110,7 +110,7 @@ class SchemeActivity : ActivityBase() {
                 EventLogger.logNotificationEvent(
                     EventAction.CAMPUS,
                     AnalyticsConstant.Label.KEYWORD_NOTIFICATION,
-                    getKeywordFromUrl(url)
+                    getKeywordFromUrl(url) ?: ""
                 )
             }
         }
@@ -131,28 +131,28 @@ class SchemeActivity : ActivityBase() {
         return Uri.parse(url).getQueryParameter("id")?.toIntOrNull()
     }
 
-    private fun getArticleIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("articleId")?.toIntOrNull() ?: -1
+    private fun getArticleIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("articleId")?.toIntOrNull()
     }
 
-    private fun getChatRoomIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("chatRoomId")?.toIntOrNull() ?: -1
+    private fun getChatRoomIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("chatRoomId")?.toIntOrNull()
     }
 
-    private fun getBoardIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("board-id")?.toIntOrNull() ?: -1
+    private fun getBoardIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("board-id")?.toIntOrNull()
     }
 
-    private fun getKeywordFromUrl(url: String): String {
-        return Uri.parse(url).getQueryParameter("keyword") ?: ""
+    private fun getKeywordFromUrl(url: String): String? {
+        return Uri.parse(url).getQueryParameter("keyword")
     }
 
-    private fun getClubIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("clubId")?.toIntOrNull() ?: -1
+    private fun getClubIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("clubId")?.toIntOrNull()
     }
 
-    private fun getEventIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("eventId")?.toIntOrNull() ?: -1
+    private fun getEventIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("eventId")?.toIntOrNull()
     }
 
     private fun navigateToActivity(intent: Intent) {

--- a/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/scheme/SchemeActivity.kt
@@ -12,7 +12,6 @@ import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.navigation.NavigatorType
-import `in`.koreatech.koin.core.navigation.SchemeType
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_ARTICLE_ID
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_BOARD_ID
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_CHAT_ROOM_ID
@@ -24,6 +23,7 @@ import `in`.koreatech.koin.core.navigation.utils.EXTRA_TYPE
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_URL
 import `in`.koreatech.koin.core.navigation.utils.toHost
 import `in`.koreatech.koin.databinding.ActivitySchemeBinding
+import `in`.koreatech.koin.navigation.SchemeType
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import javax.inject.Inject
 import timber.log.Timber
@@ -109,107 +109,43 @@ class SchemeActivity : ActivityBase() {
                 }
 
                 NavigatorType.DETAIL -> {
-                    when (val host = url?.toHost()) {
-                        SchemeType.SHOP.type -> {
-                            val intent =
-                                navigator.navigateToShop(
-                                    context = this,
-                                    targetId = Pair(EXTRA_ID, getIdFromUrl(url)),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        SchemeType.DINING.type -> {
-                            val intent =
-                                navigator.navigateToDinging(
-                                    context = this,
-                                    targetId = Pair(EXTRA_ID, ""),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        SchemeType.ARTICLE.type -> {
-                            EventLogger.logNotificationEvent(
-                                EventAction.CAMPUS,
-                                AnalyticsConstant.Label.KEYWORD_NOTIFICATION,
-                                getKeywordFromUrl(url)
-                            )
-                            val intent =
-                                navigator.navigateToArticle(
-                                    context = this,
-                                    targetId = Pair(EXTRA_ID, getIdFromUrl(url)),
-                                    targetBoardId = Pair(EXTRA_BOARD_ID, getBoardIdFromUrl(url)),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        SchemeType.CHAT.type -> {
-                            val intent =
-                                navigator.navigateToChat(
-                                    context = this,
-                                    targetArticleId = Pair(
-                                        EXTRA_ARTICLE_ID,
-                                        getArticleIdFromUrl(url)
-                                    ),
-                                    targetChatId = Pair(
-                                        EXTRA_CHAT_ROOM_ID,
-                                        getChatRoomIdFromUrl(url)
-                                    ),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        SchemeType.CLUB_RECRUIT.type -> {
-                            val intent =
-                                navigator.navigateToClubRecruitment(
-                                    context = this,
-                                    targetClubId = Pair(
-                                        EXTRA_CLUB_ID,
-                                        getIdFromUrl(url)
-                                    ),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        SchemeType.CLUB.type -> {
-                            val intent =
-                                navigator.navigateToClub(
-                                    context = this,
-                                    targetClubId = Pair(
-                                        EXTRA_CLUB_ID,
-                                        getClubIdFromUrl(url)
-                                    ),
-                                    targetEventId = Pair(
-                                        EXTRA_EVENT_ID,
-                                        getEventIdFromUrl(url)
-                                    ),
-                                    type = Pair(EXTRA_TYPE, host)
-                                )
-                            navigateToActivity(intent)
-                        }
-
-                        else -> {
-                            val intent = navigator.navigateToMain(context = this)
-                            navigateToActivity(intent)
-                        }
-                    }
-                }
-
-                else -> {
-                    val intent = navigator.navigateToMain(context = this)
+                    logging(url)
+                    val intent = navigator.navigateTo(
+                        context = this,
+                        type = Pair(EXTRA_TYPE, url?.toHost()),
+                        *(getExtraIds(url ?: "").toTypedArray())
+                    )
                     navigateToActivity(intent)
                 }
             }
         }
     }
 
-    private fun getIdFromUrl(url: String): Int {
-        return Uri.parse(url).getQueryParameter("id")?.toIntOrNull() ?: -1
+    private fun logging(url: String?) {
+        when (url?.toHost()) {
+            SchemeType.ARTICLE.type -> {
+                EventLogger.logNotificationEvent(
+                    EventAction.CAMPUS,
+                    AnalyticsConstant.Label.KEYWORD_NOTIFICATION,
+                    getKeywordFromUrl(url)
+                )
+            }
+        }
+    }
+
+    private fun getExtraIds(url: String): List<Pair<String, Any?>> {
+        return listOf(
+            Pair(EXTRA_ID, getIdFromUrl(url)),
+            Pair(EXTRA_ARTICLE_ID, getArticleIdFromUrl(url)),
+            Pair(EXTRA_CHAT_ROOM_ID, getChatRoomIdFromUrl(url)),
+            Pair(EXTRA_BOARD_ID, getBoardIdFromUrl(url)),
+            Pair(EXTRA_CLUB_ID, getClubIdFromUrl(url)),
+            Pair(EXTRA_EVENT_ID, getEventIdFromUrl(url))
+        ).filter { it.second != null }
+    }
+
+    private fun getIdFromUrl(url: String): Int? {
+        return Uri.parse(url).getQueryParameter("id")?.toIntOrNull()
     }
 
     private fun getArticleIdFromUrl(url: String): Int {

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/SplashActivity.kt
@@ -239,21 +239,22 @@ class SplashActivity : ActivityBase() {
 
         lifecycleScope.launch {
             delay()
-            val intent =
-                if (navType == NavigatorType.MAIN.type) {
-                    navigator.navigateToMain(
-                        context = this@SplashActivity,
-                        targetId = Pair(EXTRA_ID, targetId),
-                        targetBoardId = Pair(EXTRA_BOARD_ID, targetBoardId),
-                        targetArticleId = Pair(EXTRA_ARTICLE_ID, targetArticleId),
-                        targetChatId = Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
-                        targetClubId = Pair(EXTRA_CLUB_ID, targetClubId),
-                        targetEventId = Pair(EXTRA_EVENT_ID, targetEventId),
-                        type = Pair(EXTRA_TYPE, type)
+            val intent = if (navType == NavigatorType.MAIN.type) {
+                navigator.navigateTo(
+                    context = this@SplashActivity,
+                    type = Pair(EXTRA_TYPE, type),
+                    *arrayOf(
+                        Pair(EXTRA_ID, targetId),
+                        Pair(EXTRA_BOARD_ID, targetBoardId),
+                        Pair(EXTRA_ARTICLE_ID, targetArticleId),
+                        Pair(EXTRA_CHAT_ROOM_ID, targetChatId),
+                        Pair(EXTRA_CLUB_ID, targetClubId),
+                        Pair(EXTRA_EVENT_ID, targetEventId)
                     )
-                } else {
-                    Intent(this@SplashActivity, MainActivity::class.java)
-                }
+                )
+            } else {
+                Intent(this@SplashActivity, MainActivity::class.java)
+            }
 
             startActivity(intent)
             overridePendingTransition(R.anim.fade, R.anim.hold)


### PR DESCRIPTION
issue #955 

## 개요
* core:navigation 모듈 리팩토링

## 작업 내용
* SchemeType enum을 koin 모듈로 옮겼습니다.
  * 각 type에는 해당하는 activity를 같이 선언했습니다.
* core:navigation의 navigateTo* 함수를 navigateTo 함수로 통합했습니다.
  * core:navigation에서는 상위 모듈을 알고 있을 필요가 없다고 생각합니다.

## 추가적인 내용
* 이 구조에 확신이 안 들어서 태클은 언제든 환영입니다.
* 이 작업 이후로 Action (SignIn, SignUp) 단위의 navigate 함수를 추가로 구현할 예정입니다.
  * 이를 통해, navigation 모듈을 notification 모듈에서 사용하는 현재 구조에서 벗어나 각 feature 모듈에서 필요한 action으로 이동할 수 있는 구조로 변경할 예정입니다.