### PR TITLE
[Business][Fix] 상점 진입 시 발생하는 IndexOutOfBoundsException 수정

### DIFF
--- a/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/store/activity/StoreActivity.kt
@@ -191,12 +191,10 @@ class StoreActivity : KoinNavigationDrawerTimeActivity() {
         initViewModel()
         initView()
 
-        val initStoreCategory = intent.extras?.getInt(StoreActivityContract.STORE_CATEGORY, 0)
         storeCategoriesAdapter.selectPosition =
             intent.extras?.getInt(StoreActivityContract.STORE_CATEGORY)?.minus(2)
 
-        viewModel.setCategory(initStoreCategory)
-        storeCategoriesAdapter.initCategory(initStoreCategory)
+        setCategory()
     }
 
     private fun initView() {
@@ -610,6 +608,17 @@ class StoreActivity : KoinNavigationDrawerTimeActivity() {
                     binding.searchResultTextView.text =
                         "\"${viewModel.search.value}\" 관련 가게가 총 ${it.size}개 있어요."
                 }
+            }
+        }
+    }
+
+    private fun setCategory() {
+        val initStoreCategory = intent.extras?.getInt(StoreActivityContract.STORE_CATEGORY, 0)
+
+        observeLiveData(viewModel.storeCategoryList) {
+            if (it.isNotEmpty()) {
+                viewModel.setCategory(initStoreCategory)
+                storeCategoriesAdapter.initCategory(initStoreCategory)
             }
         }
     }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1124 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 상점 진입 시 발생하는 `IndexOutOfBoundsException`를 수정했습니다.
  * 상점 진입 시 ViewModel의 `storeCategoryList`로부터 사용자가 선택한 index 값의 아이템을 가져오는데, 이때 모종의 이유로 (네트워크 등등) `storeCategoryList`가 아직 초기화되지 않은 상태라면 `IndexOutOfBoundsException`가 발생하게 됩니다.
  * 따라서 해당 함수의 호출 지점을 onCreate 즉시가 아닌, onCreate 이후 `storeCategoryList`가 초기화 된 시점 (== `isNotEmpty()`)인 시점으로 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다