### PR TITLE
[Koin Project] user_id 로깅 방식 표준화

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/EventLogger.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 object EventLogger {
-    private const val USER_ID = "user_id"
     private const val USER_GENDER = "gender"
     private const val USER_MAJOR = "major"
 
@@ -155,9 +154,9 @@ object EventLogger {
         value: String
     ) {
         if (BuildConfig.IS_DEBUG) {
+            Firebase.analytics.setUserId(loggerUserData.userId)
             Firebase.analytics.logEvent("${action}_debug") {
                 loggerUserData.let {
-                    param(USER_ID, it.userId)
                     param(USER_GENDER, it.gender)
                     param(USER_MAJOR, it.major)
                 }
@@ -166,9 +165,9 @@ object EventLogger {
                 param(VALUE, value)
             }
         } else {
+            Firebase.analytics.setUserId(loggerUserData.userId)
             Firebase.analytics.logEvent(action) {
                 loggerUserData.let {
-                    param(USER_ID, it.userId)
                     param(USER_GENDER, it.gender)
                     param(USER_MAJOR, it.major)
                 }
@@ -199,9 +198,9 @@ object EventLogger {
         vararg extras: EventExtra
     ) {
         if (BuildConfig.IS_DEBUG) {
+            Firebase.analytics.setUserId(loggerUserData.userId)
             Firebase.analytics.logEvent("${action.value}_debug") {
                 loggerUserData.let {
-                    param(USER_ID, it.userId)
                     param(USER_GENDER, it.gender)
                     param(USER_MAJOR, it.major)
                 }
@@ -214,8 +213,8 @@ object EventLogger {
             }
         } else {
             Firebase.analytics.logEvent(action.value) {
+                Firebase.analytics.setUserId(loggerUserData.userId)
                 loggerUserData.let {
-                    param(USER_ID, it.userId)
                     param(USER_GENDER, it.gender)
                     param(USER_MAJOR, it.major)
                 }


### PR DESCRIPTION
issue https://github.com/BCSDLab/KOIN_ANDROID/issues/961

## 개요

- 현재 user_id가 GA4의 표준 user_id 필드가 아닌, 이벤트 매개변수(event_params) 내에 key가 'user_id'인 커스텀 항목으로 수집되고 있음

## 작업 내용

- user_id를 표준 필드에 들어가게 하였습니다.

## 추가적인 내용
