### PR TITLE
[Campus][fix] 동아리 화면에 잘못된 scroll 조건 수정

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetail.kt
@@ -431,8 +431,7 @@ fun ClubDetail(
                 .systemBarsPadding()
                 .fillMaxSize(),
             state = listState,
-            horizontalAlignment = Alignment.CenterHorizontally,
-            userScrollEnabled = qnaScrollState.value == 0
+            horizontalAlignment = Alignment.CenterHorizontally
         ) {
             item {
                 SubcomposeAsyncImage(


### PR DESCRIPTION
## PR 개요
이슈 번호: #982
- 동아리 화면에 잘못된 scroll 조건 수정

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 동아리 화면에 부모 lazyColumn 스크롤 조건이 qna 화면이 최상단일 경우에만 반응함
그로인해 다른 모집 화면에서 스크롤하려해도 qna 화면이 최상단이 아니면 안되는 오류 발생 > 수정

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다