### PR TITLE
[Koin Project][Feature] 알림 권한 체크 로직 다시 구현

### DIFF
--- a/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/keyword/ArticleKeywordFragment.kt
+++ b/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/keyword/ArticleKeywordFragment.kt
@@ -25,6 +25,7 @@ import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.permission.checkNotificationPermission
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.core.util.SnackbarUtil
+import `in`.koreatech.koin.domain.model.notification.SubscribesType
 import `in`.koreatech.koin.feature.article.R
 import `in`.koreatech.koin.feature.article.databinding.FragmentArticleKeywordBinding
 import javax.inject.Inject
@@ -36,8 +37,6 @@ class ArticleKeywordFragment : Fragment() {
     private val binding get() = _binding!!
 
     private val viewModel by viewModels<ArticleKeywordViewModel>()
-    // FIXME
-    // private val notificationViewModel by viewModels<NotificationViewModel>()
 
     @Inject
     lateinit var navigator: Navigator
@@ -320,8 +319,7 @@ class ArticleKeywordFragment : Fragment() {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.user.collect { user ->
                     if (user.isAnonymous.not()) {
-                        // FIXME
-                        // notificationViewModel.getPermissionInfo()
+                        viewModel.getPermissionInfo()
                     }
                 }
             }
@@ -346,21 +344,20 @@ class ArticleKeywordFragment : Fragment() {
                     AnalyticsConstant.Label.KEYWORD_NOTIFICATION,
                     "on"
                 )
-                // notificationViewModel.updateSubscription(SubscribesType.ARTICLE_KEYWORD)
+                viewModel.updateSubscription(SubscribesType.ARTICLE_KEYWORD)
             } else {
                 EventLogger.logClickEvent(
                     EventAction.CAMPUS,
                     AnalyticsConstant.Label.KEYWORD_NOTIFICATION,
                     "off"
                 )
-                // notificationViewModel.deleteSubscription(SubscribesType.ARTICLE_KEYWORD)
+                viewModel.deleteSubscription(SubscribesType.ARTICLE_KEYWORD)
             }
         }
 
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
-                /* FIXME
-                notificationViewModel.notificationUiState.collect { uiState ->
+                viewModel.notificationUiState.collect { uiState ->
                     if (uiState is NotificationUiState.Success) {
                         uiState.notificationPermissionInfo.subscribes.forEach {
                             if (it.type == SubscribesType.ARTICLE_KEYWORD) {
@@ -374,7 +371,6 @@ class ArticleKeywordFragment : Fragment() {
                         }
                     }
                 }
-                 */
             }
         }
     }

--- a/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/keyword/ArticleKeywordViewModel.kt
+++ b/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/keyword/ArticleKeywordViewModel.kt
@@ -4,15 +4,24 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.core.viewmodel.BaseViewModel
+import `in`.koreatech.koin.domain.model.notification.NotificationPermissionInfo
+import `in`.koreatech.koin.domain.model.notification.SubscribesType
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.repository.ArticleRepository
+import `in`.koreatech.koin.domain.usecase.notification.DeleteNotificationSubscriptionUseCase
+import `in`.koreatech.koin.domain.usecase.notification.GetNotificationPermissionInfoUseCase
+import `in`.koreatech.koin.domain.usecase.notification.UpdateNotificationSubscriptionUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
+import `in`.koreatech.koin.domain.util.onFailure
+import `in`.koreatech.koin.domain.util.onSuccess
 import javax.inject.Inject
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -20,16 +29,24 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 
 @HiltViewModel
 class ArticleKeywordViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
     private val articleRepository: ArticleRepository,
+    private val getNotificationPermissionInfoUseCase: GetNotificationPermissionInfoUseCase,
+    private val updateNotificationSubscriptionUseCase: UpdateNotificationSubscriptionUseCase,
+    private val deleteNotificationSubscriptionUseCase: DeleteNotificationSubscriptionUseCase,
     getUserStatusUseCase: GetUserStatusUseCase
 ) : BaseViewModel() {
     val user: StateFlow<User> =
         getUserStatusUseCase()
             .stateIn(viewModelScope, SharingStarted.Eagerly, User.Anonymous)
+
+    private val _notificationUiState =
+        MutableStateFlow<NotificationUiState>(NotificationUiState.Nothing)
+    val notificationUiState = _notificationUiState.asStateFlow()
 
     val keywordInputUiState: StateFlow<KeywordInputUiState> =
         savedStateHandle.getStateFlow(KEYWORD_INPUT, "").map {
@@ -103,6 +120,30 @@ class ArticleKeywordViewModel @Inject constructor(
         }.launchIn(viewModelScope)
     }
 
+    fun getPermissionInfo() {
+        viewModelScope.launchWithLoading {
+            getNotificationPermissionInfoUseCase().onSuccess { info ->
+                _notificationUiState.update {
+                    NotificationUiState.Success(info)
+                }
+            }.onFailure {
+                _notificationUiState.update { NotificationUiState.Failed }
+            }
+        }
+    }
+
+    fun updateSubscription(type: SubscribesType) {
+        viewModelScope.launchWithLoading {
+            updateNotificationSubscriptionUseCase(type)
+        }
+    }
+
+    fun deleteSubscription(type: SubscribesType) {
+        viewModelScope.launchWithLoading {
+            deleteNotificationSubscriptionUseCase(type)
+        }
+    }
+
     fun deleteKeyword(keyword: String) {
         articleRepository.deleteKeyword(keyword).onEach {
             _keywordAddUiState.emit(KeywordAddUiState.Success(keyword))
@@ -149,4 +190,14 @@ sealed interface KeywordInputUiState {
     data object Empty : KeywordInputUiState
 
     data class Valid(val keyword: String) : KeywordInputUiState
+}
+
+sealed class NotificationUiState {
+    data class Success(
+        val notificationPermissionInfo: NotificationPermissionInfo
+    ) : NotificationUiState()
+
+    data object Failed : NotificationUiState()
+
+    data object Nothing : NotificationUiState()
 }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1043 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
* 이전 PR에서 임시로 비활성화 했던 권한 체크 로직을 다시 추가했습니다.
### 논의 사항
* `notificationViewModel`이 koin 모듈에 있다보니, 결국 `notificationViewModel`의 코드가 중복되었습니다.
* 다만, `NotificationUiState`의 경우, core 모듈로 분리해도 될 것 같다는 생각이 드는데, 어떻게 생각하시는지 궁금합니다.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다