### PR TITLE
[Koin Project][Feature] 공통 Nested scroll logic 구현

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.koin.library)
+    alias(libs.plugins.koin.feature)
     alias(libs.plugins.koin.hilt)
 }
 

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollConnection.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollConnection.kt
@@ -1,0 +1,101 @@
+package `in`.koreatech.koin.core.nestedscroll
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.unit.Velocity
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+@Composable
+fun rememberKoinNestedScrollConnection(
+    state: KoinNestedScrollHeaderState
+): NestedScrollConnection {
+    val scope = rememberCoroutineScope()
+
+    return remember(state, scope) {
+        KoinNestedScrollConnection(state = state, scope = scope)
+    }
+}
+
+open class KoinNestedScrollConnection(
+    private val state: KoinNestedScrollHeaderState,
+    private val scope: CoroutineScope
+) : NestedScrollConnection {
+    override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
+        val delta = available.y
+        val currentOffset = state.headerOffsetPx
+        val headerMaxHeightPx = state.headerMaxHeightPx
+        val headerMinHeightPx = state.headerMinHeightPx
+        val collapsedOffset = -headerMaxHeightPx + headerMinHeightPx
+
+        val isScrollingUp = delta > 0
+
+        val newOffset = if (isScrollingUp) {
+            currentOffset
+        } else {
+            (currentOffset + delta).coerceIn(collapsedOffset, 0f)
+        }
+
+        val consumed = newOffset - currentOffset
+
+        if (consumed != 0f) {
+            scope.launch {
+                state.snapOffset(newOffset)
+            }
+        }
+
+        return if (consumed != 0f) Offset(0f, consumed) else Offset.Zero
+    }
+
+    override fun onPostScroll(
+        consumed: Offset,
+        available: Offset,
+        source: NestedScrollSource
+    ): Offset {
+        val delta = available.y
+        val currentOffset = state.headerOffsetPx
+        val headerMaxHeightPx = state.headerMaxHeightPx
+        val headerMinHeightPx = state.headerMinHeightPx
+        val collapsedOffset = -headerMaxHeightPx + headerMinHeightPx
+
+        val isScrollingUp = delta > 0
+
+        if (isScrollingUp && currentOffset < 0f) {
+            val newOffset = (currentOffset + delta).coerceIn(collapsedOffset, 0f)
+            val consumedByHeader = newOffset - currentOffset
+
+            if (consumedByHeader != 0f) {
+                scope.launch {
+                    state.snapOffset(newOffset)
+                }
+                return Offset(0f, consumedByHeader)
+            }
+        }
+
+        return Offset.Zero
+    }
+
+    override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+        val collapsedOffset = -state.headerMaxHeightPx + state.headerMinHeightPx
+        val expandedOffset = 0f
+        val halfwayOffset = collapsedOffset / 2f
+
+        val isHeaderPartiallyOpen = state.headerOffsetPx > collapsedOffset &&
+                state.headerOffsetPx < expandedOffset
+        val isExpandedMoreThanHalf = state.headerOffsetPx > halfwayOffset
+
+        if (isHeaderPartiallyOpen) {
+            if (isExpandedMoreThanHalf) {
+                state.expandHeader()
+            } else {
+                state.collapseHeader()
+            }
+        }
+
+        return super.onPostFling(consumed, available)
+    }
+}

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollConnection.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollConnection.kt
@@ -28,9 +28,9 @@ open class KoinNestedScrollConnection(
     override fun onPreScroll(available: Offset, source: NestedScrollSource): Offset {
         val delta = available.y
         val currentOffset = state.headerOffsetPx
-        val headerMaxHeightPx = state.headerMaxHeightPx
-        val headerMinHeightPx = state.headerMinHeightPx
-        val collapsedOffset = -headerMaxHeightPx + headerMinHeightPx
+        val headerExpandedHeightPx = state.headerExpandedHeightPx
+        val headerCollapsedHeightPx = state.headerCollapsedHeightPx
+        val collapsedOffset = -headerExpandedHeightPx + headerCollapsedHeightPx
 
         val isScrollingUp = delta > 0
 
@@ -58,9 +58,9 @@ open class KoinNestedScrollConnection(
     ): Offset {
         val delta = available.y
         val currentOffset = state.headerOffsetPx
-        val headerMaxHeightPx = state.headerMaxHeightPx
-        val headerMinHeightPx = state.headerMinHeightPx
-        val collapsedOffset = -headerMaxHeightPx + headerMinHeightPx
+        val headerExpandedHeightPx = state.headerExpandedHeightPx
+        val headerCollapsedHeightPx = state.headerCollapsedHeightPx
+        val collapsedOffset = -headerExpandedHeightPx + headerCollapsedHeightPx
 
         val isScrollingUp = delta > 0
 
@@ -80,12 +80,11 @@ open class KoinNestedScrollConnection(
     }
 
     override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
-        val collapsedOffset = -state.headerMaxHeightPx + state.headerMinHeightPx
+        val collapsedOffset = -state.headerExpandedHeightPx + state.headerCollapsedHeightPx
         val expandedOffset = 0f
         val halfwayOffset = collapsedOffset / 2f
 
-        val isHeaderPartiallyOpen = state.headerOffsetPx > collapsedOffset &&
-                state.headerOffsetPx < expandedOffset
+        val isHeaderPartiallyOpen = state.headerOffsetPx > collapsedOffset && state.headerOffsetPx < expandedOffset
         val isExpandedMoreThanHalf = state.headerOffsetPx > halfwayOffset
 
         if (isHeaderPartiallyOpen) {

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
@@ -1,0 +1,87 @@
+package `in`.koreatech.koin.core.nestedscroll
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Stable
+open class KoinNestedScrollHeaderState(
+    val headerOffsetAnimatable: Animatable<Float, *>,
+    val headerMaxHeightPx: Float = 0f,
+    val headerMinHeightPx: Float = 0f
+) {
+    val headerOffsetPx: Float
+        get() = headerOffsetAnimatable.value
+
+    @Stable
+    @Composable
+    fun progress(): State<Float> = remember {
+        derivedStateOf {
+            val offset = headerOffsetAnimatable.value
+            val range = headerMaxHeightPx - headerMinHeightPx
+            ((-offset) / range).coerceIn(0f, 1f)
+        }
+    }
+
+    @Composable
+    fun currentHeaderHeightDp(): State<Dp> {
+        val density = LocalDensity.current
+        return remember(headerOffsetAnimatable) {
+            derivedStateOf {
+                with(density) {
+                    (headerMaxHeightPx + headerOffsetAnimatable.value).toDp()
+                }
+            }
+        }
+    }
+
+    suspend fun collapseHeader() {
+        headerOffsetAnimatable.animateTo(
+            targetValue = -headerMaxHeightPx + headerMinHeightPx,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessLow
+            )
+        )
+    }
+
+    suspend fun expandHeader() {
+        headerOffsetAnimatable.animateTo(
+            targetValue = 0f,
+            animationSpec = spring(
+                dampingRatio = Spring.DampingRatioNoBouncy,
+                stiffness = Spring.StiffnessLow
+            )
+        )
+    }
+
+    suspend fun snapOffset(offset: Float) {
+        headerOffsetAnimatable.snapTo(offset)
+    }
+}
+
+@Composable
+fun rememberKoinNestedScrollHeaderState(
+    headerMinHeight: Dp = 60.dp,
+    headerMaxHeight: Dp = 300.dp
+): KoinNestedScrollHeaderState {
+    val headerOffsetAnimatable = remember { Animatable(0f) }
+    val headerMaxHeightPx = with(LocalDensity.current) { headerMaxHeight.toPx() }
+    val headerMinHeightPx = with(LocalDensity.current) { headerMinHeight.toPx() }
+
+    return remember(headerOffsetAnimatable, headerMaxHeightPx, headerMinHeightPx) {
+        KoinNestedScrollHeaderState(
+            headerOffsetAnimatable = headerOffsetAnimatable,
+            headerMaxHeightPx = headerMaxHeightPx,
+            headerMinHeightPx = headerMinHeightPx
+        )
+    }
+}

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
@@ -36,10 +36,10 @@ open class KoinNestedScrollHeaderState(
     @Composable
     fun currentHeaderHeightDp(): State<Dp> {
         val density = LocalDensity.current
-        return remember(headerOffsetAnimatable) {
+        return remember(headerOffsetPx) {
             derivedStateOf {
                 with(density) {
-                    (headerExpandedHeightPx + headerOffsetAnimatable.value).toDp()
+                    (headerExpandedHeightPx + headerOffsetPx).toDp()
                 }
             }
         }

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
@@ -66,7 +66,7 @@ open class KoinNestedScrollHeaderState(
     }
 
     suspend fun snapOffset(offset: Float) {
-        headerOffsetAnimatable.snapTo(offset)
+        headerOffsetAnimatable.snapTo(offset.coerceIn(-range, 0f))
     }
 }
 

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.unit.dp
 @Stable
 open class KoinNestedScrollHeaderState(
     val headerOffsetAnimatable: Animatable<Float, *>,
-    val headerMaxHeightPx: Float = 0f,
-    val headerMinHeightPx: Float = 0f
+    val headerExpandedHeightPx: Float = 0f,
+    val headerCollapsedHeightPx: Float = 0f
 ) {
     val headerOffsetPx: Float
         get() = headerOffsetAnimatable.value
@@ -26,7 +26,7 @@ open class KoinNestedScrollHeaderState(
     fun progress(): State<Float> = remember {
         derivedStateOf {
             val offset = headerOffsetAnimatable.value
-            val range = headerMaxHeightPx - headerMinHeightPx
+            val range = headerExpandedHeightPx - headerCollapsedHeightPx
             ((-offset) / range).coerceIn(0f, 1f)
         }
     }
@@ -37,7 +37,7 @@ open class KoinNestedScrollHeaderState(
         return remember(headerOffsetAnimatable) {
             derivedStateOf {
                 with(density) {
-                    (headerMaxHeightPx + headerOffsetAnimatable.value).toDp()
+                    (headerExpandedHeightPx + headerOffsetAnimatable.value).toDp()
                 }
             }
         }
@@ -45,7 +45,7 @@ open class KoinNestedScrollHeaderState(
 
     suspend fun collapseHeader() {
         headerOffsetAnimatable.animateTo(
-            targetValue = -headerMaxHeightPx + headerMinHeightPx,
+            targetValue = -headerExpandedHeightPx + headerCollapsedHeightPx,
             animationSpec = spring(
                 dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessLow
@@ -70,18 +70,18 @@ open class KoinNestedScrollHeaderState(
 
 @Composable
 fun rememberKoinNestedScrollHeaderState(
-    headerMinHeight: Dp = 60.dp,
-    headerMaxHeight: Dp = 300.dp
+    headerCollapsedHeight: Dp = 60.dp,
+    headerExpandedHeight: Dp = 300.dp
 ): KoinNestedScrollHeaderState {
     val headerOffsetAnimatable = remember { Animatable(0f) }
-    val headerMaxHeightPx = with(LocalDensity.current) { headerMaxHeight.toPx() }
-    val headerMinHeightPx = with(LocalDensity.current) { headerMinHeight.toPx() }
+    val headerExpandedHeightPx = with(LocalDensity.current) { headerExpandedHeight.toPx() }
+    val headerCollapsedHeightPx = with(LocalDensity.current) { headerCollapsedHeight.toPx() }
 
-    return remember(headerOffsetAnimatable, headerMaxHeightPx, headerMinHeightPx) {
+    return remember(headerOffsetAnimatable, headerExpandedHeightPx, headerCollapsedHeightPx) {
         KoinNestedScrollHeaderState(
             headerOffsetAnimatable = headerOffsetAnimatable,
-            headerMaxHeightPx = headerMaxHeightPx,
-            headerMinHeightPx = headerMinHeightPx
+            headerExpandedHeightPx = headerExpandedHeightPx,
+            headerCollapsedHeightPx = headerCollapsedHeightPx
         )
     }
 }

--- a/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
+++ b/core/src/main/java/in/koreatech/koin/core/nestedscroll/KoinNestedScrollHeaderState.kt
@@ -21,12 +21,14 @@ open class KoinNestedScrollHeaderState(
     val headerOffsetPx: Float
         get() = headerOffsetAnimatable.value
 
+    val range: Float
+        get() = headerExpandedHeightPx - headerCollapsedHeightPx
+
     @Stable
     @Composable
     fun progress(): State<Float> = remember {
         derivedStateOf {
             val offset = headerOffsetAnimatable.value
-            val range = headerExpandedHeightPx - headerCollapsedHeightPx
             ((-offset) / range).coerceIn(0f, 1f)
         }
     }
@@ -45,7 +47,7 @@ open class KoinNestedScrollHeaderState(
 
     suspend fun collapseHeader() {
         headerOffsetAnimatable.animateTo(
-            targetValue = -headerExpandedHeightPx + headerCollapsedHeightPx,
+            targetValue = -range,
             animationSpec = spring(
                 dampingRatio = Spring.DampingRatioNoBouncy,
                 stiffness = Spring.StiffnessLow


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1212 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
- 기존의 toolbar 영역은 header 영역으로 정의했습니다. (toolbar가 아닌 경우를 위해)
- core 모듈에서 정상적인 compose 사용을 위해 feature 플러그인을 사용하도록 수정했습니다.
- 공통 NestedScrollConnection을 추가했습니다.
   - `onPreScroll`은 기존의 Nested scroll logic과 유사합니다.
   - `onPostScroll`에서는 위쪽 방향으로 스크롤 + 제일 위에 도달할 경우, header 영역을 expand 합니다.
   - `onPostFling`에서는 header 영역이 절반 이상 열려있을 경우, header를 expand하고 아닐 경우 collapse 합니다.
-  사용은 `rememberKoinNestedScrollConnection()`를 사용하거나, 동작에 커스텀이 필요할 경우, `KoinNestedScrollConnection`을 상속해서 사용할 수 있습니다.

### 논의 사항
- 여전히 개선할 점이 많아보입니다. 피드백 환영합니다.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다