### PR TITLE
[Koin Project][fix] 메인화면 식단 탭에서 능수관 글자가 2줄로 보이는 현상 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager

--- a/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -155,7 +156,7 @@ fun DiningWidget(
                 DiningPlace.entries.filter { it != DiningPlace.Campus2 }
                     .forEachIndexed { index, place ->
                         Tab(
-                            modifier = Modifier.width(70.dp),
+                            modifier = Modifier.widthIn(min = 70.dp),
                             text = {
                                 Text(
                                     text = place.place,


### PR DESCRIPTION
## PR 개요
이슈 번호: #1059 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 메인화면 식단 탭에서 능수관 글자가 2줄로 보이는 현상을 수정했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다