### PR TITLE
[Business][Fix] 장바구니가 갱신되지 않던 문제 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/response/store/CartResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/store/CartResponse.kt
@@ -3,9 +3,9 @@ package `in`.koreatech.koin.data.response.store
 import com.google.gson.annotations.SerializedName
 
 data class CartResponse(
-    @SerializedName("shop_name") val shopName: String,
-    @SerializedName("shop_thumbnail_image_url") val shopThumbnailImageUrl: String,
-    @SerializedName("orderable_shop_id") val orderableShopId: Int,
+    @SerializedName("shop_name") val shopName: String?,
+    @SerializedName("shop_thumbnail_image_url") val shopThumbnailImageUrl: String?,
+    @SerializedName("orderable_shop_id") val orderableShopId: Int?,
     @SerializedName("is_delivery_available") val isDeliveryAvailable: Boolean,
     @SerializedName("is_takeout_available") val isTakeoutAvailable: Boolean,
     @SerializedName("shop_minimum_order_amount") val shopMinimumOrderAmount: Int,

--- a/domain/src/main/java/in/koreatech/koin/domain/model/store/Cart.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/store/Cart.kt
@@ -38,9 +38,9 @@ data class Cart(
 
     companion object {
         val Empty = Cart(
-            shopName = "",
-            shopThumbnailImageUrl = "",
-            orderableShopId = 0,
+            shopName = null,
+            shopThumbnailImageUrl = null,
+            orderableShopId = null,
             isDeliveryAvailable = false,
             isTakeoutAvailable = false,
             shopMinimumOrderAmount = 0,

--- a/domain/src/main/java/in/koreatech/koin/domain/model/store/Cart.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/store/Cart.kt
@@ -1,9 +1,9 @@
 package `in`.koreatech.koin.domain.model.store
 
 data class Cart(
-    val shopName: String,
-    val shopThumbnailImageUrl: String,
-    val orderableShopId: Int,
+    val shopName: String?,
+    val shopThumbnailImageUrl: String?,
+    val orderableShopId: Int?,
     val isDeliveryAvailable: Boolean,
     val isTakeoutAvailable: Boolean,
     val shopMinimumOrderAmount: Int,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/view/ShoppingCartScreen.kt
@@ -52,7 +52,9 @@ fun ShoppingCartScreen(
     LaunchedEffect(Unit) {
         snapshotFlow { uiState.cart }
             .collect {
-                viewModel.getCartValidate()
+                if (it.shopName != null) {
+                    viewModel.getCartValidate()
+                }
             }
     }
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/viewmodel/ShoppingCartViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/viewmodel/ShoppingCartViewModel.kt
@@ -63,7 +63,6 @@ class ShoppingCartViewModel @Inject constructor(
         reduce { state.copy(isLoading = true) }
         getCartItemUseCase(type.name).onSuccess {
             reduce { state.copy(cart = it, cartType = type, isLoading = false) }
-            getCartValidate()
         }.onFailure {
             reduce { state.copy(isLoading = false) }
             when (it) {


### PR DESCRIPTION
issue #932 

## 개요
* 장바구니가 갱신되지 않던 문제 수정

## 작업 내용
* nullable 값이 not-null로 선언되어 발생하던 exception을 수정했습니다.
* Cart.Empty의 일부 기본 값을 null로 변경했습니다.
* `cart/validate`가 두번씩 호출되던 문제를 수정했습니다.
* `cart/validate`가 불필요하게 호출되던 문제를 수정했습니다.