### PR TITLE
[Business][Fix] 주변상점 데이터 캐싱 로직 제거

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -274,11 +274,7 @@ class StoreRepositoryImpl @Inject constructor(
 
     override suspend fun getNearbyShops(): Result<List<Shop>> {
         return runCatching {
-            storeLocalDataSource.getCachedNearbyShops()?.map { it.toShop() } ?: storeRemoteDataSource.getNearbyShops().shops.also {
-                storeLocalDataSource.setCachedNearbyShops(it)
-            }.map {
-                it.toShop()
-            }
+            storeRemoteDataSource.getNearbyShops().shops.map { it.toShop() }
         }.onFailure { e ->
             return Result.failure(
                 when (e) {

--- a/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/StoreLocalDataSource.kt
@@ -15,12 +15,4 @@ class StoreLocalDataSource @Inject constructor() {
     fun getCachedStoreCategories(): List<StoreCategoriesItemResponse>? {
         return this.storeCategories.ifEmpty { null }
     }
-
-    fun setCachedNearbyShops(nearbyShops: List<StoreItemResponse>) {
-        this.nearbyShops = nearbyShops
-    }
-
-    fun getCachedNearbyShops(): List<StoreItemResponse>? {
-        return this.nearbyShops.ifEmpty { null }
-    }
 }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1176 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 주변 상점 API에 대한 캐싱 로직을 제거했습니다.
   * 주변 상점의 데이터를 캐싱했을 때, 무결성이 보장되지 않는 문제가 생겨 해당 로직을 제거했습니다.
   * 캐싱을 위해서는 백엔드 로직을 참고해서 동일한 로직을 구현하는 것이 필요할 것 같습니다.
### 논의 사항
* 기존의 구조는 `캐싱을 위해 모든 데이터를 API로부터 fetch -> UseCase에서 해당 데이터를 가지고 필터링 하여 반환` 하는 구조였는데, 이 과정에서 `isOpen`을 계산하는 로직 없이 캐싱된 시점의 값을 그냥 사용한 것이 문제입니다.
* 그렇다면, 캐싱을 제거한 지금 과연 기존 구조처럼 모든 데이터를 fetch 한 다음 usecase에서 필터링하는 로직이 필요할지 의문입니다.
* 일단은 추후 캐싱을 다시 도입한다는 가정하여 로직은 남겨두었습니다. 다만 캐싱을 다시 도입하지 않을 것이라면 해당 로직을 제거하고 API 요청할 때 filter를 같이 요청하는 것이 적절해보입니다.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다