### PR TITLE
[Business][Fix] 카테고리 변경 시 상점 목록이 최상위로 올라가도록 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/home/StoreHomeScreen.kt
@@ -271,10 +271,12 @@ private fun StoreHomeScreen(
 ) {
     val context = LocalContext.current
     val categoryListState = rememberLazyListState()
+    val shopListState = rememberLazyListState()
 
     LaunchedEffect(categoryId) {
         if (categoryId != -1) {
             categoryListState.animateScrollToItem(storeCategories.map { it.id }.indexOf(categoryId))
+            shopListState.animateScrollToItem(0)
         }
     }
 
@@ -402,7 +404,8 @@ private fun StoreHomeScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(horizontal = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                state = shopListState
             ) {
                 if (!isLoading && storeList.isEmpty()) {
                     item {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -308,6 +308,7 @@ internal fun NavGraphBuilder.koinStoreMainGraph(
         )
     ) {
         StoreNearbyScreen(
+            categoryId = categoryId,
             navigateToDetail = { storeId ->
                 navController.navigate("${StoreDetailNavType.StoreDetailMain.route}/$storeId/${false}")
             },

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -220,10 +220,12 @@ private fun StoreNearbyScreen(
 ) {
     val context = LocalContext.current
     val categoryListState = rememberLazyListState()
+    val shopListState = rememberLazyListState()
 
     LaunchedEffect(categoryId) {
         if (categoryId != -1) {
             categoryListState.animateScrollToItem(storeCategories.map { it.id }.indexOf(categoryId))
+            shopListState.animateScrollToItem(0)
         }
     }
 
@@ -346,7 +348,8 @@ private fun StoreNearbyScreen(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(horizontal = 24.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                state = shopListState
             ) {
                 if (!isLoading && storeList.isEmpty()) {
                     item {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.BasicText
@@ -81,6 +82,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 @Composable
 fun StoreNearbyScreen(
     modifier: Modifier = Modifier,
+    categoryId: Int = 1,
     viewModel: StoreNearbyViewModel = hiltViewModel(),
     navigateToDetail: (Int) -> Unit = { },
     navigateToCart: () -> Unit = { },
@@ -92,6 +94,12 @@ fun StoreNearbyScreen(
 
     viewModel.collectSideEffect {
         handleSideEffect(it, navigateToCart)
+    }
+
+    LaunchedEffect(Unit) {
+        if (uiState.categoryId == -1) {
+            viewModel.onCategoryChange(categoryId)
+        }
     }
 
     LaunchedEffect(Unit) {
@@ -211,6 +219,13 @@ private fun StoreNearbyScreen(
     onShowMinimumPriceOptionsChange: (Boolean) -> Unit = { }
 ) {
     val context = LocalContext.current
+    val categoryListState = rememberLazyListState()
+
+    LaunchedEffect(categoryId) {
+        if (categoryId != -1) {
+            categoryListState.animateScrollToItem(storeCategories.map { it.id }.indexOf(categoryId))
+        }
+    }
 
     Box(
         modifier = modifier.fillMaxSize()
@@ -241,6 +256,7 @@ private fun StoreNearbyScreen(
 
             LazyRow(
                 modifier = Modifier.fillMaxWidth(),
+                state = categoryListState,
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
                 contentPadding = PaddingValues(horizontal = 24.dp)

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
@@ -8,7 +8,7 @@ import `in`.koreatech.koin.feature.store.model.LocalStoreCategories
 
 data class StoreNearbyState(
     val isLoading: Boolean = true,
-    val categoryId: Int = 1,
+    val categoryId: Int = -1,
     val showSearch: Boolean = false,
     val query: String = "",
     val storeCategories: List<LocalStoreCategories> = listOf(),


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1132

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
* 주변상점 화면에서 카테고리 변경 시 카테고리 목록이 자동으로 스크롤되지 않는 문제를 수정했습니다.
* 주변상점으로 category id를 넘기도록 수정했습니다.
* 홈 및 주변상점에서 카테고리 변경 시 상점 아이템이 최상위로 올라오도록 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다