### PR TITLE
[Koin Project][Refactor] 분실물 채팅 리팩토링

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
@@ -72,9 +72,6 @@ object NetworkModule {
         tokenLocalDataSource: TokenLocalDataSource,
         stompClient: StompClient
     ): KoinStomp {
-        return runBlocking {
-            val authToken = tokenLocalDataSource.getAccessToken() ?: ""
-            KoinStomp(baseUrl, authToken, stompClient)
-        }
+        return KoinStomp(baseUrl, tokenLocalDataSource, stompClient)
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
@@ -59,8 +59,8 @@ object NetworkModule {
         return StompClient(okHttpWebSocketClient) {
             heartBeat =
                 HeartBeat(
-                    minSendPeriod = 4000.milliseconds, // Follow backend recommendation
-                    expectedPeriod = 4000.milliseconds
+                    minSendPeriod = 30000.milliseconds, // Follow backend recommendation
+                    expectedPeriod = 30000.milliseconds
                 )
         }
     }

--- a/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
@@ -12,7 +12,6 @@ import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.stomp.KoinStomp
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.hildan.krossbow.stomp.StompClient

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.data.stomp
 
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
+import javax.inject.Inject
 import kotlinx.coroutines.channels.ClosedReceiveChannelException
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -17,7 +18,6 @@ import org.hildan.krossbow.stomp.conversions.kxserialization.subscribe
 import org.hildan.krossbow.stomp.headers.StompSendHeaders
 import org.hildan.krossbow.websocket.WebSocketException
 import timber.log.Timber
-import javax.inject.Inject
 
 class KoinStomp @Inject constructor(
     private val baseUrl: String,

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -1,12 +1,12 @@
 package `in`.koreatech.koin.data.stomp
 
-import javax.inject.Inject
-import kotlinx.coroutines.CancellationException
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.json.Json.Default.serializersModule
 import kotlinx.serialization.serializer
 import org.hildan.krossbow.stomp.StompClient
@@ -48,33 +48,21 @@ class KoinStomp @Inject constructor(
         destination: String,
         deserializer: DeserializationStrategy<T>
     ): Flow<T> {
-        return flow {
-            while (true) {
-                try {
-                    jsonStompSession.subscribe(destination, deserializer)
-                        .collect { emit(it) }
-                } catch (e: WebSocketException) {
-                    Timber.d("WebSocketException, reconnecting...")
-                    connect(true)
-                    Timber.d("Reconnected. Retrying subscription...")
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    throw e
-                }
-            }
+        val subscriptionFlow = flow {
+            jsonStompSession.subscribe(destination, deserializer)
+                .collect { emit(it) }
         }
-    }
-
-    suspend fun <T : Any> convertAndSend(
-        headers: String,
-        body: T? = null,
-        serializer: SerializationStrategy<T>
-    ) {
-        try {
-            jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
-        } catch (e: UninitializedPropertyAccessException) {
-            throw e
+        return subscriptionFlow.retryWhen { cause, attempt ->
+            if (cause is WebSocketException || cause is ClosedReceiveChannelException) {
+                Timber.w("WebSocketException: attempting reconnect...")
+                disconnect()
+                connect(retry = true)
+                val delayTime = (1000L * attempt.coerceAtMost(5)).coerceAtMost(16000L)
+                delay(delayTime)
+                Timber.w("Re-subscribing to $destination")
+                return@retryWhen true
+            }
+            return@retryWhen false
         }
     }
 
@@ -83,10 +71,6 @@ class KoinStomp @Inject constructor(
         body: T
     ) {
         val serializer = serializersModule.serializer<T>()
-        try {
-            jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
-        } catch (e: UninitializedPropertyAccessException) {
-            throw e
-        }
+        jsonStompSession.convertAndSend(StompSendHeaders(headers), body, serializer)
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.data.stomp
 
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
+import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.serialization.DeserializationStrategy
@@ -16,16 +17,18 @@ import org.hildan.krossbow.stomp.conversions.kxserialization.subscribe
 import org.hildan.krossbow.stomp.headers.StompSendHeaders
 import org.hildan.krossbow.websocket.WebSocketException
 import timber.log.Timber
+import javax.inject.Inject
 
 class KoinStomp @Inject constructor(
     private val baseUrl: String,
-    private val authToken: String,
+    private val tokenLocalDataSource: TokenLocalDataSource,
     private val stompClient: StompClient
 ) {
     var stompSession: StompSession? = null
     lateinit var jsonStompSession: StompSessionWithKxSerialization
 
     suspend fun connect(retry: Boolean) {
+        val authToken = tokenLocalDataSource.getAccessToken() ?: throw IllegalStateException("No Auth Token")
         if (stompSession == null || retry) {
             stompSession =
                 stompClient.connect(


### PR DESCRIPTION
## PR 개요
이슈 번호: 1183

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명

**heartbeat 주기 변경**
heartbeat 주기를 4초에서 30초로 변경했습니다. 너무 짧은 주기는 모바일 환경에서 크래시를 발생시킬 수 있습니다. 웹은 10초, 모바일은 최소 20초 이상이 권장됩니다.

**무한 루프 로직 변경**
subscribe()의 재연결 로직을 무한 루프 방식에서 retryWhen + 지수 백오프로 개선했습니다. 1초부터 최대 16초까지 점진적으로 재시도하여 네트워크 불안정 상황에서도 안정적인 재연결을 보장하도록 구현했습니다.

**채널 종료 예외 처리**
ClosedReceiveChannelException 예외를 처리 추가해서 채널 종료 예외도 처리되도록 수정했습니다. 기존에 백그라운드에 오래 있었다가 다시 돌아왓을 때(채널 끊김) 크래시 나던 문제를 해결했습니다.

**runBlocking 제거**
추가로 토큰 주입할 때 runBlocking을 제거했습니다. runBlocking 사용한 부분이 너무 많아서 일단 저부분만 수정했습니다. 

### 논의 사항
채팅은 처음 건들여 보는거라 제대로 작성 했는지 모르겠네욤
[기록용 노션](https://www.notion.so/STOMP-2c00523f674d80a2951ae108187cdc4d?source=copy_link) 끄적여봤는데 잘못된 내용 있으면 피드백 부탁드립니다🙇‍♀️


## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다