### PR TITLE
[Koin Project][Fix] 리뷰어 스크립트 실패 수정

### DIFF
--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -91,7 +91,7 @@ fun pickRandomReviewer(prOwnerTeam: KoinTeam?, developer: Developer) {
         .filter { it.shouldPick }
         .filter { it != randomReviewerFromSameTeam }
         .filter { !it.isMentor }
-        .filter { if (prOwnerTeam != null) it.team.contains(prOwnerTeam) else true }
+        .filter { if (prOwnerTeam != null) !it.team.contains(prOwnerTeam) else true }
     val randomReviewerFromOtherTeam = otherTeamDevelopers.random()
     exportReviewer(randomReviewerFromOtherTeam.githubName, randomReviewerFromSameTeam.githubName)
 }

--- a/.github/scripts/pick_reviewer.kts
+++ b/.github/scripts/pick_reviewer.kts
@@ -75,25 +75,25 @@ fun pickPairedReviewer(developer: Developer) {
 }
 
 /**
- * Pick a random reviewer from the other team members.
+ * Pick a random reviewer.
  * The developer and reviewer should not be in the same team.
  */
 fun pickRandomReviewer(prOwnerTeam: KoinTeam?, developer: Developer) {
+    val otherTeamDevelopers = Developer.entries
+        .filter { it != developer }
+        .filter { it.shouldPick }
+        .filter { !it.isMentor }
+        .filter { if (prOwnerTeam != null) !it.team.contains(prOwnerTeam) else true }
+    val randomReviewerFromOtherTeam = otherTeamDevelopers.random()
+
     val sameTeamDevelopers = Developer.entries
         .filter { it != developer }
         .filter { it.shouldPick }
         .filter { !it.isMentor }
+        .filter { it != randomReviewerFromOtherTeam }
         .filter { if (prOwnerTeam != null) it.team.contains(prOwnerTeam) else true }
-    val randomReviewerFromSameTeam = sameTeamDevelopers.random()
-
-    val otherTeamDevelopers = Developer.entries
-        .filter { it != developer }
-        .filter { it.shouldPick }
-        .filter { it != randomReviewerFromSameTeam }
-        .filter { !it.isMentor }
-        .filter { if (prOwnerTeam != null) !it.team.contains(prOwnerTeam) else true }
-    val randomReviewerFromOtherTeam = otherTeamDevelopers.random()
-    exportReviewer(randomReviewerFromOtherTeam.githubName, randomReviewerFromSameTeam.githubName)
+    val randomReviewerFromSameTeam = sameTeamDevelopers.randomOrNull()
+    exportReviewer(randomReviewerFromOtherTeam.githubName, randomReviewerFromSameTeam?.githubName ?: "")
 }
 
 /**


### PR DESCRIPTION
close #959 

## 개요
* 리뷰어 스크립트 실패 수정

## 작업 내용
* 리뷰어 스크립트에 다른 팀 트랙원을 뽑는 코드에 있던 오타를 수정했습니다.
* 다른 팀 개발자를 우선으로 뽑고, 같은 팀 개발자를 뽑도록 수정했습니다.
  * 한 팀에 한명만 있을 수도 있다고 생각했습니다.
* 만약 같은 팀 개발자가 없다면, 빈 문자열로 넘기도록 수정했습니다. 그런 일은 없었으면 좋겠습니다.

## 추가적인 내용
* 이 간단한 스크립트를 대체 몇번 고치는건지 모르겠네요... 꼼꼼하게 작업 하겠습니다.