### PR TITLE
[Koin Project][Refactor] 채팅방 목록을 WebSocket을 통해 갱신하도록 수정

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
@@ -84,6 +84,10 @@ class ChatRepositoryImpl @Inject constructor(
         return chatRemoteDataSource.subscribeChatRoom(articleId, chatRoomId).map { it.toChatMessage() }
     }
 
+    override fun subscribeChatList(userId: Int): Flow<List<ChatListItem>> {
+        return chatRemoteDataSource.subscribeChatList(userId).map { it.map { it.toChatListItem() } }
+    }
+
     override suspend fun sendMessage(
         articleId: Int,
         chatRoomId: Int,

--- a/data/src/main/java/in/koreatech/koin/data/response/chat/ChatListItemResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/chat/ChatListItemResponse.kt
@@ -2,15 +2,32 @@ package `in`.koreatech.koin.data.response.chat
 
 import com.google.gson.annotations.SerializedName
 import `in`.koreatech.koin.domain.model.chat.ChatListItem
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class ChatListItemResponse(
-    @SerializedName("article_title") val title: String,
-    @SerializedName("recent_message_content") val recentMessage: String,
-    @SerializedName("lost_item_image_url") val imageUrl: String?,
-    @SerializedName("unread_message_count") val unReadMessageCount: Int,
-    @SerializedName("last_message_at") val lastMessageAt: String,
-    @SerializedName("article_id") val articleId: Int,
-    @SerializedName("chat_room_id") val chatRoomId: Int
+    @SerialName("article_title")
+    @SerializedName("article_title")
+    val title: String,
+    @SerialName("recent_message_content")
+    @SerializedName("recent_message_content")
+    val recentMessage: String,
+    @SerialName("lost_item_image_url")
+    @SerializedName("lost_item_image_url")
+    val imageUrl: String?,
+    @SerialName("unread_message_count")
+    @SerializedName("unread_message_count")
+    val unReadMessageCount: Int,
+    @SerialName("last_message_at")
+    @SerializedName("last_message_at")
+    val lastMessageAt: String,
+    @SerialName("article_id")
+    @SerializedName("article_id")
+    val articleId: Int,
+    @SerialName("chat_room_id")
+    @SerializedName("chat_room_id")
+    val chatRoomId: Int
 )
 
 fun ChatListItemResponse.toChatListItem() =

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -7,9 +7,11 @@ import `in`.koreatech.koin.data.response.chat.ChatListItemResponse
 import `in`.koreatech.koin.data.response.chat.ChatMessageResponse
 import `in`.koreatech.koin.data.response.chat.ChatRoomResponse
 import `in`.koreatech.koin.data.stomp.KoinStomp
+import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.serialization.builtins.ListSerializer
 
 class ChatRemoteDataSource @Inject constructor(
     private val chatApi: ChatApi,
@@ -53,6 +55,15 @@ class ChatRemoteDataSource @Inject constructor(
         return koinStomp.subscribe(
             "/topic/chat/$articleId/$chatRoomId",
             ChatMessageResponse.serializer()
+        )
+    }
+
+    fun subscribeChatList(
+        userId: Int
+    ): Flow<List<ChatListItemResponse>> {
+        return koinStomp.subscribe(
+            "/topic/chatroom/list/$userId",
+            ListSerializer(ChatListItemResponse.serializer())
         )
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ChatRemoteDataSource.kt
@@ -7,7 +7,6 @@ import `in`.koreatech.koin.data.response.chat.ChatListItemResponse
 import `in`.koreatech.koin.data.response.chat.ChatMessageResponse
 import `in`.koreatech.koin.data.response.chat.ChatRoomResponse
 import `in`.koreatech.koin.data.stomp.KoinStomp
-import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import javax.inject.Inject
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/ChatRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/ChatRepository.kt
@@ -29,6 +29,10 @@ interface ChatRepository {
         chatRoomId: Int
     ): Flow<ChatMessage>
 
+    fun subscribeChatList(
+        userId: Int
+    ): Flow<List<ChatListItem>>
+
     suspend fun sendMessage(
         articleId: Int,
         chatRoomId: Int,

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatListUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatListUseCase.kt
@@ -1,0 +1,12 @@
+package `in`.koreatech.koin.domain.usecase.chat
+
+import `in`.koreatech.koin.domain.repository.ChatRepository
+import javax.inject.Inject
+
+class SubscribeChatListUseCase @Inject constructor(
+    private val chatRepository: ChatRepository
+) {
+    operator fun invoke(
+        userId: Int,
+    ) = chatRepository.subscribeChatList(userId)
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatListUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/chat/SubscribeChatListUseCase.kt
@@ -7,6 +7,6 @@ class SubscribeChatListUseCase @Inject constructor(
     private val chatRepository: ChatRepository
 ) {
     operator fun invoke(
-        userId: Int,
+        userId: Int
     ) = chatRepository.subscribeChatList(userId)
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
@@ -50,6 +52,18 @@ fun ChatList(
     val scope = rememberCoroutineScope()
     val snackbarHostState = remember { SnackbarHostState() }
 
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    LaunchedEffect(Unit) {
+        lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+            viewModel.connectChannel.collect { shouldConnect ->
+                if (shouldConnect) {
+                    viewModel.connectToWS()
+                }
+            }
+        }
+    }
+
     LaunchedEffect(showBlockedMessage) {
         if (showBlockedMessage) {
             scope.launch {
@@ -60,8 +74,16 @@ fun ChatList(
         }
     }
 
+    LifecycleEventEffect(Lifecycle.Event.ON_START) {
+        viewModel.connectToWS()
+    }
+
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         viewModel.fetchChatList()
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+        viewModel.disconnectWS()
     }
 
     Scaffold(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListState.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListState.kt
@@ -4,5 +4,6 @@ import `in`.koreatech.koin.domain.model.chat.ChatListItem
 
 data class ChatListState(
     val isLoading: Boolean = true,
-    val chatList: List<ChatListItem> = emptyList()
+    val chatList: List<ChatListItem> = emptyList(),
+    val userId: Int = -1
 )

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
@@ -68,16 +68,15 @@ class ChatListViewModel @Inject constructor(
         }
     }
 
-    fun fetchChatList() =
-        viewModelScope.launch {
-            getChatListUseCase().collect { data ->
-                intent {
-                    reduce {
-                        state.copy(chatList = data, isLoading = false)
-                    }
+    fun fetchChatList() = viewModelScope.launch {
+        getChatListUseCase().collect { data ->
+            intent {
+                reduce {
+                    state.copy(chatList = data, isLoading = false)
                 }
             }
         }
+    }
 
     fun connectToWS() = intent {
         if (state.userId == -1) return@intent // If userId is not set, don't connect websocket

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
@@ -3,19 +3,70 @@ package `in`.koreatech.koin.feature.chat.ui.list
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.model.user.User
+import `in`.koreatech.koin.domain.usecase.chat.ChatWSConnectUseCase
+import `in`.koreatech.koin.domain.usecase.chat.ChatWSDisconnectUseCase
 import `in`.koreatech.koin.domain.usecase.chat.GetChatListUseCase
+import `in`.koreatech.koin.domain.usecase.chat.SubscribeChatListUseCase
+import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
+import java.net.UnknownHostException
 import javax.inject.Inject
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import org.hildan.krossbow.stomp.LostReceiptException
+import org.hildan.krossbow.websocket.WebSocketConnectionException
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import timber.log.Timber
 
 @HiltViewModel
 class ChatListViewModel @Inject constructor(
-    private val getChatListUseCase: GetChatListUseCase
+    private val getUserStatusUseCase: GetUserStatusUseCase,
+    private val getChatListUseCase: GetChatListUseCase,
+    private val chatWSConnectUseCase: ChatWSConnectUseCase,
+    private val chatWSDisconnectUseCase: ChatWSDisconnectUseCase,
+    private val subscribeChatListUseCase: SubscribeChatListUseCase
 ) : ViewModel(), ContainerHost<ChatListState, ChatListSideEffect> {
     override val container = container<ChatListState, ChatListSideEffect>(ChatListState())
+
+    private val _connectChannel = Channel<Boolean>()
+    val connectChannel = _connectChannel.receiveAsFlow()
+
+    init {
+        getUserInfo()
+    }
+
+    private fun getUserInfo() = intent {
+        getUserStatusUseCase().catch {
+            Timber.e(it)
+        }.collectLatest {
+            when (it) {
+                is User.Student -> {
+                    reduce {
+                        state.copy(
+                            userId = it.id
+                        )
+                    }
+                }
+
+                is User.General -> {
+                    reduce {
+                        state.copy(
+                            userId = it.id
+                        )
+                    }
+                }
+
+                is User.Anonymous -> throw IllegalAccessException()
+            }
+            _connectChannel.send(true)
+        }
+    }
 
     fun fetchChatList() =
         viewModelScope.launch {
@@ -27,4 +78,50 @@ class ChatListViewModel @Inject constructor(
                 }
             }
         }
+
+    fun connectToWS() = intent {
+        if (state.userId == -1) return@intent // If userId is not set, don't connect websocket
+        chatWSConnectUseCase().onSuccess {
+            subscribeChatList(state.userId)
+        }
+    }
+
+    fun disconnectWS() = intent { // We need to disconnect websocket on onCleared. So, we need to use coroutineScope instead of viewModelScope
+        chatWSDisconnectUseCase().onFailure {
+            // Sometimes the server closes the connection too quickly to send a RECEIPT, which is not really an error
+            // So, we can ignore LostReceiptException
+            // http://stomp.github.io/stomp-specification-1.2.html#Connection_Lingering
+            if (it !is LostReceiptException) {
+                Timber.e(it)
+            }
+        }
+    }
+
+    private fun subscribeChatList(
+        userId: Int
+    ) = intent {
+        subscribeChatListUseCase(userId).catch {
+            if (it is UnknownHostException) {
+                // Android OS disconnect network when the device enter idle.
+                // So, we set shouldReconnect to true
+                // And reconnect websocket when activity is resumed
+                _connectChannel.send(true)
+            } else if (it is WebSocketConnectionException) {
+                if (it.cause is UnknownHostException) {
+                    // Android OS disconnect network when the device enter idle.
+                    // So, we set shouldReconnect to true
+                    // And reconnect websocket when activity is resumed
+                    _connectChannel.send(true)
+                } else {
+                    Timber.e(it)
+                }
+            } else {
+                Timber.e(it)
+            }
+        }.collect { data ->
+            reduce {
+                state.copy(chatList = data)
+            }
+        }
+    }
 }

--- a/koin/src/main/java/in/koreatech/koin/firebase/KoinFirebaseMessagingService.kt
+++ b/koin/src/main/java/in/koreatech/koin/firebase/KoinFirebaseMessagingService.kt
@@ -1,17 +1,13 @@
 package `in`.koreatech.koin.firebase
 
-import android.app.ActivityManager
 import android.content.Intent
-import androidx.core.content.getSystemService
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.core.navigation.utils.EXTRA_URL
-import `in`.koreatech.koin.core.navigation.utils.toHost
 import `in`.koreatech.koin.core.notification.Notifier
 import `in`.koreatech.koin.core.qualifier.IoDispatcher
 import `in`.koreatech.koin.domain.repository.firebase.messaging.FirebaseMessagingRepository
-import `in`.koreatech.koin.feature.chat.ui.list.ChatListActivity
 import `in`.koreatech.koin.ui.scheme.SchemeActivity
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineDispatcher
@@ -55,26 +51,9 @@ class KoinFirebaseMessagingService : FirebaseMessagingService() {
         super.onMessageReceived(message)
         Timber.e("FirebaseMessaging Received Notification Payload : ${message.notification}")
 
-        val isChatListActivityRunning =
-            getSystemService<ActivityManager>()?.appTasks?.map {
-                /**
-                 * class Name : in.koreatech.koin.feature.chat.ui.list.ChatListActivity
-                 */
-                it.taskInfo.topActivity?.className?.equals(ChatListActivity::class.qualifiedName) == true
-            }
-
         message.data.let { data ->
             Timber.e("FirebaseMessaging Received Data Payload : $data")
             if (data.isNotEmpty()) {
-                isChatListActivityRunning?.any { it }.let {
-                    if (it == true && data[URL]?.toHost() == "chat") {
-                        val intent =
-                            Intent(this, ChatListActivity::class.java).apply {
-                                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            }
-                        startActivity(intent)
-                    }
-                }
                 val intent =
                     Intent(this, SchemeActivity::class.java).apply {
                         putExtra(EXTRA_URL, data[URL])


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1189 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 채팅방 목록을 `/topic/chatroom/` 경로를 구독해서 갱신하도록 수정했습니다.
* `KoinFirebaseMessagingService`에서 불필요한 `ChatListActivity` 재생성 로직을 제거했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다