### PR TITLE
[Koin Project][Fix] 게시글 위젯 자동 스크롤이 멈추는 문제 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/main/compose/ArticleMain.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/compose/ArticleMain.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +40,7 @@ import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.domain.model.article.ArticleNotiType
 import `in`.koreatech.koin.ui.main.state.ArticleMainState
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 private const val AUTO_SCROLL_INTERVAL = 5000L
 
@@ -51,11 +53,18 @@ fun HotArticlePager(
 ) {
     val pagerState = rememberPagerState { articles.size }
 
-    LaunchedEffect(pagerState.settledPage, articles.size) {
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(key1 = pagerState.currentPage, key2 = pagerState.isScrollInProgress, key3 = articles.size) {
         if (articles.isNotEmpty()) {
-            delay(AUTO_SCROLL_INTERVAL)
-            val nextPage = (pagerState.currentPage + 1) % articles.size
-            pagerState.animateScrollToPage(nextPage)
+            launch {
+                delay(AUTO_SCROLL_INTERVAL)
+                coroutineScope.launch {
+                    if (!pagerState.isScrollInProgress) {
+                        pagerState.animateScrollToPage((pagerState.currentPage + 1) % articles.size)
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1103 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 게시글 위젯을 넘어가지 못하게 잡고 있을 때 Exception이 발생하면서 자동 스크롤이 고장나는 문제를 수정했습니다. 과거 배너 오류와 동일합니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다