### PR TITLE
[Koin Project][Chore] minSdk를 28로 상향

### DIFF
--- a/.github/workflows/pick_reviewer.yml
+++ b/.github/workflows/pick_reviewer.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Add Reviewer
         uses: madrapps/add-reviewers@v1
         with:
-          reviewers: ${{ steps.pick_reviewer.outputs.reviewer1 }}, ${{ steps.pick_reviewer.outputs.reviewer2 }}
+          reviewers: ${{ steps.pick_reviewer.outputs.reviewer1 }},${{ steps.pick_reviewer.outputs.reviewer2 }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add Mentor

--- a/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
+++ b/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
@@ -9,15 +9,15 @@ internal fun Project.configureAndroidLibrary(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     (commonExtension as? LibraryExtension)?.let {
-        it.defaultConfig.targetSdk = 34
+        it.defaultConfig.targetSdk = 35
     }
 
     commonExtension.apply {
         (this as? LibraryExtension)?.let {
-            it.defaultConfig.targetSdk = 34
+            it.defaultConfig.targetSdk = 35
         }
 
-        compileSdk = 34
+        compileSdk = 35
 
         defaultConfig {
             minSdk = 28

--- a/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
+++ b/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
@@ -20,7 +20,7 @@ internal fun Project.configureAndroidLibrary(
         compileSdk = 34
 
         defaultConfig {
-            minSdk = 26
+            minSdk = 28
 
             testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         }

--- a/build-logic/convention/src/main/java/in/koreatech/convention/AndroidProject.kt
+++ b/build-logic/convention/src/main/java/in/koreatech/convention/AndroidProject.kt
@@ -20,7 +20,7 @@ internal fun configureAndroidProject(
             it.defaultConfig.targetSdk = 35
         }
         defaultConfig {
-            minSdk = 26
+            minSdk = 28
             testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
             vectorDrawables.useSupportLibrary = true
         }


### PR DESCRIPTION
## PR 개요
이슈 번호:

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
* minSdk를 Android 9 (28)로 상향했습니다.
* Library convention plugin에서 targetSdk가 상향되지 않은 문제를 수정했습니다.

### 논의 사항
* X
### 스크린샷
* X
## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다