### PR TITLE
[Koin Project] 채팅방 진입 후 메시지가 갱신되지 않는 문제 수정

### DIFF
--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
@@ -82,7 +82,7 @@ fun ChatList(
         viewModel.fetchChatList()
     }
 
-    LifecycleEventEffect(Lifecycle.Event.ON_STOP) {
+    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
         viewModel.disconnectWS()
     }
 


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1195

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
* 채팅방 목록에서 채팅방 진입 시 대화 내역이 갱신되지 않는 문제를 수정했습니다.
* 안드로이드 생명주기에 따라, `ChatListActivity`에서 `ChatRoomActivity`를 실행할 때의 생명주기는 다음과 같습니다.

|ChatListActivity|ChatRoomActivity|
|----------------------|--------------------------|
|onPause||
||onCreate|
||onStart|
||onResume|
|onStop||

* 따라서, 기존의 코드와 같이 `ChatListActivity`의 `onStop`에서 WebSocket 연결을 끊을 경우, `ChatRoomActivity`에서 채팅방 구독이 진행된 후 연결이 끊어지며 대화 내역이 갱신되지 않게 됩니다.
* 이에 따라, WebSocket 연결을 끊는 지점을 `onPause` 호출 시점으로 수정하였습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다