### PR TITLE
[Business][Fix] 홈 및 주변상점 recomposition 최적화

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.PlatformTextStyle

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreCard.kt
@@ -25,10 +25,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.paint
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,6 +42,8 @@ import coil.request.ImageRequest
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.store.R
 import `in`.koreatech.koin.feature.store.enums.FilterBadge
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 @Composable
 fun KoinStoreCard(
@@ -49,7 +54,7 @@ fun KoinStoreCard(
     modifier: Modifier = Modifier,
     storeDeliveryFee: Int? = null,
     isOpen: Boolean = true,
-    filterBadgeList: List<FilterBadge> = emptyList(),
+    filterBadgeList: ImmutableList<FilterBadge> = persistentListOf(),
     onClick: () -> Unit = { }
 ) {
     Box(
@@ -58,7 +63,7 @@ fun KoinStoreCard(
             .width(IntrinsicSize.Max)
             .clip(RebrandKoinTheme.shapes.small)
             .background(RebrandKoinTheme.colors.neutral0, shape = RebrandKoinTheme.shapes.small)
-            .clickable { onClick() }
+            .clickable(onClick = onClick)
     ) {
         if (!isOpen) {
             Box(
@@ -113,7 +118,7 @@ fun KoinStoreCard(
                         modifier = Modifier
                             .size(16.dp)
                             .paint(
-                                painter = painterResource(R.drawable.ic_rating)
+                                painter = rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_rating))
                             )
                     )
 
@@ -139,7 +144,7 @@ fun KoinStoreCard(
                             modifier = Modifier
                                 .size(16.dp)
                                 .paint(
-                                    painter = painterResource(R.drawable.ic_delivery)
+                                    painter = rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_delivery))
                                 )
                         )
 
@@ -200,7 +205,7 @@ private fun KoinStoreCardPreview() {
             storeReviewCount = 5,
             storeDeliveryFee = 2500,
             isOpen = true,
-            filterBadgeList = listOf(
+            filterBadgeList = persistentListOf(
                 FilterBadge.SERVICE,
                 FilterBadge.DELIVERY_AVAILABLE
             )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -329,7 +329,7 @@ private fun StoreHomeScreen(
                             imageLoader = KoinCoilImageLoader.getImageLoader(context)
                         ),
                         isSelected = storeCategories[index].id == categoryId,
-                        onClick = remember (key1 = category.id) { { onCategoryChange(storeCategories[index].id) } }
+                        onClick = remember(key1 = category.id) { { onCategoryChange(storeCategories[index].id) } }
                     )
                 }
             }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -36,14 +36,15 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.LineHeightStyle
@@ -345,51 +346,53 @@ private fun StoreHomeScreen(
             ) {
                 Spacer(modifier = Modifier.width(16.dp))
 
-                KoinStoreChip(
-                    modifier = Modifier.fillMaxHeight(),
-                    text = stringResource(selectedOrderOption.stringResId),
-                    chipStyle = KoinStoreChipDefaults.koinStoreChipStyle(
-                        textColor = RebrandKoinTheme.colors.primary500,
-                        borderWidth = 1.dp,
-                        borderColor = RebrandKoinTheme.colors.primary500,
-                        elevation = 0.dp
-                    ),
-                    trailingIcon = painterResource(R.drawable.ic_store_arrow_down),
-                    trailingIconStyle = KoinStoreChipDefaults.koinStoreIconStyle(
-                        iconColor = RebrandKoinTheme.colors.primary500
-                    )
-                ) {
-                    onShowOrderOptionsChange(true)
+                key(selectedOrderOption) {
+                    KoinStoreChip(
+                        modifier = Modifier.fillMaxHeight(),
+                        text = stringResource(selectedOrderOption.stringResId),
+                        chipStyle = KoinStoreChipDefaults.koinStoreChipStyle(
+                            textColor = RebrandKoinTheme.colors.primary500,
+                            borderWidth = 1.dp,
+                            borderColor = RebrandKoinTheme.colors.primary500,
+                            elevation = 0.dp
+                        ),
+                        trailingIcon = rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_store_arrow_down)),
+                        trailingIconStyle = KoinStoreChipDefaults.koinStoreIconStyle(
+                            iconColor = RebrandKoinTheme.colors.primary500
+                        )
+                    ) {
+                        onShowOrderOptionsChange(true)
+                    }
                 }
 
                 Spacer(modifier = Modifier.width(8.dp))
 
                 storeFilters.forEach {
-                    val isSelected = selectedStoreFilter.contains(it)
-                    KoinStoreChip(
-                        modifier = Modifier.fillMaxHeight(),
-                        text = stringResource(it.stringResId),
-                        leadingIcon = painterResource(it.iconResId),
-                        chipStyle = if (isSelected) {
-                            KoinStoreChipDefaults.koinStoreChipStyle(
-                                elevation = 0.dp,
-                                containerColor = RebrandKoinTheme.colors.primary500,
-                                textColor = RebrandKoinTheme.colors.neutral0
-                            )
-                        } else {
-                            KoinStoreChipDefaults.koinStoreChipStyle()
-                        },
-                        leadingIconStyle = if (isSelected) {
-                            KoinStoreChipDefaults.koinStoreIconStyle(
-                                iconColor = RebrandKoinTheme.colors.neutral0
-                            )
-                        } else {
-                            KoinStoreChipDefaults.koinStoreIconStyle()
-                        },
-                        onClick = {
-                            onSelectedStoreFilterChange(it)
-                        }
-                    )
+                    key(it) {
+                        val isSelected = selectedStoreFilter.contains(it)
+                        KoinStoreChip(
+                            modifier = Modifier.fillMaxHeight(),
+                            text = stringResource(it.stringResId),
+                            leadingIcon = rememberVectorPainter(ImageVector.vectorResource(it.iconResId)),
+                            chipStyle = if (isSelected) {
+                                KoinStoreChipDefaults.koinStoreChipStyle(
+                                    elevation = 0.dp,
+                                    containerColor = RebrandKoinTheme.colors.primary500,
+                                    textColor = RebrandKoinTheme.colors.neutral0
+                                )
+                            } else {
+                                KoinStoreChipDefaults.koinStoreChipStyle()
+                            },
+                            leadingIconStyle = if (isSelected) {
+                                KoinStoreChipDefaults.koinStoreIconStyle(
+                                    iconColor = RebrandKoinTheme.colors.neutral0
+                                )
+                            } else {
+                                KoinStoreChipDefaults.koinStoreIconStyle()
+                            },
+                            onClick = remember(key1 = it) { { onSelectedStoreFilterChange(it) } }
+                        )
+                    }
                 }
 
                 KoinStoreMinimumPriceChip(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -314,7 +314,12 @@ private fun StoreHomeScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 contentPadding = PaddingValues(horizontal = 24.dp)
             ) {
-                itemsIndexed(storeCategories) { index, category ->
+                itemsIndexed(
+                    storeCategories,
+                    key = { index, category ->
+                        category.id
+                    }
+                ) { index, category ->
                     KoinStoreCategoryItem(
                         categoryName = category.name,
                         categoryIcon = rememberAsyncImagePainter(
@@ -435,7 +440,12 @@ private fun StoreHomeScreen(
                         }
                     }
                 } else {
-                    items(storeList) {
+                    items(
+                        storeList,
+                        key = {
+                            it.shopId
+                        }
+                    ) {
                         KoinStoreCard(
                             modifier = Modifier.fillMaxWidth(),
                             storeName = it.name,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -80,6 +80,8 @@ import `in`.koreatech.koin.feature.store.model.LocalStoreCategories
 import `in`.koreatech.koin.feature.store.model.OrderStatus
 import `in`.koreatech.koin.feature.store.model.OrderType
 import java.time.format.DateTimeFormatter
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.combine
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -252,10 +254,10 @@ fun StoreHomeScreen(
 private fun StoreHomeScreen(
     isLoading: Boolean,
     categoryId: Int,
-    storeList: List<LocalShop>,
-    storeCategories: List<LocalStoreCategories>,
+    storeList: ImmutableList<LocalShop>,
+    storeCategories: ImmutableList<LocalStoreCategories>,
     selectedOrderOption: OrderOption,
-    selectedStoreFilter: List<StoreFilter>,
+    selectedStoreFilter: ImmutableList<StoreFilter>,
     selectedMinimumPriceOption: MinimumPriceOption,
     showOrderOptions: Boolean,
     showMinimumPriceOptions: Boolean,
@@ -493,12 +495,12 @@ private fun StoreHomeScreenPreview() {
             isLoading = false,
             showOrderOptions = false,
             categoryId = 0,
-            storeList = listOf(
+            storeList = persistentListOf(
                 LocalShop(
                     shopId = 1,
                     orderableShopId = 1,
                     name = "Sample Store",
-                    filterBadgeList = listOf(
+                    filterBadgeList = persistentListOf(
                         FilterBadge.PICKUP_AVAILABLE,
                         FilterBadge.DELIVERY_AVAILABLE,
                         FilterBadge.SERVICE
@@ -515,7 +517,7 @@ private fun StoreHomeScreenPreview() {
                     openStatus = OpenStatus.OPERATING
                 )
             ),
-            storeCategories = listOf(
+            storeCategories = persistentListOf(
                 LocalStoreCategories(
                     id = 0,
                     name = "Category 1",
@@ -528,7 +530,7 @@ private fun StoreHomeScreenPreview() {
                 )
             ),
             selectedOrderOption = OrderOption.NONE,
-            selectedStoreFilter = listOf(StoreFilter.IS_OPEN),
+            selectedStoreFilter = persistentListOf(StoreFilter.IS_OPEN),
             selectedMinimumPriceOption = MinimumPriceOption.ALL,
             showMinimumPriceOptions = false
         )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -327,10 +328,7 @@ private fun StoreHomeScreen(
                             imageLoader = KoinCoilImageLoader.getImageLoader(context)
                         ),
                         isSelected = storeCategories[index].id == categoryId,
-                        onClick = {
-                            if (storeCategories[index].id == categoryId) return@KoinStoreCategoryItem
-                            onCategoryChange(storeCategories[index].id) // Category IDs start from 1
-                        }
+                        onClick = remember (key1 = category.id) { { onCategoryChange(storeCategories[index].id) } }
                     )
                 }
             }
@@ -454,10 +452,9 @@ private fun StoreHomeScreen(
                             storeDeliveryFee = it.minimumDeliveryTip,
                             storeImageUrl = it.thumbnail,
                             isOpen = it.isOpen,
-                            filterBadgeList = it.filterBadgeList
-                        ) {
-                            navigateToDetail(it.orderableShopId)
-                        }
+                            filterBadgeList = it.filterBadgeList,
+                            onClick = remember(key1 = it.shopId) { { navigateToDetail(it.orderableShopId) } }
+                        )
                     }
                 }
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeState.kt
@@ -6,16 +6,18 @@ import `in`.koreatech.koin.feature.store.enums.StoreFilter
 import `in`.koreatech.koin.feature.store.model.LocalOrderInProgress
 import `in`.koreatech.koin.feature.store.model.LocalShop
 import `in`.koreatech.koin.feature.store.model.LocalStoreCategories
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class StoreHomeState(
     val isLoading: Boolean = true,
     val categoryId: Int = -1,
-    val storeCategories: List<LocalStoreCategories> = listOf(),
-    val orderableShops: List<LocalShop> = listOf(),
+    val storeCategories: ImmutableList<LocalStoreCategories> = persistentListOf(),
+    val orderableShops: ImmutableList<LocalShop> = persistentListOf(),
     val showOrderOptions: Boolean = false,
     val showMinimumPriceOptions: Boolean = false,
     val selectedOrderOption: OrderOption = OrderOption.NONE,
-    val selectedStoreFilter: List<StoreFilter> = listOf(StoreFilter.IS_OPEN),
+    val selectedStoreFilter: ImmutableList<StoreFilter> = persistentListOf(StoreFilter.IS_OPEN),
     val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL,
     val cartItemCount: Int = 0,
     val isLoggedIn: Boolean = false,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeViewModel.kt
@@ -16,6 +16,7 @@ import `in`.koreatech.koin.feature.store.model.toLocalOrderInProgress
 import `in`.koreatech.koin.feature.store.model.toLocalShop
 import `in`.koreatech.koin.feature.store.model.toLocalStoreCategories
 import javax.inject.Inject
+import kotlinx.collections.immutable.toImmutableList
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -38,7 +39,7 @@ class StoreHomeViewModel @Inject constructor(
             getStoreCategoriesUseCase().let {
                 reduce {
                     state.copy(
-                        storeCategories = it.map { it.toLocalStoreCategories() }
+                        storeCategories = it.map { it.toLocalStoreCategories() }.toImmutableList()
                     )
                 }
             }
@@ -124,7 +125,7 @@ class StoreHomeViewModel @Inject constructor(
                 state.copy(
                     orderableShops = it.map {
                         it.toLocalShop()
-                    },
+                    }.toImmutableList(),
                     isLoading = false
                 )
             }
@@ -160,7 +161,7 @@ class StoreHomeViewModel @Inject constructor(
                     state.selectedStoreFilter - selectedStoreFilter
                 } else {
                     state.selectedStoreFilter + selectedStoreFilter
-                }
+                }.toImmutableList()
             )
         }
     }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/model/LocalShop.kt
@@ -4,6 +4,8 @@ import android.os.Parcelable
 import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.domain.model.store.Shop
 import `in`.koreatech.koin.feature.store.enums.FilterBadge
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
@@ -11,7 +13,7 @@ data class LocalShop(
     val shopId: Int,
     val orderableShopId: Int,
     val name: String,
-    val filterBadgeList: List<FilterBadge>,
+    val filterBadgeList: ImmutableList<FilterBadge>,
     val minimumOrderAmount: Int,
     val ratingAverage: Double,
     val reviewCount: Int,
@@ -41,7 +43,7 @@ internal fun Shop.toLocalShop(): LocalShop {
             if (isTakeoutAvailable) FilterBadge.PICKUP_AVAILABLE else null,
             if (isDeliveryAvailable) FilterBadge.DELIVERY_AVAILABLE else null,
             if (serviceEvent) FilterBadge.SERVICE else null
-        ),
+        ).toImmutableList(),
         minimumOrderAmount = minimumOrderAmount,
         ratingAverage = ratingAverage,
         reviewCount = reviewCount,
@@ -51,7 +53,7 @@ internal fun Shop.toLocalShop(): LocalShop {
         categoryIds = categoryIds,
         images = images.map {
             it.imageUrl
-        },
+        }.toImmutableList(),
         thumbnail = images.firstOrNull { it.isThumbnail }?.imageUrl ?: "",
         openStatus = openStatus
     )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -35,11 +35,13 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
@@ -278,52 +280,54 @@ private fun StoreNearbyScreen(
             ) {
                 Spacer(modifier = Modifier.width(16.dp))
 
-                KoinStoreChip(
-                    modifier = Modifier.fillMaxHeight(),
-                    text = stringResource(selectedOrderOption.stringResId),
-                    chipStyle = KoinStoreChipDefaults.koinStoreChipStyle(
-                        textColor = RebrandKoinTheme.colors.primary500,
-                        borderWidth = 1.dp,
-                        borderColor = RebrandKoinTheme.colors.primary500,
-                        elevation = 0.dp
-                    ),
-                    trailingIcon = painterResource(R.drawable.ic_store_arrow_down),
-                    trailingIconStyle = KoinStoreChipDefaults.koinStoreIconStyle(
-                        iconColor = RebrandKoinTheme.colors.primary500
-                    )
-                ) {
-                    onShowOrderOptionsChange(true)
+                key(selectedOrderOption) {
+                    KoinStoreChip(
+                        modifier = Modifier.fillMaxHeight(),
+                        text = stringResource(selectedOrderOption.stringResId),
+                        chipStyle = KoinStoreChipDefaults.koinStoreChipStyle(
+                            textColor = RebrandKoinTheme.colors.primary500,
+                            borderWidth = 1.dp,
+                            borderColor = RebrandKoinTheme.colors.primary500,
+                            elevation = 0.dp
+                        ),
+                        trailingIcon = rememberVectorPainter(ImageVector.vectorResource(R.drawable.ic_store_arrow_down)),
+                        trailingIconStyle = KoinStoreChipDefaults.koinStoreIconStyle(
+                            iconColor = RebrandKoinTheme.colors.primary500
+                        )
+                    ) {
+                        onShowOrderOptionsChange(true)
+                    }
                 }
 
                 Spacer(modifier = Modifier.width(8.dp))
 
                 StoreFilter.IS_OPEN.let {
-                    val isSelected = selectedStoreFilter.contains(it)
+                    key(it) {
+                        val isSelected = selectedStoreFilter.contains(it)
 
-                    KoinStoreChip(
-                        modifier = Modifier.fillMaxHeight(),
-                        text = stringResource(it.stringResId),
-                        leadingIcon = painterResource(it.iconResId),
-                        chipStyle = if (isSelected) {
-                            KoinStoreChipDefaults.koinStoreChipStyle(
-                                elevation = 0.dp,
-                                containerColor = RebrandKoinTheme.colors.primary500,
-                                textColor = RebrandKoinTheme.colors.neutral0
-                            )
-                        } else {
-                            KoinStoreChipDefaults.koinStoreChipStyle()
-                        },
-                        leadingIconStyle = if (isSelected) {
-                            KoinStoreChipDefaults.koinStoreIconStyle(
-                                iconColor = RebrandKoinTheme.colors.neutral0
-                            )
-                        } else {
-                            KoinStoreChipDefaults.koinStoreIconStyle()
-                        },
-                        onClick = {
-                            onSelectedStoreFilterChange(it)
-                        }
-                    )
+                        KoinStoreChip(
+                            modifier = Modifier.fillMaxHeight(),
+                            text = stringResource(it.stringResId),
+                            leadingIcon = rememberVectorPainter(ImageVector.vectorResource(it.iconResId)),
+                            chipStyle = if (isSelected) {
+                                KoinStoreChipDefaults.koinStoreChipStyle(
+                                    elevation = 0.dp,
+                                    containerColor = RebrandKoinTheme.colors.primary500,
+                                    textColor = RebrandKoinTheme.colors.neutral0
+                                )
+                            } else {
+                                KoinStoreChipDefaults.koinStoreChipStyle()
+                            },
+                            leadingIconStyle = if (isSelected) {
+                                KoinStoreChipDefaults.koinStoreIconStyle(
+                                    iconColor = RebrandKoinTheme.colors.neutral0
+                                )
+                            } else {
+                                KoinStoreChipDefaults.koinStoreIconStyle()
+                            },
+                            onClick = remember(key1 = it) { { onSelectedStoreFilterChange(it) } }
+                        )
+                    }
                 }
 
                 Spacer(modifier = Modifier.width(16.dp))

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -247,7 +248,12 @@ private fun StoreNearbyScreen(
                 verticalAlignment = Alignment.CenterVertically,
                 contentPadding = PaddingValues(horizontal = 24.dp)
             ) {
-                itemsIndexed(storeCategories) { index, category ->
+                itemsIndexed(
+                    storeCategories,
+                    key = { index, category ->
+                        category.id
+                    }
+                ) { index, category ->
                     KoinStoreCategoryItem(
                         categoryName = category.name,
                         categoryIcon = rememberAsyncImagePainter(
@@ -363,7 +369,12 @@ private fun StoreNearbyScreen(
                         }
                     }
                 } else {
-                    items(storeList) {
+                    items(
+                        storeList,
+                        key = {
+                            it.shopId
+                        }
+                    ) {
                         KoinStoreCard(
                             modifier = Modifier.fillMaxWidth(),
                             storeName = it.name,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -73,6 +73,8 @@ import `in`.koreatech.koin.feature.store.enums.StoreFilter
 import `in`.koreatech.koin.feature.store.enums.minimumPriceOptions
 import `in`.koreatech.koin.feature.store.model.LocalShop
 import `in`.koreatech.koin.feature.store.model.LocalStoreCategories
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.flow.combine
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -193,10 +195,10 @@ fun StoreNearbyScreen(
 private fun StoreNearbyScreen(
     isLoading: Boolean,
     categoryId: Int,
-    storeList: List<LocalShop>,
-    storeCategories: List<LocalStoreCategories>,
+    storeList: ImmutableList<LocalShop>,
+    storeCategories: ImmutableList<LocalStoreCategories>,
     selectedOrderOption: OrderOption,
-    selectedStoreFilter: List<StoreFilter>,
+    selectedStoreFilter: ImmutableList<StoreFilter>,
     selectedMinimumPriceOption: MinimumPriceOption,
     showOrderOptions: Boolean,
     showMinimumPriceOptions: Boolean,
@@ -420,12 +422,12 @@ private fun StoreNearbyScreenPreview() {
             isLoading = false,
             showOrderOptions = false,
             categoryId = 0,
-            storeList = listOf(
+            storeList = persistentListOf(
                 LocalShop(
                     shopId = 1,
                     orderableShopId = 1,
                     name = "Sample Store",
-                    filterBadgeList = listOf(
+                    filterBadgeList = persistentListOf(
                         FilterBadge.PICKUP_AVAILABLE,
                         FilterBadge.DELIVERY_AVAILABLE,
                         FilterBadge.SERVICE
@@ -442,7 +444,7 @@ private fun StoreNearbyScreenPreview() {
                     openStatus = OpenStatus.OPERATING
                 )
             ),
-            storeCategories = listOf(
+            storeCategories = persistentListOf(
                 LocalStoreCategories(
                     id = 0,
                     name = "Category 1",
@@ -455,7 +457,7 @@ private fun StoreNearbyScreenPreview() {
                 )
             ),
             selectedOrderOption = OrderOption.NONE,
-            selectedStoreFilter = listOf(StoreFilter.IS_OPEN),
+            selectedStoreFilter = persistentListOf(StoreFilter.IS_OPEN),
             selectedMinimumPriceOption = MinimumPriceOption.ALL,
             showMinimumPriceOptions = false
         )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -261,10 +261,7 @@ private fun StoreNearbyScreen(
                             imageLoader = KoinCoilImageLoader.getImageLoader(context)
                         ),
                         isSelected = index + 1 == categoryId,
-                        onClick = {
-                            if (index + 1 == categoryId) return@KoinStoreCategoryItem
-                            onCategoryChange(index + 1) // Category IDs start from 1
-                        }
+                        onClick = remember(key1 = category.id) { { onCategoryChange(index + 1) } }
                     )
                 }
             }
@@ -382,10 +379,9 @@ private fun StoreNearbyScreen(
                             storeReviewCount = it.reviewCount,
                             storeImageUrl = it.thumbnail,
                             isOpen = it.isOpen,
-                            filterBadgeList = it.filterBadgeList
-                        ) {
-                            navigateToDetail(it.shopId)
-                        }
+                            filterBadgeList = it.filterBadgeList,
+                            onClick = remember(key1 = it.shopId) { { navigateToDetail(it.shopId) } }
+                        )
                     }
                 }
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -44,7 +44,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.LineHeightStyle

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
@@ -5,18 +5,20 @@ import `in`.koreatech.koin.feature.store.enums.OrderOption
 import `in`.koreatech.koin.feature.store.enums.StoreFilter
 import `in`.koreatech.koin.feature.store.model.LocalShop
 import `in`.koreatech.koin.feature.store.model.LocalStoreCategories
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 
 data class StoreNearbyState(
     val isLoading: Boolean = true,
     val categoryId: Int = 1,
     val showSearch: Boolean = false,
     val query: String = "",
-    val storeCategories: List<LocalStoreCategories> = listOf(),
-    val orderableShops: List<LocalShop> = listOf(),
+    val storeCategories: ImmutableList<LocalStoreCategories> = persistentListOf(),
+    val orderableShops: ImmutableList<LocalShop> = persistentListOf(),
     val showOrderOptions: Boolean = false,
     val showMinimumPriceOptions: Boolean = false,
     val selectedOrderOption: OrderOption = OrderOption.NONE,
-    val selectedStoreFilter: List<StoreFilter> = listOf(StoreFilter.IS_OPEN),
+    val selectedStoreFilter: ImmutableList<StoreFilter> = persistentListOf(StoreFilter.IS_OPEN),
     val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL,
     val cartItemCount: Int = 0,
     val isLoggedIn: Boolean = false,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
@@ -14,6 +14,7 @@ import `in`.koreatech.koin.feature.store.enums.toStoreSorter
 import `in`.koreatech.koin.feature.store.model.toLocalShop
 import `in`.koreatech.koin.feature.store.model.toLocalStoreCategories
 import javax.inject.Inject
+import kotlinx.collections.immutable.toImmutableList
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -35,7 +36,7 @@ class StoreNearbyViewModel @Inject constructor(
             getStoreCategoriesUseCase().let {
                 reduce {
                     state.copy(
-                        storeCategories = it.map { it.toLocalStoreCategories() }
+                        storeCategories = it.map { it.toLocalStoreCategories() }.toImmutableList()
                     )
                 }
             }
@@ -103,7 +104,7 @@ class StoreNearbyViewModel @Inject constructor(
         ).onSuccess {
             reduce {
                 state.copy(
-                    orderableShops = it.map { it.toLocalShop() },
+                    orderableShops = it.map { it.toLocalShop() }.toImmutableList(),
                     isLoading = false
                 )
             }
@@ -139,7 +140,7 @@ class StoreNearbyViewModel @Inject constructor(
                     state.selectedStoreFilter - selectedStoreFilter
                 } else {
                     state.selectedStoreFilter + selectedStoreFilter
-                }
+                }.toImmutableList()
             )
         }
     }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1132

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 홈 및 주변상점 화면의 recomposition을 최적화했습니다.
  * mutable한 `List` 대신 `ImmutableList`를 사용하도록 수정했습니다.
  * `key` 함수를 사용하여 값이 바뀌지 않았을 때는 recomposition이 skip 되도록 수정했습니다.
  * `painterResource` 대신 `ImageVector`를 사용했습니다.
  * Unstable한 lambda가 recomposition을 유발하는 것을 방지하기 위해 `remember`를 사용했습니다.
* 결론
  * 기존의 경우, 하나의 Composable이 변경될 경우, Unstable한 값들로 인해 변경되지 않은 Composable 또한 skip되지 않고 모두 recomposition 되었습니다.
  * 본 PR 이후 하나의 Composable이 변경되더라고, 변경되지 않은 Composable들은 recomposition 되지 않고 skip 되는 것을 확인할 수 있습니다.
### 논의 사항

### 스크린샷
<img width="493" height="899" alt="image" src="https://github.com/user-attachments/assets/f25fb18e-e978-4323-8ec1-b64969967a4e" />

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다