### PR TITLE
[Business][Fix] 웹뷰에서 뒤로가기 동작 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -194,9 +194,16 @@ fun NavGraphBuilder.koinStoreGraph(
         StorePaymentScreen(
             cartType = cartType,
             finish = finish,
-            navigateBack = {
+            navigateToMain = {
                 navController.navigate(StoreNavType.StoreMain.route) {
                     popUpTo(StoreNavType.StoreMain.route) {
+                        inclusive = true
+                    }
+                }
+            },
+            navigateToCart = {
+                navController.navigate(StoreNavType.StoreCart.route) {
+                    popUpTo(StoreNavType.StoreCart.route) {
                         inclusive = true
                     }
                 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/payment/StorePaymentScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/payment/StorePaymentScreen.kt
@@ -9,6 +9,7 @@ import android.webkit.URLUtil
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
@@ -34,9 +35,12 @@ fun StorePaymentScreen(
     cartType: String,
     viewModel: StorePaymentViewModel = hiltViewModel(),
     finish: () -> Unit = {},
-    navigateBack: () -> Unit = {}
+    navigateToMain: () -> Unit = {},
+    navigateToCart: () -> Unit = {}
 ) {
     val context = LocalContext.current
+    val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
+
     val authToken by viewModel.authToken.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
@@ -67,7 +71,7 @@ fun StorePaymentScreen(
         koinWebAppInterface = StorePaymentScreenInterface(
             navigateBack = {
                 (context as Activity).runOnUiThread {
-                    navigateBack()
+                    dispatcher?.onBackPressed()
                 }
             },
             finish = finish
@@ -77,10 +81,20 @@ fun StorePaymentScreen(
         ),
         backHandler = { webView ->
             BackHandler {
-                if (webView?.canGoBack() == true) {
-                    webView.goBack()
-                } else {
-                    navigateBack()
+                when (webView?.url?.toUri()?.path) {
+                    "/payment" -> {
+                        navigateToCart()
+                    }
+                    "/result", "/orderCancel" -> {
+                        navigateToMain()
+                    }
+                    else -> {
+                        if (webView?.canGoBack() == true) {
+                            webView.goBack()
+                        } else {
+                            navigateToMain()
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
issue #932 

## 개요
* 웹뷰에서 뒤로가기 동작 수정

## 작업 내용
* 웹뷰에서 현재 페이지에 따라 뒤로가기 동작이 다른 화면으로 넘어가도록 수정했습니다.
  * 결제 화면에서는 장바구니로 이동
  * 결제 완료 및 결제 취소 화면에서는 상점 목록으로 이동
  * 기타는 이전 히스토리로 이동 or 없을 경우 상점 목록으로 이동
