### PR TITLE
[Koin Project][Fix] API 29 이하에서 Edge to edge가 정상적으로 적용되지 않던 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -32,6 +35,16 @@ class ArticleActivity : ActivityBase() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_article)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+
+            view.updatePadding(
+                top = navigationBars.top,
+                bottom = navigationBars.bottom
+            )
+            insets
+        }
 
         window.whiteStatusBar()
 

--- a/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/dining/DiningActivity.kt
@@ -2,8 +2,12 @@ package `in`.koreatech.koin.ui.dining
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.viewModels
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager.widget.ViewPager
@@ -84,6 +88,16 @@ class DiningActivity : KoinNavigationDrawerActivity() {
         enableEdgeToEdgeWithDarkStatusBar()
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
+
+            view.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = navigationBars.bottom
+            }
+
+            insets
+        }
 
         initCalendar()
         initViewPager()

--- a/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.ui.land
 
 import android.os.Bundle
 import android.widget.Toast
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.core.widget.addTextChangedListener
 import androidx.databinding.DataBindingUtil
@@ -34,6 +35,7 @@ class LandActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = DataBindingUtil.setContentView(this, R.layout.land_activity_main)
         initView()
         landViewModel.landData.observe(this) {

--- a/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/activity/MainActivity.kt
@@ -191,7 +191,7 @@ class MainActivity : KoinNavigationDrawerTimeActivity() {
                 topMargin = systemBars.top
                 rightMargin = systemBars.right
             }
-            WindowInsetsCompat.CONSUMED
+            insets
         }
 
         binding.nestedScrollViewMain.setOnScrollChangeListener { v, scrollX, scrollY, oldScrollX, oldScrollY ->

--- a/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/term/TermActivity.kt
@@ -5,9 +5,7 @@ import android.view.ViewGroup.MarginLayoutParams
 import androidx.activity.viewModels
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.marginBottom
 import androidx.core.view.updateLayoutParams
-import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -53,22 +51,14 @@ class TermActivity : ActivityBase(R.layout.activity_term) {
         binding = ActivityTermBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        ViewCompat.setOnApplyWindowInsetsListener(binding.rvContent) { view, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-
-            view.updatePadding(
-                bottom = systemBars.bottom
-            )
-            WindowInsetsCompat.CONSUMED
-        }
-
-        ViewCompat.setOnApplyWindowInsetsListener(binding.fab) { view, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { view, insets ->
+            val navigationBars = insets.getInsets(WindowInsetsCompat.Type.navigationBars())
 
             view.updateLayoutParams<MarginLayoutParams> {
-                bottomMargin = view.marginBottom + systemBars.bottom
+                bottomMargin = navigationBars.bottom
             }
-            WindowInsetsCompat.CONSUMED
+
+            insets
         }
 
         loadTerm()


### PR DESCRIPTION
close #971 

## 개요
* API 29 이하에서 Edge to edge가 정상적으로 적용되지 않던 문제 수정

## 작업 내용
* API 29 이하에서 Edge to edge가 정상적으로 적용되지 않던 문제를 수정했습니다.

## 추가적인 내용
* 사실 insets 처리가 이상하게 되어 있던게 좀 있는 것 같은데, 이게 30 이상에서는 크게 문제가 안되는데 29 이하에서는 문제가 되네요
* 대부분 문제가 되던 부분은 상위 view에서 insets을 consumed 처리 해버려서 하위 view에서 insets이 적용되지 않던 문제였습니다.
* 그 외에는 insets 처리가 누락된 부분이었습니다.
* 빠진 것 없나 리뷰할 때 확인 부탁드려요. 저번에도 몇개 빼먹었네요