### PR TITLE
[Business][Fix] 일부 부자연스러운 UI 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
@@ -90,7 +90,7 @@ fun KoinStoreCard(
                         CircularProgressIndicator()
                     }
                 },
-                contentScale = ContentScale.Fit,
+                contentScale = ContentScale.Crop,
                 contentDescription = null,
                 modifier = Modifier
                     .size(128.dp)

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -151,11 +151,11 @@ fun StoreDetailScreen(
         combine(
             snapshotFlow { rememberState.listState.firstVisibleItemIndex },
             snapshotFlow { rememberState.listState.layoutInfo.visibleItemsInfo.lastIndex }
-        ) { v1, v2 ->
-            Pair(v1, v2)
-        }.collect { (first, _) ->
+        ) { index, _ ->
+            index
+        }.collect { index ->
             val visibleCategory = if (!rememberState.listState.isScrolledToTheEnd()) {
-                uiState.categories.getOrNull(first - 2)
+                uiState.categories.getOrNull(index - 2)
             } else {
                 uiState.categories.lastOrNull()
             }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -222,6 +222,7 @@ fun StoreDetailScreen(
                             storeInfo = uiState.store,
                             storeReview = uiState.storeReview,
                             storeDescriptionModel = uiState.shopDescription,
+                            isOrderableShop = uiState.isOrderableShop,
                             navigateToReview = {
                                 navigateToReview(
                                     StoreNavigationData(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -71,6 +72,7 @@ import `in`.koreatech.koin.feature.store.state.rememberCollapsingToolbarState
 import `in`.koreatech.koin.feature.store.util.customCollapsingToolbarContent
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -146,13 +148,21 @@ fun StoreDetailScreen(
     }
 
     LaunchedEffect(rememberState.listState) {
-        snapshotFlow { rememberState.listState.firstVisibleItemIndex }
-            .collect { index ->
-                val visibleCategory = uiState.categories.getOrNull(index - 2)
-                visibleCategory?.let {
-                    viewModel.changeCategory(it.menuGroupId)
-                }
+        combine(
+            snapshotFlow { rememberState.listState.firstVisibleItemIndex },
+            snapshotFlow { rememberState.listState.layoutInfo.visibleItemsInfo.lastIndex }
+        ) { v1, v2 ->
+            Pair(v1, v2)
+        }.collect { (first, _) ->
+            val visibleCategory = if (!rememberState.listState.isScrolledToTheEnd()) {
+                uiState.categories.getOrNull(first - 2)
+            } else {
+                uiState.categories.lastOrNull()
             }
+            visibleCategory?.let {
+                viewModel.changeCategory(it.menuGroupId)
+            }
+        }
     }
 
     if (uiState.showSignInDialog) {
@@ -358,3 +368,5 @@ fun handleSideEffect(
         }
     }
 }
+
+fun LazyListState.isScrolledToTheEnd() = layoutInfo.visibleItemsInfo.lastOrNull()?.index == layoutInfo.totalItemsCount - 1

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
@@ -277,7 +277,6 @@ class StoreDetailViewModel @Inject constructor(
                 selectedCategoryId = categoryId
             )
         }
-        changeCategory(categoryId)
     }
 
     fun changeCategory(categoryId: Int) = blockingIntent {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
@@ -79,7 +79,7 @@ fun LazyListScope.menuListSection(
                         if (index != menus.lastIndex) {
                             Divider(
                                 color = KoinTheme.colors.neutral300,
-                                thickness = 2.dp
+                                thickness = 1.dp
                             )
                         }
                     }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
@@ -77,7 +77,7 @@ fun LazyListScope.menuListSection(
                             menu = menu
                         )
                         if (index != menus.lastIndex) {
-                            Divider(color = KoinTheme.colors.neutral300)
+                            Divider(color = RebrandKoinTheme.colors.neutral300)
                         }
                     }
                 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
@@ -77,10 +77,7 @@ fun LazyListScope.menuListSection(
                             menu = menu
                         )
                         if (index != menus.lastIndex) {
-                            Divider(
-                                color = KoinTheme.colors.neutral300,
-                                thickness = 1.dp
-                            )
+                            Divider(color = KoinTheme.colors.neutral300)
                         }
                     }
                 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/MenuListSection.kt
@@ -115,33 +115,36 @@ fun MenuItem(
             )
         }
         Spacer(modifier = Modifier.width(16.dp))
-        Box(
-            modifier = Modifier
-                .align(Alignment.Bottom)
-                .size(88.dp)
-                .clip(KoinTheme.shapes.small)
-        ) {
-            AsyncImage(
-                model = ImageRequest.Builder(LocalContext.current)
-                    .data(menu.thumbnailImage)
-                    .crossfade(true)
-                    .build(),
-                contentDescription = null,
-                contentScale = ContentScale.Fit,
-                modifier = Modifier.matchParentSize()
-            )
 
-            if (menu.isSoldOut) {
-                Image(
-                    imageVector = ImageVector.vectorResource(R.drawable.ic_sold_out),
-                    contentDescription = "",
+        menu.thumbnailImage?.let {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Bottom)
+                    .size(88.dp)
+                    .clip(KoinTheme.shapes.small)
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(it)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = null,
                     contentScale = ContentScale.Fit,
-                    modifier = Modifier
-                        .matchParentSize()
-                        .background(RebrandKoinTheme.colors.neutral800.copy(alpha = 0.6f))
-                        .padding(14.dp)
-
+                    modifier = Modifier.matchParentSize()
                 )
+
+                if (menu.isSoldOut) {
+                    Image(
+                        imageVector = ImageVector.vectorResource(R.drawable.ic_sold_out),
+                        contentDescription = "",
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(RebrandKoinTheme.colors.neutral800.copy(alpha = 0.6f))
+                            .padding(14.dp)
+
+                    )
+                }
             }
         }
     }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
@@ -37,6 +37,7 @@ fun StoreDetailInfo(
     storeReview: StoreReview,
     storeDescriptionModel: StoreDescriptionModel,
     modifier: Modifier = Modifier,
+    isOrderableShop: Boolean = true,
     navigateToReview: () -> Unit = {},
     navigateToDetailInfo: (selectedInfo: String) -> Unit = {}
 ) {
@@ -73,7 +74,8 @@ fun StoreDetailInfo(
                     .clip(RoundedCornerShape(50))
                     .clickable {
                         navigateToDetailInfo(StoreDetailInfoType.ORIGIN.name)
-                    }
+                    },
+                isOrderableShop = isOrderableShop
             )
         }
         Spacer(modifier = Modifier.height(12.dp))

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.domain.model.store.StoreReview
 import `in`.koreatech.koin.feature.store.R
 import `in`.koreatech.koin.feature.store.enums.StoreDetailInfoType
@@ -47,7 +48,7 @@ fun StoreDetailInfo(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Row(
-                modifier = Modifier.clickable { navigateToReview() },
+                modifier = Modifier.noRippleClickable { navigateToReview() },
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically
             ) {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfoChip.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfoChip.kt
@@ -27,7 +27,8 @@ import `in`.koreatech.koin.feature.store.model.ShopInfoModel
 
 @Composable
 fun OriginInfoChips(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    isOrderableShop: Boolean = true
 ) {
     Surface(
         modifier = modifier,
@@ -42,7 +43,7 @@ fun OriginInfoChips(
             modifier = Modifier.padding(horizontal = 12.dp)
         ) {
             Text(
-                text = stringResource(id = R.string.store_info_and_origin),
+                text = stringResource(id = if (isOrderableShop) R.string.store_info_and_origin else R.string.store_info_detail),
                 fontSize = 11.sp,
                 color = Color(0xFF333333)
             )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginInfoScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginInfoScreen.kt
@@ -225,54 +225,57 @@ fun ShopOriginInfoScreen(
                     )
                 }
             )
-            Spacer(Modifier.height(6.dp))
-            HighlightSection(
-                content = {
-                    Text(
-                        text = stringResource(R.string.business_info),
-                        style = RebrandKoinTheme.typography.bold15
-                    )
 
-                    Spacer(modifier = Modifier.height(12.dp))
-
-                    if (uiState.shopDescription.ownerInfo.hasAnyInfo()) {
-                        KoinStoreGrid(
-                            modifier = Modifier
-                                .wrapContentHeight(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            leftContent = {
-                                Text(text = stringResource(R.string.owner_name))
-                                Text(text = stringResource(R.string.trade_name))
-                                Text(text = stringResource(R.string.business_address))
-                                Text(stringResource(R.string.business_registration_number))
-                            },
-                            rightContent = {
-                                uiState.shopDescription.ownerInfo?.name?.let { Text(it) }
-                                uiState.shopDescription.ownerInfo?.shopName?.let { Text(it) }
-                                uiState.shopDescription.ownerInfo?.address?.let { Text(it) }
-                                uiState.shopDescription.ownerInfo?.companyRegistrationNumber?.let { Text(it) }
-                            }
+            if (uiState.isOrderableShop) {
+                Spacer(Modifier.height(6.dp))
+                HighlightSection(
+                    content = {
+                        Text(
+                            text = stringResource(R.string.business_info),
+                            style = RebrandKoinTheme.typography.bold15
                         )
-                    } else {
-                        Text(text = stringResource(R.string.no_registered_information))
+
+                        Spacer(modifier = Modifier.height(12.dp))
+
+                        if (uiState.shopDescription.ownerInfo.hasAnyInfo()) {
+                            KoinStoreGrid(
+                                modifier = Modifier
+                                    .wrapContentHeight(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                leftContent = {
+                                    Text(text = stringResource(R.string.owner_name))
+                                    Text(text = stringResource(R.string.trade_name))
+                                    Text(text = stringResource(R.string.business_address))
+                                    Text(stringResource(R.string.business_registration_number))
+                                },
+                                rightContent = {
+                                    uiState.shopDescription.ownerInfo?.name?.let { Text(it) }
+                                    uiState.shopDescription.ownerInfo?.shopName?.let { Text(it) }
+                                    uiState.shopDescription.ownerInfo?.address?.let { Text(it) }
+                                    uiState.shopDescription.ownerInfo?.companyRegistrationNumber?.let { Text(it) }
+                                }
+                            )
+                        } else {
+                            Text(text = stringResource(R.string.no_registered_information))
+                        }
                     }
-                }
-            )
-            Spacer(Modifier.height(6.dp))
-            HighlightSection(
-                content = {
-                    Text(
-                        text = stringResource(R.string.origin_marking),
-                        style = RebrandKoinTheme.typography.bold18
-                    )
-                    Text(
-                        text = uiState.shopDescription.origins?.joinToString(separator = ", ") {
-                            "${it.ingredients} (${it.origin})"
-                        } ?: stringResource(R.string.no_registered_information),
-                        style = RebrandKoinTheme.typography.regular14
-                    )
-                }
-            )
+                )
+                Spacer(Modifier.height(6.dp))
+                HighlightSection(
+                    content = {
+                        Text(
+                            text = stringResource(R.string.origin_marking),
+                            style = RebrandKoinTheme.typography.bold18
+                        )
+                        Text(
+                            text = uiState.shopDescription.origins?.joinToString(separator = ", ") {
+                                "${it.ingredients} (${it.origin})"
+                            } ?: stringResource(R.string.no_registered_information),
+                            style = RebrandKoinTheme.typography.regular14
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginState.kt
@@ -4,6 +4,7 @@ import `in`.koreatech.koin.feature.store.model.StoreDescriptionModel
 
 data class ShopOriginState(
     val cartItemCount: Int = 0,
+    val isOrderableShop: Boolean = true,
     val isLoading: Boolean = true,
     val isLoggedIn: Boolean = false,
     val shopDescription: StoreDescriptionModel = StoreDescriptionModel.empty()

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginViewModel.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.orderShop.GetOrderShopOriginInfoUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetCartItemsCountUseCase
+import `in`.koreatech.koin.domain.usecase.store.GetStoreWithMenuUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.store.model.DeliveryTipModel
 import `in`.koreatech.koin.feature.store.model.OriginModel
@@ -25,7 +26,8 @@ class ShopOriginViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getCartItemsCountUseCase: GetCartItemsCountUseCase,
     private val getOrderShopOriginInfoUseCase: GetOrderShopOriginInfoUseCase,
-    private val getUserStatusUseCase: GetUserStatusUseCase
+    private val getUserStatusUseCase: GetUserStatusUseCase,
+    private val getStoreWithMenuUseCase: GetStoreWithMenuUseCase
 ) : ViewModel(), ContainerHost<ShopOriginState, Unit> {
     override val container = container<ShopOriginState, Unit>(ShopOriginState()) {
         val storeId = savedStateHandle.get<Int>(STORE_ID)
@@ -34,6 +36,8 @@ class ShopOriginViewModel @Inject constructor(
 
         if (isOrderableShop) {
             fetchOrderStoreNotice(storeId)
+        } else {
+            fetchShopInfo(storeId)
         }
     }
 
@@ -50,6 +54,7 @@ class ShopOriginViewModel @Inject constructor(
                         state.copy(isLoggedIn = true)
                     }
                 }
+
                 is User.Anonymous -> {
                     reduce {
                         state.copy(isLoggedIn = false)
@@ -110,6 +115,34 @@ class ShopOriginViewModel @Inject constructor(
                             result.address,
                             result.ownerInfo.companyRegistrationNumber ?: ""
                         )
+                    )
+                )
+            }
+        }
+    }
+
+    private fun fetchShopInfo(id: Int) = intent {
+        getStoreWithMenuUseCase(id).also { result ->
+            reduce {
+                state.copy(
+                    isLoading = false,
+                    shopDescription = StoreDescriptionModel(
+                        id = id,
+                        storeName = result.name,
+                        address = result.address ?: "",
+                        description = result.description,
+                        notice = result.description,
+                        phone = result.phone,
+                        openTime = result.open.openTime,
+                        closeTime = result.open.closeTime,
+                        closedDays = emptyList(),
+                        deliveryTips = DeliveryTipModel(
+                            fromAmount = 0,
+                            toAmount = null,
+                            fee = result.deliveryPrice
+                        ).let { listOf(it) },
+                        origins = null,
+                        ownerInfo = null
                     )
                 )
             }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/origin/ShopOriginViewModel.kt
@@ -17,6 +17,7 @@ import `in`.koreatech.koin.feature.store.navigation.STORE_ID
 import `in`.koreatech.koin.feature.store.util.toKoreanWeek
 import javax.inject.Inject
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
@@ -33,6 +34,14 @@ class ShopOriginViewModel @Inject constructor(
         val storeId = savedStateHandle.get<Int>(STORE_ID)
         val isOrderableShop = savedStateHandle.get<Boolean>(IS_ORDERABLE_SHOP) ?: true
         checkNotNull(storeId)
+
+        blockingIntent {
+            reduce {
+                state.copy(
+                    isOrderableShop = isOrderableShop
+                )
+            }
+        }
 
         if (isOrderableShop) {
             fetchOrderStoreNotice(storeId)

--- a/feature/store/src/main/res/values/strings.xml
+++ b/feature/store/src/main/res/values/strings.xml
@@ -40,6 +40,7 @@
 
     <!--가게 정보 및 원산지-->
     <string name="store_info_and_origin">가게정보·원산지</string>
+    <string name="store_info_detail">가게정보</string>
     <string name="store_info">가게 소개</string>
     <string name="store_notice">가게 알림</string>
     <string name="address">주소</string>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1132 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 리뷰 페이지 진입점에서 ripple 이펙트를 제거했습니다.
* 메뉴 이미지가 없을 경우, 빈 메뉴 이미지를 그리지 않도록 수정했습니다.
* Divider 높이를 수정했습니다.
* 주변 상점에서 원산지 및 사업자 정보를 제거했습니다.
* 주변 상점에서 가게 정보가 보이지 않던 문제를 수정했습니다.
* 가게 대표 이미지가 Crop 처리되도록 수정했습니다.
* 메뉴 스크롤 시 마지막 메뉴 카테고리가 선택되지 않던 문제를 수정했습니다.
* 일부 메뉴 카테고리 클릭 시 두번 카테고리가 변경되는 문제를 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다