### PR TITLE
[Campus][Feature] NavigationDrawer 화면에 분실물 메뉴 추가

### DIFF
--- a/core/src/main/res/layout/base_navigation_drawer_right.xml
+++ b/core/src/main/res/layout/base_navigation_drawer_right.xml
@@ -148,6 +148,15 @@
                     android:textAppearance="@style/TextAppearance.Koin.Regular.16" />
 
                 <androidx.appcompat.widget.AppCompatTextView
+                    android:id="@+id/navi_item_lost_and_found"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="24dp"
+                    android:text="@string/navigation_item_lost_and_found"
+                    android:textAppearance="@style/TextAppearance.Koin.Regular.16" />
+
+                <androidx.appcompat.widget.AppCompatTextView
                     android:id="@+id/navi_item_bus_timetable"
                     android:layout_width="match_parent"
                     android:layout_height="56dp"

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -45,6 +45,7 @@ import `in`.koreatech.koin.feature.article.ArticleActivity
 import `in`.koreatech.koin.feature.chat.ui.list.ChatListActivity
 import `in`.koreatech.koin.feature.club.ui.ClubActivity
 import `in`.koreatech.koin.feature.dining.ui.DiningActivity
+import `in`.koreatech.koin.feature.lostandfound.ui.LostAndFoundActivity
 import `in`.koreatech.koin.feature.store.StoreActivity
 import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
 import `in`.koreatech.koin.feature.user.ui.signup.SignUpActivity
@@ -98,6 +99,7 @@ abstract class KoinNavigationDrawerActivity :
             R.id.navi_item_land,
             R.id.navi_item_owner,
             R.id.navi_item_article,
+            R.id.navi_item_lost_and_found,
             R.id.navi_item_contact
         ).map {
             findViewById<View>(it)
@@ -117,6 +119,7 @@ abstract class KoinNavigationDrawerActivity :
                 MenuState.Land,
                 MenuState.Owner,
                 MenuState.Article,
+                MenuState.LostAndFound,
                 MenuState.Contact
             )
         ) { view, state ->
@@ -399,6 +402,8 @@ abstract class KoinNavigationDrawerActivity :
 
                 MenuState.Article -> goToArticleActivity()
 
+                MenuState.LostAndFound -> goToLostAndFoundActivity()
+
                 MenuState.Contact -> {
                     goToContactWebActivity()
                 }
@@ -627,6 +632,16 @@ abstract class KoinNavigationDrawerActivity :
 
     private fun goToArticleActivity() {
         val intent = Intent(this, ArticleActivity::class.java)
+
+        if (menuState != MenuState.Main) {
+            goToActivityFinish(intent)
+        } else {
+            startActivity(intent)
+        }
+    }
+
+    private fun goToLostAndFoundActivity() {
+        val intent = Intent(this, LostAndFoundActivity::class.java)
 
         if (menuState != MenuState.Main) {
             goToActivityFinish(intent)

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/state/MenuState.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/state/MenuState.kt
@@ -31,6 +31,8 @@ sealed class MenuState {
 
     data object Article : MenuState()
 
+    data object LostAndFound : MenuState()
+
     data object Contact : MenuState()
 
     data object BenefitStore : MenuState()

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -159,6 +159,7 @@
     <string name="forgotpassword_sent_email_message">학교 메일로 비밀번호 초기화를 완료해 주세요. 이동하실래요?</string>
 
     <!--lost and found-->
+    <string name="navigation_item_lost_and_found">분실물</string>
     <string name="lost_and_found_created">생성되었습니다.</string>
     <string name="lost_and_found_edited">수정되었습니다.</string>
     <string name="lost_and_found_deleted">삭제되었습니다.</string>


### PR DESCRIPTION
## PR 개요
이슈 번호:#1214

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명

NavigationDrawer 에 분실물 메뉴를 추가했습니다.
현재 클릭 이벤트는 LostAndFoundActivity 화면으로 이동합니다.

아직 로그 명세는 없기에 로그는 따로 찍지 않습니다.

### 논의 사항

### 스크린샷
<img width="40%" alt="Screenshot_20260114_155126" src="https://github.com/user-attachments/assets/c1b3a073-6bdb-4c46-8ef2-f37a1172ae7e" />

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다