### PR TITLE
[Business][Fix] 앱이 백그라운드로 갔다 돌아왔을 때 웹뷰가 로딩되지 않는 문제 수정

### DIFF
--- a/core/webapp/src/main/java/in/koreatech/koin/core/webapp/WebApp.kt
+++ b/core/webapp/src/main/java/in/koreatech/koin/core/webapp/WebApp.kt
@@ -16,9 +16,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.os.bundleOf
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import java.net.URL
 
 /**
@@ -48,6 +52,15 @@ fun WebApp(
 ) {
     var webView: WebView? by remember { mutableStateOf(null) }
     val cookieManager = CookieManager.getInstance()
+    val bundle = rememberSaveable { bundleOf() }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
+        webView?.saveState(bundle)
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        webView?.restoreState(bundle)
+    }
 
     AndroidView(
         modifier = modifier
@@ -79,7 +92,9 @@ fun WebApp(
                     setCookie(baseUrl, "${cookie.first}=${cookie.second}")
                 }
             }
-            it.loadUrl(url)
+            if (bundle.isEmpty) {
+                it.loadUrl(url)
+            }
         },
         onRelease = {
             webView = null


### PR DESCRIPTION
issue #932 

## 개요
* 앱이 백그라운드로 갔다 돌아왔을 때 웹뷰가 로딩되지 않는 문제 수정

## 작업 내용
* webview의 state를 저장하고 불러오도록 수정했습니다.

## 추가적인 내용
* 최초 해당 이슈를 해결하기 위해 hardware render를 비활성화 시켰었지만, 그럼 웹뷰 렌더링이 정상적으로 되지 않는 문제가 있었습니다.
* 따라서, 완벽하지는 않지만, on pause시에 webview의 state를 저장했다가 on resume 시에 다시 불러와 정상적으로 렌더링 되는 방식으로 해결했습니다.
* 다만, scroll position과 모달 상태는 저장되지 않는 문제가 있습니다.
* 다른 해결책이 있다면 말씀 해주시면 감사하겠습니다.