### PR TITLE
[Business][Fix] 상점 리뷰 작성 시 발생하는 오류 수정

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/store/ModifyReviewUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/store/ModifyReviewUseCase.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.domain.usecase.store
 import `in`.koreatech.koin.domain.model.store.Review
 import `in`.koreatech.koin.domain.repository.StoreRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 
 class ModifyReviewUseCase @Inject constructor(
     private val storeRepository: StoreRepository
@@ -11,7 +12,15 @@ class ModifyReviewUseCase @Inject constructor(
         reviewId: Int,
         storeId: Int,
         content: Review
-    ) {
-        storeRepository.modifyReview(reviewId, storeId, content)
+    ): Result<Unit> {
+        return runCatching {
+            storeRepository.modifyReview(reviewId, storeId, content)
+        }.onFailure {
+            if (it is CancellationException) {
+                throw it
+            } else {
+                return Result.failure(it)
+            }
+        }
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/WriteReviewActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/WriteReviewActivity.kt
@@ -36,6 +36,7 @@ import kotlin.properties.Delegates
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
@@ -189,7 +190,6 @@ class WriteReviewActivity : ActivityBase(R.layout.activity_write_review) {
                     (storeName ?: "Unknown"),
                     EventExtra(AnalyticsConstant.DURATION_TIME, (elapsedTime / 1000.0).toString())
                 )
-                finish()
             }
         }
     }
@@ -248,6 +248,14 @@ class WriteReviewActivity : ActivityBase(R.layout.activity_write_review) {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.toastEvent.collect {
                     showToast(getString(R.string.write_review_error))
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                shouldFinish.collectLatest {
+                    if (it) finish()
                 }
             }
         }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
 @HiltViewModel
 class WriteReviewViewModel @Inject constructor(
@@ -36,7 +35,7 @@ class WriteReviewViewModel @Inject constructor(
     val shouldFinish = _shouldFinish.asSharedFlow()
 
     fun writeReview(storeId: Int, content: Review) {
-        viewModelScope.launch {
+        viewModelScope.launchWithLoading {
             writeReviewUseCase(storeId, content).also {
                 _review.value = content
             }.onSuccess {
@@ -52,7 +51,7 @@ class WriteReviewViewModel @Inject constructor(
     }
 
     fun modifyReview(reviewId: Int, storeId: Int, content: Review) {
-        viewModelScope.launch {
+        viewModelScope.launchWithLoading {
             modifyReviewUseCase(reviewId, storeId, content).also {
                 _review.value = content
             }.onSuccess {

--- a/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
@@ -55,6 +55,10 @@ class WriteReviewViewModel @Inject constructor(
         viewModelScope.launch {
             modifyReviewUseCase(reviewId, storeId, content).also {
                 _review.value = content
+            }.onSuccess {
+                _shouldFinish.emit(true)
+            }.onFailure {
+                _toastEvent.emit(Unit)
             }
         }
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/viewmodel/WriteReviewViewModel.kt
@@ -32,10 +32,15 @@ class WriteReviewViewModel @Inject constructor(
     private val _toastEvent = MutableSharedFlow<Unit>()
     val toastEvent = _toastEvent.asSharedFlow()
 
+    private val _shouldFinish = MutableSharedFlow<Boolean>()
+    val shouldFinish = _shouldFinish.asSharedFlow()
+
     fun writeReview(storeId: Int, content: Review) {
         viewModelScope.launch {
             writeReviewUseCase(storeId, content).also {
                 _review.value = content
+            }.onSuccess {
+                _shouldFinish.emit(true)
             }.onFailure {
                 _toastEvent.emit(Unit)
             }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1087 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 상점 리뷰 작성 시 발생하던 `IOException`을 수정했습니다.
  * Retrofit에서는 요청이 완료되기 전에 취소되면 `java.io.IOException: Canceled`를 반환합니다.
  * 기존 코드에서 리뷰가 작성되기 전에 `finish()`가 호출되면서 `IOException`이 발생했습니다.
  * 이를 해결하기 위해 SharedFlow를 사용해 요청이 완료되었을 때 `finish()`가 호출되도록 수정했습니다.
* 리뷰 수정 UseCase에서 Result로 성공 / 실패를 반환하도록 수정했습니다.
* 리뷰 작성 중 progress가 표시되도록 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다