### PR TITLE
[Koin Project][fix] 식단 ab 버튼 하단 padding 추가

### DIFF
--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -564,7 +565,7 @@ private fun DiningDetailScreenImpl(
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter)
-                    .padding(WindowInsets.navigationBars.asPaddingValues())
+                    .windowInsetsPadding(WindowInsets.navigationBars)
                     .padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
                 onClick = {
                     val sessionId = onGetSessionId()

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
@@ -22,9 +22,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
@@ -562,7 +564,8 @@ private fun DiningDetailScreenImpl(
                 modifier = Modifier
                     .fillMaxWidth()
                     .align(Alignment.BottomCenter)
-                    .padding(start = 16.dp, end = 8.dp, bottom = 16.dp),
+                    .padding(WindowInsets.navigationBars.asPaddingValues())
+                    .padding(start = 16.dp, end = 16.dp, bottom = 8.dp),
                 onClick = {
                     val sessionId = onGetSessionId()
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1068 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `DiningDetailScreenImpl.kt`에서 DiningAbTestFloatingButton 하단에 navigation bars padding을 추가하였습니다.

### 논의 사항

### 스크린샷
| 수정 전 | 수정 후 |
|:---:|:---:|
| <img width="733" height="140" alt="image" src="https://github.com/user-attachments/assets/7690e75a-d757-4a5d-bc1b-0c4dbced68b6" /> | <img width="732" height="207" alt="image" src="https://github.com/user-attachments/assets/53f3e875-0410-40a2-b66a-e8011c2d5c8a" /> |


## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다