### PR TITLE
[Business][feature] 결제 완료 화면 WebApp bridge 구현

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -212,7 +212,7 @@ fun NavGraphBuilder.koinStoreGraph(
             },
             navigateToDetail = { storeId ->
                 navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${false}")
-            },
+            }
         )
     }
 
@@ -246,7 +246,7 @@ fun NavGraphBuilder.koinStoreGraph(
             },
             navigateToDetail = { storeId ->
                 navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${false}")
-            },
+            }
         )
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -209,7 +209,10 @@ fun NavGraphBuilder.koinStoreGraph(
                         inclusive = true
                     }
                 }
-            }
+            },
+            navigateToDetail = { storeId ->
+                navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${false}")
+            },
         )
     }
 
@@ -240,7 +243,10 @@ fun NavGraphBuilder.koinStoreGraph(
                         inclusive = true
                     }
                 }
-            }
+            },
+            navigateToDetail = { storeId ->
+                navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${false}")
+            },
         )
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/webapp/StoreWebAppScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/webapp/StoreWebAppScreen.kt
@@ -35,7 +35,8 @@ fun StoreWebAppScreen(
     viewModel: StoreWebAppViewModel = hiltViewModel(),
     finish: () -> Unit = {},
     navigateToMain: () -> Unit = {},
-    navigateToCart: () -> Unit = {}
+    navigateToCart: () -> Unit = {},
+    navigateToDetail: (Int) -> Unit = {}
 ) {
     val context = LocalContext.current
     val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
@@ -68,6 +69,11 @@ fun StoreWebAppScreen(
             )
         ),
         koinWebAppInterface = StorePaymentScreenInterface(
+            navigateDetail = { storeId ->
+                (context as Activity).runOnUiThread {
+                    navigateToDetail(storeId)
+                }
+            },
             navigateBack = {
                 (context as Activity).runOnUiThread {
                     dispatcher?.onBackPressed()
@@ -101,6 +107,7 @@ fun StoreWebAppScreen(
 }
 
 internal class StorePaymentScreenInterface(
+    private val navigateDetail: (Int) -> Unit,
     private val navigateBack: () -> Unit,
     private val finish: () -> Unit
 ) : KoinWebAppInterface() {
@@ -109,6 +116,11 @@ internal class StorePaymentScreenInterface(
 
     @JavascriptInterface
     fun finish() = finish.invoke()
+
+    @JavascriptInterface
+    fun goToShopDetail(shopId: Int) {
+        navigateDetail(shopId)
+    }
 }
 
 internal class StorePaymentWebViewClient(private val tokens: Tokens) : KoinWebAppWebViewClient() {

--- a/feature/store/src/test/java/in/koreatech/koin/feature/store/WebAppBridgeTest.kt
+++ b/feature/store/src/test/java/in/koreatech/koin/feature/store/WebAppBridgeTest.kt
@@ -32,7 +32,7 @@ class WebAppBridgeTest {
     internal class WebAppBridgeTestInterface(val testStoreId: Int) : KoinWebAppInterface() {
         @JavascriptInterface
         fun goToShopDetail(shopId: Int) {
-            Log.e("BridgeTest", "result = ${shopId == testStoreId}, StoreId = ${shopId}, TestStoreId = ${testStoreId}")
+            Log.e("BridgeTest", "result = ${shopId == testStoreId}, StoreId = $shopId, TestStoreId = $testStoreId")
         }
     }
 

--- a/feature/store/src/test/java/in/koreatech/koin/feature/store/WebAppBridgeTest.kt
+++ b/feature/store/src/test/java/in/koreatech/koin/feature/store/WebAppBridgeTest.kt
@@ -1,0 +1,78 @@
+package `in`.koreatech.koin.feature.store
+
+import android.content.Context
+import android.util.Log
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.JavascriptInterface
+import android.webkit.WebSettings
+import android.webkit.WebView
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import `in`.koreatech.koin.core.webapp.KoinWebAppInterface
+import `in`.koreatech.koin.core.webapp.KoinWebAppWebChromeClient
+import `in`.koreatech.koin.core.webapp.KoinWebAppWebViewClient
+
+class WebAppBridgeTest {
+    val TEST_STORE_ID = 845
+
+    val webAppBridgeHtml = """
+        <html>
+          <body>
+            <button style="padding: 20px 40px;" onclick="Android.goToShopDetail(${TEST_STORE_ID})">
+              Call goToShopDetail(${TEST_STORE_ID})
+            </button>
+          </body>
+        </html>
+    """.trimIndent()
+
+    internal class WebAppBridgeTestInterface(val testStoreId: Int) : KoinWebAppInterface() {
+        @JavascriptInterface
+        fun goToShopDetail(shopId: Int) {
+            Log.e("BridgeTest", "result = ${shopId == testStoreId}, StoreId = ${shopId}, TestStoreId = ${testStoreId}")
+        }
+    }
+
+    @Composable
+    fun WebAppBridgeTestWebView(
+        context: Context = LocalContext.current
+    ) {
+        AndroidView(
+            modifier = Modifier
+                .fillMaxSize(),
+            factory = { factoryContext ->
+                WebView(context).apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
+                    )
+                    webViewClient = KoinWebAppWebViewClient()
+                    webChromeClient = KoinWebAppWebChromeClient()
+                    addJavascriptInterface(WebAppBridgeTestInterface(TEST_STORE_ID), "Android")
+                    overScrollMode = View.OVER_SCROLL_NEVER
+                    settings.apply {
+                        builtInZoomControls = false
+                        domStorageEnabled = true
+                        javaScriptEnabled = true
+                        loadWithOverviewMode = true
+                        blockNetworkLoads = false
+                        mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+                        setSupportZoom(false)
+                    }
+                }
+            },
+            update = { webView ->
+                webView.loadDataWithBaseURL(
+                    "",
+                    webAppBridgeHtml,
+                    "text/html",
+                    "utf-8",
+                    null
+                )
+            }
+        )
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1023

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
기존 `StorePaymentScreenInterface` 구현부에
 ```
 @JavascriptInterface
    fun goToShopDetail(shopId: Int) {
        navigateDetail(shopId)
    }
```
를 추가로 선언하여
webapp bridge 를 만들었습니다.

추가적으로 JavascriptInterface 의 내부 실행이 background thread 에서 실행될 수 있어서
기존 방식에 따라 `(context as Activity).runOnUiThread` 을 통해 Ui thread 로 고정했습니다.

### 논의 사항
현재 누르면 다른 가게로 가는데 이건 이야기 해보겠습니다.
> 받는 값은 orderable_store_id 인데 제가 store_id 값으로 사용하도록 만들었네요 수정했습니다.

### 스크린샷
| 자료(논의 사항 참고) |
|:--:|
| <img src=https://github.com/user-attachments/assets/b7a60eee-3a7f-4cc1-aeb2-c6614a42c4a3 width = 70%> |

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다