### PR TITLE
[Business][Fix] 가게 대표 이미지가 없을때 클릭 시 발생하는 크래시 제거

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/dialog/StoreImageDialog.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/dialog/StoreImageDialog.kt
@@ -41,6 +41,10 @@ fun StoreImageDialog(
     initialPage: Int = 0,
     onDismiss: () -> Unit = { }
 ) {
+    if (imageUrls.isEmpty()) {
+        onDismiss()
+        return
+    }
     val pagerState = rememberPagerState(
         initialPage = initialPage.coerceIn(0, imageUrls.size - 1)
     ) {


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1181 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* `StoreImageDialog`에서 `imageUrls`가 없을 경우, 크래시가 발생하던 문제를 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다