### PR TITLE
[Koin Project][Refactor] 개발자 옵션 구조 개선

### DIFF
--- a/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOption.kt
+++ b/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOption.kt
@@ -1,0 +1,12 @@
+package `in`.koreatech.koin.core.developer
+
+import androidx.annotation.StringRes
+import `in`.koreatech.koin.core.R
+
+sealed class DeveloperOption(val key: String, @param:StringRes val title: Int, @param:StringRes val description: Int?) {
+    data object DeliverySprint : DeveloperOption("delivery_sprint", R.string.developer_setting_delivery_title, null)
+}
+
+val developerOptionList = listOf(
+    DeveloperOption.DeliverySprint
+)

--- a/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOptionUtil.kt
+++ b/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOptionUtil.kt
@@ -9,8 +9,12 @@ import kotlinx.coroutines.flow.update
 object DeveloperOptionUtil {
     private val _developerOptions = MutableStateFlow(mapOf<DeveloperOption, Boolean>())
 
-    fun getDeveloperOption(developerOption: DeveloperOption): Flow<Boolean> {
+    fun getDeveloperOptionFlow(developerOption: DeveloperOption): Flow<Boolean> {
         return _developerOptions.map { it[developerOption] ?: false }.distinctUntilChanged()
+    }
+
+    fun getDeveloperOption(developerOption: DeveloperOption): Boolean {
+        return _developerOptions.value[developerOption] ?: false
     }
 
     fun setDeveloperOption(developerOption: DeveloperOption, value: Boolean) {

--- a/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOptionUtil.kt
+++ b/core/src/main/java/in/koreatech/koin/core/developer/DeveloperOptionUtil.kt
@@ -1,0 +1,21 @@
+package `in`.koreatech.koin.core.developer
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+
+object DeveloperOptionUtil {
+    private val _developerOptions = MutableStateFlow(mapOf<DeveloperOption, Boolean>())
+
+    fun getDeveloperOption(developerOption: DeveloperOption): Flow<Boolean> {
+        return _developerOptions.map { it[developerOption] ?: false }.distinctUntilChanged()
+    }
+
+    fun setDeveloperOption(developerOption: DeveloperOption, value: Boolean) {
+        _developerOptions.update {
+            it.toMutableMap().apply { put(developerOption, value) }
+        }
+    }
+}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -266,6 +266,9 @@
     <string name="force_update_dialog_content">업데이트 이후에도 이 화면이 나타나는\n경우에는 스토어에서 코인을\n삭제 후 재설치 해 주세요.</string>
     <string name="force_update_go_store">스토어로 가기</string>
 
+    <!-- Developer setting -->
+    <string name="developer_setting_delivery_title">배달 스프린트 활성화</string>
+
     <!-- etc -->
     <string name="copyright_2024">Copyright 2024. BCSD Lab. All rights reserved.</string>
 </resources>

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/StoreActivity.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/StoreActivity.kt
@@ -31,6 +31,8 @@ import androidx.navigation.compose.rememberNavController
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
+import `in`.koreatech.koin.core.developer.DeveloperOption
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
 import `in`.koreatech.koin.feature.store.component.KoinStoreNavigationBar
 import `in`.koreatech.koin.feature.store.component.KoinStoreNavigationBarItem
 import `in`.koreatech.koin.feature.store.navigation.StoreNavType
@@ -78,7 +80,7 @@ class StoreActivity : ComponentActivity() {
                     }
                 }
 
-                CompositionLocalProvider(LocalDeliveryDeveloperOption provides viewModel.deliveryDeveloperSetting.collectAsState().value) {
+                CompositionLocalProvider(LocalDeliveryDeveloperOption provides DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) {
                     val enableDelivery = LocalDeliveryDeveloperOption.current
 
                     Scaffold(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/StoreViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/StoreViewModel.kt
@@ -1,13 +1,11 @@
 package `in`.koreatech.koin.feature.store
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.usecase.setting.GetDeveloperSettingUseCase
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.launch
 
 @HiltViewModel
 class StoreViewModel @Inject constructor(
@@ -16,22 +14,7 @@ class StoreViewModel @Inject constructor(
     private val _currentRoute = MutableStateFlow(0)
     val currentRoute = _currentRoute.asStateFlow()
 
-    private val _deliveryDeveloperSetting = MutableStateFlow(false)
-    val deliveryDeveloperSetting get() = _deliveryDeveloperSetting
-
-    init {
-        getDeveloperSettings()
-    }
-
     fun setCurrentRoute(route: Int) {
         _currentRoute.value = route
-    }
-
-    private fun getDeveloperSettings() = viewModelScope.launch {
-        _deliveryDeveloperSetting.value = getDeveloperSettingUseCase(DELIVERY_SPRINT)
-    }
-
-    companion object {
-        const val DELIVERY_SPRINT = "delivery_sprint"
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailState.kt
@@ -36,8 +36,7 @@ data class StoreDetailState(
     val cartType: CartType = CartType.DELIVERY,
     val cartValidation: CartValidation = CartValidation.NONE,
     val showCallDialog: Boolean = false,
-    val showImageDialog: Boolean = false,
-    val deliverySprintEnabled: Boolean = false // TODO: Remove after delivery sprint complete
+    val showImageDialog: Boolean = false
 )
 fun OwnerInfoModel?.hasAnyInfo(): Boolean {
     return this?.let {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
@@ -3,6 +3,8 @@ package `in`.koreatech.koin.feature.store.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.developer.DeveloperOption
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
 import `in`.koreatech.koin.domain.error.store.KoinStoreException
 import `in`.koreatech.koin.domain.model.cart.CartType
 import `in`.koreatech.koin.domain.model.user.User
@@ -84,14 +86,6 @@ class StoreDetailViewModel @Inject constructor(
             fetchReview(storeId)
             checkToken()
         }
-
-    init {
-        intent {
-            getDeveloperSettingUseCase(DELIVERY_SPRINT).let {
-                reduce { state.copy(deliverySprintEnabled = it) }
-            }
-        }
-    }
 
     private fun getUserType() = intent {
         getUserStatusUseCase().collect {
@@ -271,7 +265,7 @@ class StoreDetailViewModel @Inject constructor(
     }
 
     fun getCartItemsCount() = intent {
-        if (!state.deliverySprintEnabled) return@intent
+        if (!DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) return@intent
         reduce {
             state.copy(isLoading = true)
         }
@@ -324,7 +318,7 @@ class StoreDetailViewModel @Inject constructor(
     }
 
     fun getCart(type: CartType): Job = intent {
-        if (!state.deliverySprintEnabled) return@intent
+        if (!DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) return@intent
         reduce { state.copy(isLoading = true) }
         getCartItemUseCase(type.name).onSuccess {
             reduce { state.copy(cart = it, cartType = type, isLoading = false) }
@@ -339,7 +333,7 @@ class StoreDetailViewModel @Inject constructor(
     }
 
     fun getCartValidate() = intent {
-        if (!state.deliverySprintEnabled) return@intent
+        if (!DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) return@intent
         reduce { state.copy(isLoading = true) }
         validateCartItemsUseCase(state.cartType.name).onSuccess {
             reduce {
@@ -365,7 +359,7 @@ class StoreDetailViewModel @Inject constructor(
     }
 
     private fun getCartSummary() = intent {
-        if (!state.deliverySprintEnabled) return@intent
+        if (!DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) return@intent
         if (state.cart.orderableShopId == null) return@intent
         getCartSummaryUseCase(state.cart.orderableShopId!!).onSuccess {
             reduce {
@@ -381,9 +375,5 @@ class StoreDetailViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    companion object {
-        const val DELIVERY_SPRINT = "delivery_sprint"
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyState.kt
@@ -22,6 +22,5 @@ data class StoreNearbyState(
     val selectedMinimumPriceOption: MinimumPriceOption = MinimumPriceOption.ALL,
     val cartItemCount: Int = 0,
     val isLoggedIn: Boolean = false,
-    val showSignInDialog: Boolean = false,
-    val deliverySprintEnabled: Boolean = false // TODO: Remove after delivery sprint complete
+    val showSignInDialog: Boolean = false
 )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
@@ -2,8 +2,9 @@ package `in`.koreatech.koin.feature.store.nearby
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.developer.DeveloperOption
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
 import `in`.koreatech.koin.domain.model.user.User
-import `in`.koreatech.koin.domain.usecase.setting.GetDeveloperSettingUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetCartItemsCountUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetNearbyShopUseCase
 import `in`.koreatech.koin.domain.usecase.store.GetStoreCategoriesUseCase
@@ -28,8 +29,7 @@ class StoreNearbyViewModel @Inject constructor(
     private val getStoreCategoriesUseCase: GetStoreCategoriesUseCase,
     private val getCartItemsCountUseCase: GetCartItemsCountUseCase,
     private val getNearbyShopUseCase: GetNearbyShopUseCase,
-    private val getUserStatusUseCase: GetUserStatusUseCase,
-    private val getDeveloperSettingUseCase: GetDeveloperSettingUseCase
+    private val getUserStatusUseCase: GetUserStatusUseCase
 ) : ViewModel(), ContainerHost<StoreNearbyState, StoreNearbySideEffect> {
     override val container = container<StoreNearbyState, StoreNearbySideEffect>(StoreNearbyState())
 
@@ -41,9 +41,6 @@ class StoreNearbyViewModel @Inject constructor(
                         storeCategories = it.map { it.toLocalStoreCategories() }.toImmutableList()
                     )
                 }
-            }
-            getDeveloperSettingUseCase(DELIVERY_SPRINT).let {
-                reduce { state.copy(deliverySprintEnabled = it) }
             }
         }
     }
@@ -68,7 +65,7 @@ class StoreNearbyViewModel @Inject constructor(
     }
 
     private fun getCartItemsCount() = intent {
-        if (!state.deliverySprintEnabled) return@intent
+        if (!DeveloperOptionUtil.getDeveloperOption(DeveloperOption.DeliverySprint)) return@intent
         reduce {
             state.copy(isLoading = true)
         }
@@ -194,9 +191,5 @@ class StoreNearbyViewModel @Inject constructor(
 
     fun onSearch() = intent {
         // TODO
-    }
-
-    companion object {
-        const val DELIVERY_SPRINT = "delivery_sprint"
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingScreen.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingScreen.kt
@@ -5,12 +5,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import `in`.koreatech.koin.R
-import `in`.koreatech.koin.ui.developer.DeveloperSettingViewModel.Companion.DELIVERY_SPRINT
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
+import `in`.koreatech.koin.core.developer.developerOptionList
 import `in`.koreatech.koin.ui.developer.component.DeveloperSettingItem
 
 @Composable
@@ -18,17 +19,20 @@ fun DeveloperSettingScreen(
     modifier: Modifier = Modifier,
     developerSettingViewModel: DeveloperSettingViewModel = hiltViewModel()
 ) {
-    val deliveryDeveloperSetting by developerSettingViewModel.deliveryDeveloperSetting.collectAsState()
-
     Column(
         modifier = modifier
     ) {
-        DeveloperSettingItem(
-            modifier = Modifier.padding(vertical = 16.dp, horizontal = 24.dp),
-            title = stringResource(R.string.developer_setting_delivery_title),
-            key = DELIVERY_SPRINT,
-            value = deliveryDeveloperSetting,
-            onValueChange = developerSettingViewModel::setDeveloperSetting
-        )
+        developerOptionList.forEach {
+            key(it.key) {
+                DeveloperSettingItem(
+                    modifier = Modifier.padding(vertical = 16.dp, horizontal = 24.dp),
+                    title = stringResource(it.title),
+                    description = it.description?.let { res -> stringResource(res) },
+                    key = it,
+                    value = DeveloperOptionUtil.getDeveloperOption(it).collectAsState(false).value,
+                    onValueChange = developerSettingViewModel::setDeveloperSetting
+                )
+            }
+        }
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingScreen.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -29,7 +28,7 @@ fun DeveloperSettingScreen(
                     title = stringResource(it.title),
                     description = it.description?.let { res -> stringResource(res) },
                     key = it,
-                    value = DeveloperOptionUtil.getDeveloperOption(it).collectAsState(false).value,
+                    value = DeveloperOptionUtil.getDeveloperOptionFlow(it).collectAsState(false).value,
                     onValueChange = developerSettingViewModel::setDeveloperSetting
                 )
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/developer/DeveloperSettingViewModel.kt
@@ -3,10 +3,12 @@ package `in`.koreatech.koin.ui.developer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.developer.DeveloperOption
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
+import `in`.koreatech.koin.core.developer.developerOptionList
 import `in`.koreatech.koin.domain.usecase.setting.GetDeveloperSettingUseCase
 import `in`.koreatech.koin.domain.usecase.setting.SetDeveloperSettingUseCase
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -14,23 +16,19 @@ class DeveloperSettingViewModel @Inject constructor(
     private val getDeveloperSettingUseCase: GetDeveloperSettingUseCase,
     private val setDeveloperSettingUseCase: SetDeveloperSettingUseCase
 ) : ViewModel() {
-    private val _deliveryDeveloperSetting = MutableStateFlow(false)
-    val deliveryDeveloperSetting get() = _deliveryDeveloperSetting
 
     init {
         getDeveloperSettings()
     }
 
-    fun setDeveloperSetting(key: String, value: Boolean) = viewModelScope.launch {
-        setDeveloperSettingUseCase(key, value)
-        getDeveloperSettings()
+    fun setDeveloperSetting(key: DeveloperOption, value: Boolean) = viewModelScope.launch {
+        setDeveloperSettingUseCase(key.key, value)
+        DeveloperOptionUtil.setDeveloperOption(key, value)
     }
 
     fun getDeveloperSettings() = viewModelScope.launch {
-        _deliveryDeveloperSetting.value = getDeveloperSettingUseCase(DELIVERY_SPRINT)
-    }
-
-    companion object {
-        const val DELIVERY_SPRINT = "delivery_sprint"
+        developerOptionList.forEach {
+            DeveloperOptionUtil.setDeveloperOption(it, getDeveloperSettingUseCase(it.key))
+        }
     }
 }

--- a/koin/src/main/java/in/koreatech/koin/ui/developer/component/DeveloperSettingItem.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/developer/component/DeveloperSettingItem.kt
@@ -17,15 +17,16 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.developer.DeveloperOption
 
 @Composable
 fun DeveloperSettingItem(
     title: String,
-    key: String,
+    key: DeveloperOption,
     value: Boolean,
     modifier: Modifier = Modifier,
     description: String? = null,
-    onValueChange: (String, Boolean) -> Unit = { _, _ -> }
+    onValueChange: (DeveloperOption, Boolean) -> Unit = { _, _ -> }
 ) {
     val backgroundColor by animateColorAsState(
         if (value) KoinTheme.colors.primary500 else KoinTheme.colors.neutral300,

--- a/koin/src/main/java/in/koreatech/koin/ui/splash/viewmodel/SplashViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/splash/viewmodel/SplashViewModel.kt
@@ -5,21 +5,26 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
+import `in`.koreatech.koin.core.developer.developerOptionList
 import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import `in`.koreatech.koin.core.viewmodel.SingleLiveEvent
 import `in`.koreatech.koin.domain.model.version.Version
 import `in`.koreatech.koin.domain.state.version.VersionUpdatePriority
+import `in`.koreatech.koin.domain.usecase.setting.GetDeveloperSettingUseCase
 import `in`.koreatech.koin.domain.usecase.token.IsTokenSavedInDeviceUseCase
 import `in`.koreatech.koin.domain.usecase.version.GetVersionInformationUseCase
 import `in`.koreatech.koin.domain.usecase.version.UpdateLatestVersionUseCase
 import `in`.koreatech.koin.ui.splash.state.TokenState
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
     private val getVersionInformationUseCase: GetVersionInformationUseCase,
     private val updateLatestVersionUseCase: UpdateLatestVersionUseCase,
-    private val isTokenSavedInDeviceUseCase: IsTokenSavedInDeviceUseCase
+    private val isTokenSavedInDeviceUseCase: IsTokenSavedInDeviceUseCase,
+    private val getDeveloperSettingUseCase: GetDeveloperSettingUseCase
 ) : BaseViewModel() {
     private val _version = MutableLiveData<Version>()
     val version: LiveData<Version> get() = _version
@@ -29,6 +34,10 @@ class SplashViewModel @Inject constructor(
 
     private val _tokenState = SingleLiveEvent<TokenState>()
     val tokenState: LiveData<TokenState> get() = _tokenState
+
+    init {
+        getDeveloperSettings()
+    }
 
     fun checkUpdate() {
         viewModelScope.launchIgnoreCancellation {
@@ -68,6 +77,12 @@ class SplashViewModel @Inject constructor(
                 .onFailure {
                     Log.d("SplashViewModel", "Fail to update latest version: ${it.message}")
                 }
+        }
+    }
+
+    private fun getDeveloperSettings() = viewModelScope.launch {
+        developerOptionList.forEach {
+            DeveloperOptionUtil.setDeveloperOption(it, getDeveloperSettingUseCase(it.key))
         }
     }
 }

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -645,8 +645,4 @@
     <string name="inspection_title">개발 중인 페이지입니다</string>
     <string name="inspection_content">죄송합니다. 현재 개발 중인 페이지입니다.\n최대한 빠르게 오픈하도록 하겠습니다.</string>
     <string name="go_to_main">메인 화면 바로가기</string>
-
-    <!-- Developer setting -->
-    <string name="developer_setting_store_title">주변상점 스프린트 활성화</string>
-    <string name="developer_setting_delivery_title">배달 스프린트 활성화</string>
 </resources>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1179

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 개발자 옵션 구조를 개선했습니다.
* `DeveloperOption`은 개발자 옵션의 종류를 나타내는 sealed class이며, `DeveloperOptionUtil`은 실제 개발자 옵션 설정 값을 읽고 저장하는 싱글톤 클래스입니다.
* `DeveloperOptionUtil`에서는 개발자 옵션 값들을 `map`을 이용해 저장하며, 애플리케이션 실행 시점(==Splash)에서 값을 초기화합니다.
* 기존의 구조 또한 각 ViewModel에서 값을 불러와 저장하던 방식의 코드를 전부 제거하고 `DeveloperOptionUtil`을 사용하도록 수정했습니다.
* 추가로, string resource 또한 core 모듈로 이전했습니다.
### 논의 사항
* 약간 우려되는 부분은 결국 코드가 core와 koin 모듈에 걸쳐 파편화 되어 있기 때문에, 이 부분이 유지보수하는 입장에서 부담되지 않을까 걱정됩니다. 좋은 방법 있다면 말씀해주세요.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다