### PR TITLE
[Koin Project] Webview 에서 Intent:// 링크 처리 불가 문제

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -164,7 +164,8 @@ internal class KoinWebViewClient(
                 intent.getPackage()?.let { packageName ->
                     try {
                         val marketIntent = Intent(Intent.ACTION_VIEW).apply {
-                            data = Uri.parse("market://details?id=$packageName")
+                            data = Uri.parse("https://play.google.com/store/apps/details?id=$packageName")
+                            setPackage("com.android.vending")
                         }
                         context.startActivity(marketIntent)
                     } catch (e: ActivityNotFoundException) {

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -1,9 +1,11 @@
 package `in`.koreatech.koin.core.activity
 
 import android.annotation.SuppressLint
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Bundle
 import android.os.Message
 import android.view.Menu
@@ -152,9 +154,32 @@ internal class KoinWebViewClient(
         view: WebView?,
         request: WebResourceRequest?
     ): Boolean {
+        val url = request?.url.toString()
+
+        if (url.startsWith("intent://")) {
+            val intent = Intent.parseUri(url, Intent.URI_INTENT_SCHEME)
+            try {
+                context.startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                intent.getPackage()?.let { packageName ->
+                    try {
+                        val marketIntent = Intent(Intent.ACTION_VIEW).apply{
+                            data = Uri.parse("market://details?id=$packageName")
+                        }
+                        context.startActivity(marketIntent)
+                    } catch (e: ActivityNotFoundException) {
+                        intent.getStringExtra("browser_fallback_url")?.let { fallbackUrl ->
+                            view?.loadUrl(fallbackUrl)
+                        }
+                    }
+                }
+            }
+            return true
+        }
+
         if (openInNewTab) {
             val intent = Intent(context, WebViewActivity::class.java)
-            intent.putExtra("url", request?.url.toString())
+            intent.putExtra("url", url)
             context.startActivity(intent)
             return true
         }

--- a/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
+++ b/core/src/main/java/in/koreatech/koin/core/activity/WebViewActivity.kt
@@ -163,7 +163,7 @@ internal class KoinWebViewClient(
             } catch (e: ActivityNotFoundException) {
                 intent.getPackage()?.let { packageName ->
                     try {
-                        val marketIntent = Intent(Intent.ACTION_VIEW).apply{
+                        val marketIntent = Intent(Intent.ACTION_VIEW).apply {
                             data = Uri.parse("market://details?id=$packageName")
                         }
                         context.startActivity(marketIntent)


### PR DESCRIPTION
## PR 개요
이슈 번호: #1002 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
Webview 에서 Intent:// 를 처리할 수 없어 직접 Intent 로 변경이 필요

1. shouldOverrideUrlLoading 에 url.startsWith("intent://") 을 통해 intent:// 링크인지 확인
2. intent 링크이면 이를 intent 객체로 만듦
3. activity 를 실행시켜봄
3-1.  해당 activity 가 없으면 ActivityNotFoundException 호출 후 해당 packageName 을 가진 market 으로 Intent 처리
3-1-1. 해당 market 조차 없으면 browser_fallback_url 을 가져와서 webview 에 보여줌

### 논의 사항
우선 대부분의 사람들이 저렇게 처리하기에 따라 만들었습니다. 

결제는 정상적으로 작동합니다(실제 결제 성공)

3-1-1 은 제거할지 고민중입니다. (안드로이드인데 playStore 가 없다..? simulater 말곤 없을 거 같은...) 우선 시뮬도중 오류가 뜨니까 처리는 해봤습니다.

payco 말고 모든 intent:// 에 대해 동일하게 작동하니 다른 intent 의 경우에도 발생할 수 있는 문제라면 알려주세요.

> 추가적으로 WebView에 status bar 배경이 흰색인데 icon 색상도 흰색이라 안보입니다. (에초에 배경이 설정되면 안될거같은데..) 이것도 고쳐야할 거 같습니다.

### 스크린샷
| playStroe 없음(3-1-1) | payco 앱 없음(3-1) | payco 앱 실행(3) |
|:--:|:--:|:--:|
| <img alt="Screenshot_20250908_142419" src="https://github.com/user-attachments/assets/b62311eb-0e89-4f10-ae89-c33498e5bf21" width=60% /> | <img alt="Screenshot_20250908_144457" src="https://github.com/user-attachments/assets/3f8773ff-f4c3-4acb-8959-ba7f0d625e0e" width=60% /> | <img alt="Screenshot_20250908_142419" src="https://github.com/user-attachments/assets/a72b6d32-79ac-460d-847a-c03e3cd0c7b3" width=60% />



## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다