### PR TITLE
[Campus][Fix] 분실물 화면 navigationBars insets 중복 적용 수정

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/lostandfound/LostAndFound.kt
@@ -101,7 +101,9 @@ fun LostAndFoundList(
                 val fabFoundText = stringResource(R.string.fab_found)
                 val fabLostText = stringResource(R.string.fab_lost)
                 LostAndFoundFAB(
-                    modifier = Modifier.padding(bottom = fabBottomPadding),
+                    modifier = Modifier
+                        .padding(bottom = fabBottomPadding)
+                        .consumeWindowInsets(WindowInsets.navigationBars),
                     isDialogExpanded = uiState.isFabDialogExpanded,
                     dialogExpandButtonText = fabWrite,
                     dialogExpandButtonPainter = painterResource(id = R.drawable.ic_fab_write),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/LostAndFoundWriteArticle.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/LostAndFoundWriteArticle.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -66,6 +67,7 @@ fun LostAndFoundWriteArticle(
         Scaffold(
             modifier = Modifier
                 .fillMaxSize()
+                .consumeWindowInsets(WindowInsets.navigationBars)
                 .imePadding(),
             containerColor = KoinTheme.colors.neutral0,
             bottomBar = {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/component/WriteArticleDoneButton.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/component/WriteArticleDoneButton.kt
@@ -39,7 +39,7 @@ fun WriteArticleDoneButton(
     windowInsets: WindowInsets = WriteArticleDoneButtonDefaults.windowInsets,
     onClick: () -> Unit = {}
 ) = Column(
-    modifier = Modifier.windowInsetsPadding(windowInsets),
+    modifier = modifier.windowInsetsPadding(windowInsets),
     horizontalAlignment = Alignment.CenterHorizontally
 ) {
     HorizontalDivider(
@@ -48,16 +48,14 @@ fun WriteArticleDoneButton(
         color = KoinTheme.colors.neutral100
     )
     Box(
-        modifier =
-        modifier
+        modifier = Modifier
             .padding(24.dp)
             .fillMaxWidth(),
         contentAlignment = Alignment.Center
     ) {
         Button(
             onClick = onClick,
-            modifier =
-            Modifier
+            modifier = Modifier
                 .padding(vertical = 8.dp, horizontal = 24.dp)
                 .width(160.dp)
                 .height(38.dp),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/component/WriteArticleDoneButton.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/component/WriteArticleDoneButton.kt
@@ -4,13 +4,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -39,7 +39,7 @@ fun WriteArticleDoneButton(
     windowInsets: WindowInsets = WriteArticleDoneButtonDefaults.windowInsets,
     onClick: () -> Unit = {}
 ) = Column(
-    modifier = Modifier.padding(windowInsets.asPaddingValues()),
+    modifier = Modifier.windowInsetsPadding(windowInsets),
     horizontalAlignment = Alignment.CenterHorizontally
 ) {
     HorizontalDivider(


### PR DESCRIPTION
## PR 개요
이슈 번호: #1019 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 분실물 화면에서 navigation bar windowinsets이 중복 적용되는 문제를 수정했습니다.
* WindowInsets.asPaddingValue 대신 windowInsetsPadding을 사용해서 insets이 consumed 되었을 경우 무시되도록 수정했습니다.
* modifier가 잘못 적용된 문제를 수정했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다