### PR TITLE
[Koin Project][Refactor] navigateToSignIn 구현

### DIFF
--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -5,9 +5,19 @@ plugins {
 
 android {
     namespace = "in.koreatech.koin.core.navigation"
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.10"
+    }
+
+    buildFeatures {
+        compose = true
+    }
 }
 
 dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.bundles.compose.m3)
 }

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     alias(libs.plugins.koin.library)
+    alias(libs.plugins.koin.hilt)
 }
 
 android {

--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
@@ -16,4 +16,9 @@ interface Navigator {
         type: Pair<String, String?> = Pair("", ""), // SchemeType
         vararg args: Pair<String, Any?> // Extra IDs
     ): Intent
+
+    fun navigateToSignIn(
+        context: Context,
+        redirectUrl: String? = null
+    ): Intent
 }

--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/utils/NavigatorEntryPoint.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/utils/NavigatorEntryPoint.kt
@@ -1,0 +1,30 @@
+package `in`.koreatech.koin.core.navigation.utils
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.android.EntryPointAccessors
+import dagger.hilt.components.SingletonComponent
+import `in`.koreatech.koin.core.navigation.Navigator
+
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface NavigatorEntryPoint {
+    fun navigator(): Navigator
+}
+
+@Composable
+fun rememberNavigator(): Navigator {
+    val context = LocalContext.current
+
+    return remember {
+        val entrypoint = EntryPointAccessors.fromApplication(
+            context.applicationContext,
+            NavigatorEntryPoint::class.java
+        )
+
+        entrypoint.navigator()
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/constant/Constant.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/constant/Constant.kt
@@ -19,8 +19,6 @@ const val KOIN_WEB_URL = "https://koreatech.in/"
 
 const val KOIN_WEB_STAGE_URL = "https://stage.koreatech.in/"
 
-const val LOGIN_ACTIVITY_URL = "koin://login/login"
-
 const val HTTP_URL = "http://"
 
 const val HTTPS_URL = "https://"

--- a/feature/club/build.gradle.kts
+++ b/feature/club/build.gradle.kts
@@ -20,6 +20,7 @@ android {
 
 dependencies {
     implementation(project(":core"))
+    implementation(project(":core:navigation"))
     implementation(project(":domain"))
     implementation(project(":core:designsystem"))
     implementation(project(":core:analytics"))

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -71,10 +71,10 @@ import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.domain.constant.KOIN_WEB_STAGE_URL
 import `in`.koreatech.koin.domain.constant.KOIN_WEB_URL
-import `in`.koreatech.koin.domain.constant.LOGIN_ACTIVITY_URL
 import `in`.koreatech.koin.domain.util.ext.formatPhoneNumber
 import `in`.koreatech.koin.domain.util.ext.isValidGoogleFormUrl
 import `in`.koreatech.koin.domain.util.ext.isValidInstagramUrl
@@ -167,6 +167,8 @@ fun ClubDetail(
     val isQnaScrollable = remember { derivedStateOf { !listState.canScrollForward || qnaScrollState.value != 0 } }
 
     var tabRowHeight by remember { mutableStateOf(0.dp) }
+
+    val navigator = rememberNavigator()
 
     viewModel.collectSideEffect { sideEffect ->
         handleSideEffect(sideEffect, context, snackbarHostState)
@@ -276,7 +278,9 @@ fun ClubDetail(
                 positiveButtonText = stringResource(id = R.string.detail_dialog_login_positive),
                 onPositive = {
                     viewModel.dismissLoginDialog()
-                    viewModel.openUrl(LOGIN_ACTIVITY_URL)
+                    navigator.navigateToSignIn(context).let {
+                        context.startActivity(it)
+                    }
                 },
                 onNegative = { viewModel.dismissLoginDialog() }
             )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.feature.club.ui.clublist
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -47,14 +46,13 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
-import `in`.koreatech.koin.domain.constant.LOGIN_ACTIVITY_URL
+import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.feature.club.R
 import `in`.koreatech.koin.feature.club.component.KoinClubCategoryItem
 import `in`.koreatech.koin.feature.club.component.KoinClubDropdown
@@ -87,6 +85,7 @@ fun ClubListScreen(
 ) {
     val uiState by viewModel.collectAsState()
     val context = LocalContext.current
+    val navigator = rememberNavigator()
 
     viewModel.collectSideEffect {
         handleSideEffect(it, viewModel, context, navigateToCreateClub)
@@ -189,7 +188,7 @@ fun ClubListScreen(
                 viewModel.updateRecruiting(isRecruiting)
             },
             navigateToLogin = {
-                Intent(Intent.ACTION_VIEW, LOGIN_ACTIVITY_URL.toUri()).let {
+                navigator.navigateToSignIn(context).let {
                     context.startActivity(it)
                 }
             }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/Constant.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/Constant.kt
@@ -11,7 +11,6 @@ const val VERIFICATION_CODE_LENGTH = 6
 const val KOREATECH_EMAIL_DOMAIN = "koreatech.ac.kr"
 
 const val DEEPLINK_MAIN = "koin://main/activity"
-const val DEEPLINK_ARTICLE = "koin://article/activity"
 
 const val OWNER_URL_STAGE = "https://owner.stage.koreatech.in/"
 const val OWNER_URL_PRODUCTION = "https://owner.koreatech.in/"

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/Constant.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/Constant.kt
@@ -11,7 +11,6 @@ const val VERIFICATION_CODE_LENGTH = 6
 const val KOREATECH_EMAIL_DOMAIN = "koreatech.ac.kr"
 
 const val DEEPLINK_MAIN = "koin://main/activity"
-const val DEEPLINK_TIMETABLE = "koin://timetable/activity"
 const val DEEPLINK_ARTICLE = "koin://article/activity"
 
 const val OWNER_URL_STAGE = "https://owner.stage.koreatech.in/"

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
@@ -27,6 +27,7 @@ import `in`.koreatech.koin.feature.user.DEEPLINK_MAIN
 import `in`.koreatech.koin.feature.user.DEEPLINK_TIMETABLE
 import javax.inject.Inject
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 @AndroidEntryPoint
 class SignInActivity : ComponentActivity() {
@@ -68,8 +69,7 @@ class SignInActivity : ComponentActivity() {
     }
 
     private fun goToNextRoute(isSignIn: Boolean) {
-        val uri = intent.data
-        val link = uri?.getQueryParameter("link")
+        val link = intent.extras?.getString("link")
 
         if (link != null) {
             try {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
@@ -15,14 +15,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
 import androidx.core.net.toUri
-import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
 import `in`.koreatech.koin.core.onboarding.OnboardingManager
 import `in`.koreatech.koin.feature.signin.ui.SignInScreen
-import `in`.koreatech.koin.feature.user.DEEPLINK_ARTICLE
 import `in`.koreatech.koin.feature.user.DEEPLINK_MAIN
 import javax.inject.Inject
 import kotlinx.coroutines.launch
@@ -85,26 +83,10 @@ class SignInActivity : ComponentActivity() {
                 }
             }
         } else {
-            if (handleArticleIntent()) {
-                val bundle = intent.getBundleExtra(BUNDLE_EXTRA_KEY)
-                val startBoard = bundle?.getInt(START_BOARD, 4)
-                startActivity(
-                    Intent(Intent.ACTION_VIEW).apply {
-                        data = DEEPLINK_ARTICLE.toUri()
-                        putExtra(
-                            BUNDLE_EXTRA_KEY,
-                            bundleOf(
-                                START_BOARD to startBoard
-                            )
-                        )
-                    }
-                )
-            } else {
-                Intent(Intent.ACTION_VIEW).apply {
-                    data = DEEPLINK_MAIN.toUri()
-                }.let {
-                    startActivity(it)
-                }
+            Intent(Intent.ACTION_VIEW).apply {
+                data = DEEPLINK_MAIN.toUri()
+            }.let {
+                startActivity(it)
             }
         }
 
@@ -137,17 +119,8 @@ class SignInActivity : ComponentActivity() {
         }
     }
 
-    private fun handleArticleIntent(): Boolean {
-        val bundle = intent.getBundleExtra(BUNDLE_EXTRA_KEY)
-        return bundle?.getBoolean(NAV_ARTICLE, false) ?: false
-    }
-
     companion object {
         private const val INFO_REQUIRED_URI = "koin://inforequired/activity"
         private const val EXTRA_IS_FULL = "extra_is_full"
-        const val BUNDLE_EXTRA_KEY = "BUNDLE_EXTRA_KEY"
-        const val NAV_TIMETABLE = "timetable"
-        const val NAV_ARTICLE = "article"
-        const val START_BOARD = "start_board"
     }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInActivity.kt
@@ -24,10 +24,8 @@ import `in`.koreatech.koin.core.onboarding.OnboardingManager
 import `in`.koreatech.koin.feature.signin.ui.SignInScreen
 import `in`.koreatech.koin.feature.user.DEEPLINK_ARTICLE
 import `in`.koreatech.koin.feature.user.DEEPLINK_MAIN
-import `in`.koreatech.koin.feature.user.DEEPLINK_TIMETABLE
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class SignInActivity : ComponentActivity() {
@@ -87,13 +85,7 @@ class SignInActivity : ComponentActivity() {
                 }
             }
         } else {
-            if (handleTimetableIntent()) {
-                Intent(Intent.ACTION_VIEW).apply {
-                    data = DEEPLINK_TIMETABLE.toUri()
-                }.let {
-                    startActivity(it)
-                }
-            } else if (handleArticleIntent()) {
+            if (handleArticleIntent()) {
                 val bundle = intent.getBundleExtra(BUNDLE_EXTRA_KEY)
                 val startBoard = bundle?.getInt(START_BOARD, 4)
                 startActivity(
@@ -143,11 +135,6 @@ class SignInActivity : ComponentActivity() {
         } else {
             overridePendingTransition(0, 0)
         }
-    }
-
-    private fun handleTimetableIntent(): Boolean {
-        val bundle = intent.getBundleExtra(BUNDLE_EXTRA_KEY)
-        return bundle?.getBoolean(NAV_TIMETABLE, false) ?: false
     }
 
     private fun handleArticleIntent(): Boolean {

--- a/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.navigation.utils.buildIntent
+import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
 import `in`.koreatech.koin.ui.main.activity.MainActivity
 import `in`.koreatech.koin.ui.splash.SplashActivity
 import javax.inject.Inject
@@ -30,5 +31,12 @@ class NavigatorImpl @Inject constructor() : Navigator {
         val intent = context.buildIntent(className, type, *args)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         return intent
+    }
+
+    override fun navigateToSignIn(context: Context, redirectUrl: String?): Intent {
+        return context.buildIntent(SignInActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("link", redirectUrl)
+        }
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleActivity.kt
@@ -181,7 +181,6 @@ class ArticleActivity : ActivityBase() {
 
     companion object {
         const val NAVIGATE_ACTION = "navigate_action"
-        const val NAV_ARTICLE = "article"
         const val START_BOARD = "start_board"
         const val BUNDLE_ARTICLE_EXTRA_KEY = "BUNDLE_EXTRA_KEY"
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/ArticleKeywordFragment.kt
@@ -1,7 +1,5 @@
 package `in`.koreatech.koin.ui.article
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -24,6 +22,7 @@ import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.dialog.AlertModalDialog
 import `in`.koreatech.koin.core.dialog.AlertModalDialogData
+import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.permission.checkNotificationPermission
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.databinding.FragmentArticleKeywordBinding
@@ -34,6 +33,7 @@ import `in`.koreatech.koin.ui.article.viewmodel.KeywordInputUiState
 import `in`.koreatech.koin.ui.notification.viewmodel.NotificationUiState
 import `in`.koreatech.koin.ui.notification.viewmodel.NotificationViewModel
 import `in`.koreatech.koin.util.SnackbarUtil
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -43,6 +43,9 @@ class ArticleKeywordFragment : Fragment() {
 
     private val viewModel by viewModels<ArticleKeywordViewModel>()
     private val notificationViewModel by viewModels<NotificationViewModel>()
+
+    @Inject
+    lateinit var navigator: Navigator
 
     private val loginModal: AlertModalDialog by lazy {
         AlertModalDialog(
@@ -57,10 +60,7 @@ class ArticleKeywordFragment : Fragment() {
                     AnalyticsConstant.Label.LOGIN_PROMPT,
                     "키워드 알림 팝업"
                 )
-                val intent =
-                    Intent(Intent.ACTION_VIEW).apply {
-                        data = Uri.parse("koin://login/login?link=koin://article/activity?fragment=article_keyword")
-                    }
+                val intent = navigator.navigateToSignIn(this.requireContext(), redirectUrl = "koin://article/activity?fragment=article_keyword")
                 it.dismiss()
                 startActivity(intent)
             },

--- a/koin/src/main/java/in/koreatech/koin/ui/article/lostandfound/ArticleListLostAndFoundFragment.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/article/lostandfound/ArticleListLostAndFoundFragment.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.ui.article.lostandfound
 
-import android.content.Intent
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -12,16 +11,17 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.feature.lostandfound.ui.lostandfound.LostAndFoundList
 import `in`.koreatech.koin.feature.lostandfound.ui.write.LostAndFoundWriteArticleViewModel.Companion.LOST_OR_FOUND_TYPE
-import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
-import `in`.koreatech.koin.ui.article.ArticleActivity.Companion.BUNDLE_ARTICLE_EXTRA_KEY
-import `in`.koreatech.koin.ui.article.ArticleActivity.Companion.NAV_ARTICLE
-import `in`.koreatech.koin.ui.article.ArticleActivity.Companion.START_BOARD
-import `in`.koreatech.koin.ui.article.ArticleBoardType
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class ArticleListLostAndFoundFragment : Fragment() {
+
+    @Inject
+    lateinit var navigator: Navigator
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -59,17 +59,10 @@ class ArticleListLostAndFoundFragment : Fragment() {
                         )
                     },
                     navigateToLoginActivity = {
-                        Intent(requireContext(), SignInActivity::class.java).apply {
-                            putExtra(
-                                BUNDLE_ARTICLE_EXTRA_KEY,
-                                bundleOf(
-                                    NAV_ARTICLE to true,
-                                    START_BOARD to ArticleBoardType.LOSTANDFOUND.id
-                                )
-                            )
-                            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-                            requireActivity().finish()
-                        }.let(::startActivity)
+                        navigator.navigateToSignIn(
+                            requireContext(),
+                            "koin://article/activity?fragment=article_lost_and_found"
+                        ).let(::startActivity)
                     }
                 )
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -47,7 +47,6 @@ import `in`.koreatech.koin.feature.timetable.view.dialog.ScheduleDuplicationDial
 import `in`.koreatech.koin.feature.timetable.view.dialog.SelectDepartmentDialog
 import `in`.koreatech.koin.feature.timetable.view.dialog.TimetableTimePickerDialog
 import `in`.koreatech.koin.feature.timetable.viewmodel.TimetableViewModel
-import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
 import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
 import `in`.koreatech.koin.ui.navigation.state.MenuState
 import javax.inject.Inject

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -29,6 +29,7 @@ import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHo
 import `in`.koreatech.koin.core.designsystem.component.snackbar.showSnackBarWithDismiss
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithDarkStatusBar
+import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.util.KeyboardUtils
 import `in`.koreatech.koin.databinding.ActivityTimetableBinding
 import `in`.koreatech.koin.feature.timetable.component.CircleLoadingBar
@@ -49,6 +50,7 @@ import `in`.koreatech.koin.feature.timetable.viewmodel.TimetableViewModel
 import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
 import `in`.koreatech.koin.ui.navigation.KoinNavigationDrawerActivity
 import `in`.koreatech.koin.ui.navigation.state.MenuState
+import javax.inject.Inject
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -58,6 +60,9 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
         get() = SCREEN_TITLE
     override val menuState: MenuState
         get() = MenuState.Timetable
+
+    @Inject
+    lateinit var navigator: Navigator
 
     private lateinit var binding: ActivityTimetableBinding
     private val viewModel: TimetableViewModel by viewModels()
@@ -76,11 +81,7 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
             }
 
             if (it.resultCode == TimetableSemesterActivity.REQUEST_CODE_LOGIN_ACTIVITY) {
-                it.data?.getBundleExtra(BUNDLE_LOGIN_EXTRA_KEY)?.let { bundle ->
-                    bundle.getBoolean(NAV_TIMETABLE).let {
-                        if (it) startToLoginActivity()
-                    }
-                }
+                startToLoginActivity()
             }
         }
 
@@ -407,11 +408,7 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
     }
 
     private fun startToLoginActivity() {
-        Intent(this, SignInActivity::class.java).apply {
-            putExtra(BUNDLE_LOGIN_EXTRA_KEY, bundleOf(NAV_TIMETABLE to true))
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-            finish()
-        }.let(::startActivity)
+        navigator.navigateToSignIn(this, "koin://timetable/activity").let(::startActivity)
     }
 
     private fun saveTimetable(bitmap: Bitmap, callback: (Boolean) -> Unit) {

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
@@ -235,11 +235,7 @@ class TimetableSemesterActivity : ActivityBase() {
     }
 
     private fun startToLoginActivity() {
-        val intent =
-            Intent().apply {
-                putExtra(BUNDLE_LOGIN_EXTRA_KEY, bundleOf(NAV_TIMETABLE to true))
-            }
-        setResult(REQUEST_CODE_LOGIN_ACTIVITY, intent)
+        setResult(REQUEST_CODE_LOGIN_ACTIVITY)
         finish()
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableSemesterActivity.kt
@@ -32,8 +32,6 @@ import `in`.koreatech.koin.feature.timetable.view.dialog.EditTimetableFrameDialo
 import `in`.koreatech.koin.feature.timetable.view.dialog.RequestLoginDialog
 import `in`.koreatech.koin.feature.timetable.viewmodel.ScreenStateUIMode
 import `in`.koreatech.koin.feature.timetable.viewmodel.SemesterViewModel
-import `in`.koreatech.koin.ui.timetablev2.TimetableActivity.Companion.BUNDLE_LOGIN_EXTRA_KEY
-import `in`.koreatech.koin.ui.timetablev2.TimetableActivity.Companion.NAV_TIMETABLE
 import timber.log.Timber
 
 @AndroidEntryPoint


### PR DESCRIPTION
issue #955 

## 개요
* navigateToSignIn 구현

## 작업 내용
* core:navigation 모듈에 hilt 및 compose 의존성을 추가했습니다.
* `navigateToSignIn`을 구현했습니다.
  * Activity에서는 `Navigator`를 Inject해서 사용하시면 됩니다.
  * Composable에서는 `rememberNavigator()`를 사용하시면 됩니다.
  * `redirectUrl` parameter에 deeplink를 넘기면 로그인 후 해당 deeplink로 이동합니다.
* 시간표, 키워드 알림 및 분실물 화면에서 `navigateToSignIn`를 사용하도록 수정했습니다.
  * 해당 화면들은 추후 모듈 분리 예정입니다.
  * 따라서, 기존의 `SignInActivity`를 직접 호출하는 방식은 리팩토링 후 문제가 발생할 수 있습니다
* 동아리 화면에서 `navigateToSignIn`을 사용하도록 수정했습니다.
  * 이제 해당 화면에서 로그인 화면 deeplink를 사용할 필요가 없습니다.
* `SignInActivity`에서 시간표 및 분실물 Intent 분기처리를 제거했습니다.
* 리팩토링에 따라 사용하지 않게 된 Constant를 제거했습니다.

## 추가적인 내용
* 저번 PR과 마찬가지로 꼼꼼하게 리뷰 부탁드립니다.