### PR TITLE
[Business][Fix] 장바구니 2차 QA 사항 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreDialog.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreDialog.kt
@@ -52,13 +52,13 @@ fun KoinStoreDialog(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clip(RebrandKoinTheme.shapes.extraSmall)
-                    .background(RebrandKoinTheme.colors.primary500, RebrandKoinTheme.shapes.extraSmall),
+                    .background(RebrandKoinTheme.colors.primary500, RebrandKoinTheme.shapes.extraSmall)
+                    .clickable {
+                        onClick()
+                    }.padding(12.dp),
                 contentAlignment = Alignment.Center
             ) {
                 BasicText(
-                    modifier = Modifier.clickable {
-                        onClick()
-                    }.padding(12.dp),
                     text = buttonText,
                     style = RebrandKoinTheme.typography.regular15.copy(
                         color = RebrandKoinTheme.colors.neutral0,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -57,7 +57,15 @@ fun NavGraphBuilder.koinStoreGraph(
         ShoppingCartScreen(
             isCartModified = isCartModified,
             navigateToStoreDetail = { storeId ->
-                navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${true}")
+                val targetRoute = "${StoreDetailNavType.StoreDetailMain.route}/$storeId/${true}"
+                val isPopped = navController.popBackStack(route = targetRoute, inclusive = false)
+                if (!isPopped) {
+                    navController.navigate(targetRoute) {
+                        launchSingleTop = true
+                    }
+                } else {
+                    navController.currentBackStackEntry?.savedStateHandle?.set(IS_CART_MODIFIED, true)
+                }
             },
             navigateToPayment = {
                 navController.navigate(StoreNavType.StorePayment.route)
@@ -66,6 +74,7 @@ fun NavGraphBuilder.koinStoreGraph(
                 navController.navigate("${StoreNavType.StoreCartEdit.route}/$it")
             },
             navigateToStoreMain = {
+                navController.previousBackStackEntry?.savedStateHandle?.set(IS_CART_MODIFIED, false)
                 navController.navigate(StoreNavType.StoreMain.route)
             },
             navigateBack = {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -56,14 +56,8 @@ fun NavGraphBuilder.koinStoreGraph(
 
         ShoppingCartScreen(
             isCartModified = isCartModified,
-            navigateToStoreDetail = {
-                navController.previousBackStackEntry?.savedStateHandle?.set(
-                    IS_CART_MODIFIED,
-                    true
-                )
-                if (!navController.navigateUp()) {
-                    finish()
-                }
+            navigateToStoreDetail = { storeId ->
+                navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${true}")
             },
             navigateToPayment = {
                 navController.navigate(StoreNavType.StorePayment.route)
@@ -73,6 +67,11 @@ fun NavGraphBuilder.koinStoreGraph(
             },
             navigateToStoreMain = {
                 navController.navigate(StoreNavType.StoreMain.route)
+            },
+            navigateBack = {
+                if (!navController.navigateUp()) {
+                    finish()
+                }
             }
         )
     }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -58,14 +58,13 @@ fun NavGraphBuilder.koinStoreGraph(
             isCartModified = isCartModified,
             navigateToStoreDetail = { storeId ->
                 val targetRoute = "${StoreDetailNavType.StoreDetailMain.route}/$storeId/${true}"
-                val isPopped = navController.popBackStack(route = targetRoute, inclusive = false)
-                if (!isPopped) {
-                    navController.navigate(targetRoute) {
-                        launchSingleTop = true
+                navController.navigate(targetRoute) {
+                    launchSingleTop = true
+                    popUpTo(targetRoute) {
+                        inclusive = false
                     }
-                } else {
-                    navController.currentBackStackEntry?.savedStateHandle?.set(IS_CART_MODIFIED, true)
                 }
+                navController.currentBackStackEntry?.savedStateHandle?.set(IS_CART_MODIFIED, false)
             },
             navigateToPayment = {
                 navController.navigate(StoreNavType.StorePayment.route)

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartContent.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartContent.kt
@@ -116,9 +116,11 @@ fun ShoppingCartContent(
                         .weight(1f)
                         .padding(4.dp),
                     onClick = {
-                        onOrderModeChanged(
-                            CartType.DELIVERY
-                        )
+                        if (cartType != CartType.DELIVERY) {
+                            onOrderModeChanged(
+                                CartType.DELIVERY
+                            )
+                        }
                     },
                     enabled = cart.isDeliveryAvailable,
                     shape = RebrandKoinTheme.shapes.medium,
@@ -139,9 +141,11 @@ fun ShoppingCartContent(
                         .weight(1f)
                         .padding(4.dp),
                     onClick = {
-                        onOrderModeChanged(
-                            CartType.TAKE_OUT
-                        )
+                        if (cartType != CartType.TAKE_OUT) {
+                            onOrderModeChanged(
+                                CartType.TAKE_OUT
+                            )
+                        }
                     },
                     enabled = cart.isTakeoutAvailable,
                     shape = RebrandKoinTheme.shapes.medium,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
@@ -44,7 +44,8 @@ fun ShoppingCartScreen(
     navigateToStoreDetail: (Int) -> Unit = { },
     navigateToPayment: () -> Unit = { },
     navigateToCartEdit: (Int) -> Unit = { },
-    navigateToStoreMain: () -> Unit = { }
+    navigateToStoreMain: () -> Unit = { },
+    navigateBack: () -> Unit = { }
 ) {
     val uiState by viewModel.collectAsState()
 
@@ -86,9 +87,10 @@ fun ShoppingCartScreen(
                 ),
                 title = stringResource(R.string.shopping_cart),
                 onNavigationIconClick = {
-                    uiState.cart.orderableShopId?.let { storeId ->
-                        navigateToStoreDetail(storeId)
-                    }
+                    navigateBack()
+//                    uiState.cart.orderableShopId?.let { storeId ->
+//                        navigateToStoreDetail(storeId)
+//                    }
                 },
                 actions = {
                     Text(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
@@ -88,9 +88,6 @@ fun ShoppingCartScreen(
                 title = stringResource(R.string.shopping_cart),
                 onNavigationIconClick = {
                     navigateBack()
-//                    uiState.cart.orderableShopId?.let { storeId ->
-//                        navigateToStoreDetail(storeId)
-//                    }
                 },
                 actions = {
                     Text(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
@@ -105,6 +105,10 @@ fun StoreHomeScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.getCartItemsCount()
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
@@ -38,7 +38,7 @@ class StoreHomeViewModel @Inject constructor(
         }
     }
 
-    private fun getCartItemsCount() = intent {
+    fun getCartItemsCount() = intent {
         reduce {
             state.copy(isLoading = true)
         }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/home/StoreHomeViewModel.kt
@@ -26,7 +26,6 @@ class StoreHomeViewModel @Inject constructor(
     override val container = container<StoreHomeState, StoreHomeSideEffect>(StoreHomeState())
 
     init {
-        getCartItemsCount()
         intent {
             getStoreCategoriesUseCase().let {
                 reduce {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyScreen.kt
@@ -95,6 +95,10 @@ fun StoreNearbyScreen(
         }
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.getCartItemsCount()
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
@@ -27,7 +27,6 @@ class StoreNearbyViewModel @Inject constructor(
     override val container = container<StoreNearbyState, StoreNearbySideEffect>(StoreNearbyState())
 
     init {
-        getCartItemsCount()
         intent {
             getStoreCategoriesUseCase().let {
                 reduce {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/main/nearby/StoreNearbyViewModel.kt
@@ -39,7 +39,7 @@ class StoreNearbyViewModel @Inject constructor(
         }
     }
 
-    private fun getCartItemsCount() = intent {
+    fun getCartItemsCount() = intent {
         reduce {
             state.copy(isLoading = true)
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -49,8 +49,7 @@ import `in`.koreatech.koin.ui.navigation.state.MenuState
 import `in`.koreatech.koin.ui.navigation.viewmodel.KoinNavigationDrawerViewModel
 import `in`.koreatech.koin.ui.operating.OperatingInfoActivity
 import `in`.koreatech.koin.ui.setting.SettingActivity
-//import `in`.koreatech.koin.ui.store.activity.StoreActivity
-import  `in`.koreatech.koin.feature.store.StoreActivity
+import `in`.koreatech.koin.ui.store.activity.StoreActivity
 import `in`.koreatech.koin.util.ext.addDrawerListener
 import `in`.koreatech.koin.util.ext.blueStatusBar
 import `in`.koreatech.koin.util.ext.closeDrawer

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -49,7 +49,8 @@ import `in`.koreatech.koin.ui.navigation.state.MenuState
 import `in`.koreatech.koin.ui.navigation.viewmodel.KoinNavigationDrawerViewModel
 import `in`.koreatech.koin.ui.operating.OperatingInfoActivity
 import `in`.koreatech.koin.ui.setting.SettingActivity
-import `in`.koreatech.koin.ui.store.activity.StoreActivity
+//import `in`.koreatech.koin.ui.store.activity.StoreActivity
+import  `in`.koreatech.koin.feature.store.StoreActivity
 import `in`.koreatech.koin.util.ext.addDrawerListener
 import `in`.koreatech.koin.util.ext.blueStatusBar
 import `in`.koreatech.koin.util.ext.closeDrawer


### PR DESCRIPTION
issue #965

## 개요

- 장바구니 2차 QA 사항을 수정하였습니다

## 작업 내용

- 장바구니에서 더 담으러가기 버튼 클릭 시 해당하는 가게로 이동하도록 수정하였습니다.
- 장바구니 페이지에서 배달/포장을 선택한 이후에 같은 옵션을 다시 누르면 API가 호출되지 않도록 수정하였습니다.
- 에러 메시지를 출력하는 다이얼로그의 확인 버튼이 텍스트 영역만 클릭이 가능하던 문제를 수정하였습니다.
- 주문 가능 상점 페이지, 주변 상점 페이지에서 장바구니 수량이 항상 최신 값으로 업데이트되도록 수정하였습니다.

## 추가적인 내용

- 현재 상점 페이지에서 장바구니 수량을 매번 업데이트하는 방식으로 우선 구현했습니다. 이유는 StoreHomeViewModel에서 stateflow로 상태 변수를 생성하고 이것을 cartAddScreen, cartEditScreen에서 변경해서 업데이트하는 방식으로 구현해봤는데 어떤 이유에서인지 cartAddScreen과 cartEditScreen에서 변경이 정상적으로 이루어짐에도 StoreHomeScreen에서는 상태 변화를 관찰하지 못하고 false만 출력됩니다... 추후 후속 PR로 개선해서 올리겠습니다.
- 업데이트 방식에 대해서 다른 방법이 있다면 의견 부탁드립니다