### PR TITLE
[Koin Project][Fix] 게시글 위젯에서 발생하는 NoSuchElement 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/main/compose/ArticleMain.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/compose/ArticleMain.kt
@@ -49,6 +49,7 @@ fun HotArticlePager(
     onNotiClick: (ArticleMainState.Noti) -> Unit = {},
     onArticleClick: (ArticleMainState.Content) -> Unit = {}
 ) {
+    if (articles.isEmpty()) return
     val pagerState = rememberPagerState { articles.size }
 
     LaunchedEffect(pagerState.settledPage, articles.size) {


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1105 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* compose foundation 라이브러리 `PagerLazyAnimateScrollScope`의 [`lastVisibleItemIndex`](https://android.googlesource.com/platform//frameworks/support/+/83040cf151db157d7cc1e50588ae10b0b5a12369/compose/foundation/foundation/src/commonMain/kotlin/androidx/compose/foundation/pager/PagerLazyAnimateScrollScope.kt#40)를 보면 empty 여부를 확인하지 않고 `last()`를 호출하고 있습니다.
* 정상적인 경우에는 문제가 없어야 하지만, 코인 실행 도중 백그라운드로 진입하게 되면 해당 부분에서 크래시가 발생합니다.
* 따라서, `ArticleMain` 위젯에서 articles가 empty일 경우 return 하도록 해 해당 오류가 발생할 수 없도록 방지했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다