### PR TITLE
[Koin Project][Refactor] Presigned Url 업로드 로직 리팩토링

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/UploadUrlApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/UploadUrlApi.kt
@@ -4,6 +4,7 @@ import `in`.koreatech.koin.data.request.upload.UploadUrlRequest
 import `in`.koreatech.koin.data.response.upload.UploadUrlResponse
 import retrofit2.http.Body
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface UploadUrlApi {
     @POST("/owners/upload/url")
@@ -23,6 +24,12 @@ interface UploadUrlApi {
 
     @POST("/club/upload/url")
     suspend fun postUploadClubUrl(
+        @Body uploadUrlRequest: UploadUrlRequest
+    ): UploadUrlResponse
+
+    @POST("/{domain}/upload/url")
+    suspend fun postUploadUrlV2(
+        @Path("domain") domain: String,
         @Body uploadUrlRequest: UploadUrlRequest
     ): UploadUrlResponse
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/UploadUrlRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UploadUrlRepositoryImpl.kt
@@ -100,4 +100,27 @@ class UploadUrlRepositoryImpl @Inject constructor(
             Result.failure(t)
         }
     }
+
+    override suspend fun getUploadUrlV2(domain: String, contentLength: Long, contentType: String, fileName: String): Result<PreSignedUrl> {
+        return try {
+            val dataSource = uploadUrlRemoteDataSource.postUploadUrlV2(
+                domain = domain,
+                uploadUrlRequest = UploadUrlRequest(contentLength, contentType, fileName)
+            )
+
+            val preSignedUrl = dataSource.preSignedUrl
+            val fileUrl = dataSource.fileUrl
+
+            Result.success(
+                PreSignedUrl(
+                    fileUrl = fileUrl,
+                    preSignedUrl = preSignedUrl
+                )
+            )
+        } catch (e: CancellationException) {
+            throw e
+        } catch (t: Throwable) {
+            Result.failure(t)
+        }
+    }
 }

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/UploadUrlRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/UploadUrlRemoteDataSource.kt
@@ -21,4 +21,6 @@ class UploadUrlRemoteDataSource @Inject constructor(
         )
 
     suspend fun postUploadClubUrl(uploadUrlRequest: UploadUrlRequest): UploadUrlResponse = uploadUrl.postUploadClubUrl(uploadUrlRequest)
+
+    suspend fun postUploadUrlV2(domain: String, uploadUrlRequest: UploadUrlRequest): UploadUrlResponse = uploadUrl.postUploadUrlV2(domain, uploadUrlRequest)
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/upload/PreSignedUrlDomain.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/upload/PreSignedUrlDomain.kt
@@ -1,0 +1,8 @@
+package `in`.koreatech.koin.domain.model.upload
+
+enum class PreSignedUrlDomain(val domain: String) {
+    OWNERS("owners"),
+    MARKET("market"),
+    LOST_AND_FOUND("lost_items"),
+    CLUB("club")
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UploadUrlRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UploadUrlRepository.kt
@@ -26,4 +26,11 @@ interface UploadUrlRepository {
         contentType: String,
         fileName: String
     ): Result<PreSignedUrl>
+
+    suspend fun getUploadUrlV2(
+        domain: String,
+        contentLength: Long,
+        contentType: String,
+        fileName: String
+    ): Result<PreSignedUrl>
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/presignedurl/UploadImageUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/presignedurl/UploadImageUseCase.kt
@@ -5,7 +5,7 @@ import `in`.koreatech.koin.domain.repository.PreSignedUrlRepository
 import `in`.koreatech.koin.domain.repository.UploadUrlRepository
 import javax.inject.Inject
 
-class UploadPreSignedUrlV2UseCase @Inject constructor(
+class UploadImageUseCase @Inject constructor(
     private val preSignedUrlRepository: PreSignedUrlRepository,
     private val uploadUrlRepository: UploadUrlRepository
 ) {

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/presignedurl/UploadPreSignedUrlV2UseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/presignedurl/UploadPreSignedUrlV2UseCase.kt
@@ -1,0 +1,35 @@
+package `in`.koreatech.koin.domain.usecase.presignedurl
+
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
+import `in`.koreatech.koin.domain.repository.PreSignedUrlRepository
+import `in`.koreatech.koin.domain.repository.UploadUrlRepository
+import javax.inject.Inject
+
+class UploadPreSignedUrlV2UseCase @Inject constructor(
+    private val preSignedUrlRepository: PreSignedUrlRepository,
+    private val uploadUrlRepository: UploadUrlRepository
+) {
+    suspend operator fun invoke(
+        domain: PreSignedUrlDomain,
+        contentLength: Long,
+        contentType: String,
+        fileName: String,
+        imageUri: String
+    ): Result<String> = runCatching {
+        val preSignedUrl = uploadUrlRepository.getUploadUrlV2(
+            domain = domain.domain,
+            contentLength = contentLength,
+            contentType = contentType,
+            fileName = fileName
+        ).getOrThrow()
+
+        preSignedUrlRepository.uploadFile(
+            url = preSignedUrl.preSignedUrl,
+            imageUri = imageUri,
+            mediaType = contentType,
+            mediaSize = contentLength
+        ).getOrThrow()
+
+        preSignedUrl.fileUrl
+    }
+}

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateScreen.kt
@@ -142,7 +142,7 @@ fun ClubCreateScreen(
             onShouldShowPermissionDialogChange = viewModel::updateShowPermissionDialog,
             onUserRoleChange = viewModel::updateUserRole,
             uploadImage = { fileSize, fileType, fileName, fileUri ->
-                viewModel.getPreSignedUrl(
+                viewModel.uploadImage(
                     fileSize = fileSize,
                     fileType = fileType,
                     fileName = fileName,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
@@ -4,10 +4,10 @@ import android.net.Uri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.model.user.User
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
 import `in`.koreatech.koin.domain.usecase.club.CreateClubUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.club.model.ClubCategories
 import javax.inject.Inject
@@ -23,8 +23,7 @@ import org.orbitmvi.orbit.viewmodel.container
 class ClubCreateViewModel @Inject constructor(
     private val getUserStatusUseCase: GetUserStatusUseCase,
     private val createClubUseCase: CreateClubUseCase,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
 ) : ViewModel(), ContainerHost<ClubCreateState, ClubCreateSideEffect> {
     override val container = container<ClubCreateState, ClubCreateSideEffect>(ClubCreateState())
 
@@ -167,38 +166,7 @@ class ClubCreateViewModel @Inject constructor(
         }
     }
 
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = viewModelScope.launch {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
-        ).onSuccess {
-            intent {
-                reduce {
-                    state.copy(
-                        clubImageUrl = fileUrl,
-                        isLoading = false
-                    )
-                }
-            }
-        }.onFailure {
-            intent {
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                postSideEffect(ClubCreateSideEffect.ClubImageUploadFailure)
-            }
-        }
-    }
-
-    fun getPreSignedUrl(
+    fun uploadImage(
         fileSize: Long,
         fileType: String,
         fileName: String,
@@ -210,18 +178,21 @@ class ClubCreateViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            getClubPreSignedUrlUseCase(
-                fileSize,
-                fileType,
-                fileName
+            uploadPreSignedUrlV2UseCase(
+                domain = PreSignedUrlDomain.CLUB,
+                contentLength = fileSize,
+                contentType = fileType,
+                fileName = fileName,
+                imageUri = imageUri.toString()
             ).onSuccess {
-                uploadImage(
-                    preSignedUrl = it.preSignedUrl,
-                    fileUrl = it.fileUrl,
-                    mediaType = fileType,
-                    mediaSize = fileSize,
-                    imageUri = imageUri
-                )
+                intent {
+                    reduce {
+                        state.copy(
+                            clubImageUrl = it,
+                            isLoading = false
+                        )
+                    }
+                }
             }.onFailure {
                 intent {
                     reduce {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.club.CreateClubUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.club.model.ClubCategories
 import javax.inject.Inject
@@ -23,7 +23,7 @@ import org.orbitmvi.orbit.viewmodel.container
 class ClubCreateViewModel @Inject constructor(
     private val getUserStatusUseCase: GetUserStatusUseCase,
     private val createClubUseCase: CreateClubUseCase,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
+    private val uploadImageUseCase: UploadImageUseCase
 ) : ViewModel(), ContainerHost<ClubCreateState, ClubCreateSideEffect> {
     override val container = container<ClubCreateState, ClubCreateSideEffect>(ClubCreateState())
 
@@ -178,7 +178,7 @@ class ClubCreateViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            uploadPreSignedUrlV2UseCase(
+            uploadImageUseCase(
                 domain = PreSignedUrlDomain.CLUB,
                 contentLength = fileSize,
                 contentType = fileType,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateScreen.kt
@@ -118,7 +118,7 @@ fun ClubEventCreateScreen(
             eventStartDateTime = uiState.eventStartDateTime,
             eventEndDateTime = uiState.eventEndDateTime,
             imageUrls = uiState.eventImageUrls,
-            uploadImage = viewModel::getPreSignedUrl,
+            uploadImage = viewModel::uploadImage,
             onMaxImageError = viewModel::postMaxImageLimitError,
             onImageDeleteClick = viewModel::deleteImageUrl,
             maxImageLimit = MAX_IMAGE_LIMIT,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.CreateClubEventUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import java.time.LocalDate
 import java.time.LocalTime
@@ -23,7 +23,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubEventCreateViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
+    private val uploadImageUseCase: UploadImageUseCase,
     private val createClubEventUseCase: CreateClubEventUseCase
 ) : ViewModel(), ContainerHost<ClubEventCreateState, ClubEventCreateSideEffect> {
 
@@ -157,7 +157,7 @@ class ClubEventCreateViewModel @Inject constructor(
         imageUri: Uri
     ) = blockingIntent {
         reduce { state.copy(isLoading = true) }
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.CLUB,
             contentLength = fileSize,
             contentType = fileType,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventcreate/ClubEventCreateViewModel.kt
@@ -4,9 +4,9 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.CreateClubEventUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import java.time.LocalDate
 import java.time.LocalTime
@@ -23,8 +23,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubEventCreateViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase,
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
     private val createClubEventUseCase: CreateClubEventUseCase
 ) : ViewModel(), ContainerHost<ClubEventCreateState, ClubEventCreateSideEffect> {
 
@@ -151,53 +150,31 @@ class ClubEventCreateViewModel @Inject constructor(
         reduce { state.copy(eventEndDateTime = newDate) }
     }
 
-    fun getPreSignedUrl(
+    fun uploadImage(
         fileSize: Long,
         fileType: String,
         fileName: String,
         imageUri: Uri
     ) = blockingIntent {
         reduce { state.copy(isLoading = true) }
-        getClubPreSignedUrlUseCase(
-            fileSize,
-            fileType,
-            fileName
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
         ).onSuccess {
-            uploadImage(
-                preSignedUrl = it.preSignedUrl,
-                fileUrl = it.fileUrl,
-                mediaType = fileType,
-                mediaSize = fileSize,
-                imageUri = imageUri
-            )
-        }.onFailure {
-            reduce { state.copy(isLoading = false) }
-            postSideEffect(ClubEventCreateSideEffect.ClubImageUploadFailure)
-        }
-    }
-
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = blockingIntent {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
-        ).onSuccess {
-            reduce {
-                state.copy(
-                    eventImageUrls = if (state.eventImageUrls.size < MAX_IMAGE_LIMIT) {
-                        state.eventImageUrls.toPersistentList().add(fileUrl)
-                    } else {
-                        state.eventImageUrls
-                    },
-                    isLoading = false
-                )
+            intent {
+                reduce {
+                    state.copy(
+                        eventImageUrls = if (state.eventImageUrls.size < MAX_IMAGE_LIMIT) {
+                            state.eventImageUrls.toPersistentList().add(it)
+                        } else {
+                            state.eventImageUrls
+                        },
+                        isLoading = false
+                    )
+                }
             }
         }.onFailure {
             reduce { state.copy(isLoading = false) }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyScreen.kt
@@ -119,7 +119,7 @@ fun ClubEventModifyScreen(
             eventStartDateTime = uiState.eventStartDateTime,
             eventEndDateTime = uiState.eventEndDateTime,
             imageUrls = uiState.eventImageUrls,
-            uploadImage = viewModel::getPreSignedUrl,
+            uploadImage = viewModel::uploadImage,
             onMaxImageError = viewModel::postMaxImageLimitError,
             maxImageLimit = MAX_IMAGE_LIMIT,
             isLoading = uiState.isEventLoading,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyViewModel.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubEventUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubEventUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.club.model.toLocalDateTime
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import `in`.koreatech.koin.feature.club.navigation.EVENT_ID
@@ -27,7 +27,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubEventModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
+    private val uploadImageUseCase: UploadImageUseCase,
     private val getClubEventUseCase: GetClubEventUseCase,
     private val modifyClubEventUseCase: ModifyClubEventUseCase
 ) : ViewModel(), ContainerHost<ClubEventModifyState, ClubEventModifySideEffect> {
@@ -251,7 +251,7 @@ class ClubEventModifyViewModel @Inject constructor(
         imageUri: Uri
     ) = blockingIntent {
         reduce { state.copy(isLoading = true) }
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.CLUB,
             contentLength = fileSize,
             contentType = fileType,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubeventmodify/ClubEventModifyViewModel.kt
@@ -4,10 +4,10 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubEventUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubEventUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.feature.club.model.toLocalDateTime
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import `in`.koreatech.koin.feature.club.navigation.EVENT_ID
@@ -27,8 +27,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubEventModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase,
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
     private val getClubEventUseCase: GetClubEventUseCase,
     private val modifyClubEventUseCase: ModifyClubEventUseCase
 ) : ViewModel(), ContainerHost<ClubEventModifyState, ClubEventModifySideEffect> {
@@ -245,48 +244,24 @@ class ClubEventModifyViewModel @Inject constructor(
         reduce { state.copy(eventEndDateTime = newDate) }
     }
 
-    fun getPreSignedUrl(
+    fun uploadImage(
         fileSize: Long,
         fileType: String,
         fileName: String,
         imageUri: Uri
     ) = blockingIntent {
         reduce { state.copy(isLoading = true) }
-        getClubPreSignedUrlUseCase(
-            fileSize,
-            fileType,
-            fileName
-        ).onSuccess {
-            uploadImage(
-                preSignedUrl = it.preSignedUrl,
-                fileUrl = it.fileUrl,
-                mediaType = fileType,
-                mediaSize = fileSize,
-                imageUri = imageUri
-            )
-        }.onFailure {
-            reduce { state.copy(isLoading = false) }
-            postSideEffect(ClubEventModifySideEffect.ClubImageUploadFailure)
-        }
-    }
-
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = blockingIntent {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
         ).onSuccess {
             reduce {
                 state.copy(
                     eventImageUrls = if (state.eventImageUrls.size < MAX_IMAGE_LIMIT) {
-                        state.eventImageUrls.toPersistentList().add(fileUrl)
+                        state.eventImageUrls.toPersistentList().add(it)
                     } else {
                         state.eventImageUrls
                     },

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
@@ -135,7 +135,7 @@ fun ClubModifyScreen(
             onCancelModifyClub = onNavigateUp,
             onShouldShowModifyDialogChange = viewModel::updateShowModifyDialog,
             uploadImage = { fileSize, fileType, fileName, fileUri ->
-                viewModel.getPreSignedUrl(
+                viewModel.uploadImage(
                     fileSize = fileSize,
                     fileType = fileType,
                     fileName = fileName,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -8,7 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubDetailsUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.club.model.ClubCategories
 import `in`.koreatech.koin.feature.club.model.toClubCategory
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
@@ -27,7 +27,7 @@ class ClubModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getClubDetailsUseCase: GetClubDetailsUseCase,
     private val modifyClubUseCase: ModifyClubUseCase,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
+    private val uploadImageUseCase: UploadImageUseCase
 ) : ViewModel(), ContainerHost<ClubModifyState, ClubModifySideEffect> {
     override val container = container<ClubModifyState, ClubModifySideEffect>(ClubModifyState(), savedStateHandle) {
         val clubId = savedStateHandle.get<Int>(CLUB_ID)
@@ -169,7 +169,7 @@ class ClubModifyViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            uploadPreSignedUrlV2UseCase(
+            uploadImageUseCase(
                 domain = PreSignedUrlDomain.CLUB,
                 contentLength = fileSize,
                 contentType = fileType,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubDetailsUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.feature.club.model.ClubCategories
 import `in`.koreatech.koin.feature.club.model.toClubCategory
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
@@ -27,8 +27,7 @@ class ClubModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val getClubDetailsUseCase: GetClubDetailsUseCase,
     private val modifyClubUseCase: ModifyClubUseCase,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
 ) : ViewModel(), ContainerHost<ClubModifyState, ClubModifySideEffect> {
     override val container = container<ClubModifyState, ClubModifySideEffect>(ClubModifyState(), savedStateHandle) {
         val clubId = savedStateHandle.get<Int>(CLUB_ID)
@@ -158,39 +157,7 @@ class ClubModifyViewModel @Inject constructor(
         }
     }
 
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = viewModelScope.launch {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
-        ).onSuccess {
-            intent {
-                reduce {
-                    state.copy(
-                        clubImageUrl = fileUrl,
-                        isClubImageChanged = true,
-                        isLoading = false
-                    )
-                }
-            }
-        }.onFailure {
-            intent {
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                postSideEffect(ClubModifySideEffect.ClubImageUploadFailure)
-            }
-        }
-    }
-
-    fun getPreSignedUrl(
+    fun uploadImage(
         fileSize: Long,
         fileType: String,
         fileName: String,
@@ -202,18 +169,21 @@ class ClubModifyViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
-            getClubPreSignedUrlUseCase(
-                fileSize,
-                fileType,
-                fileName
+            uploadPreSignedUrlV2UseCase(
+                domain = PreSignedUrlDomain.CLUB,
+                contentLength = fileSize,
+                contentType = fileType,
+                fileName = fileName,
+                imageUri = imageUri.toString()
             ).onSuccess {
-                uploadImage(
-                    preSignedUrl = it.preSignedUrl,
-                    fileUrl = it.fileUrl,
-                    mediaType = fileType,
-                    mediaSize = fileSize,
-                    imageUri = imageUri
-                )
+                intent {
+                    reduce {
+                        state.copy(
+                            clubImageUrl = it,
+                            isLoading = false
+                        )
+                    }
+                }
             }.onFailure {
                 intent {
                     reduce {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateScreen.kt
@@ -98,7 +98,7 @@ fun ClubRecruitCreateScreen(
                 .padding(contentPadding),
             imageUrl = uiState.recruitImageUrl,
             uploadImage = { fileSize, fileType, fileName, fileUri ->
-                viewModel.getPreSignedUrl(
+                viewModel.uploadImage(
                     fileSize = fileSize,
                     fileType = fileType,
                     fileName = fileName,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.CreateClubRecruitmentUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -20,7 +20,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubRecruitCreateViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
+    private val uploadImageUseCase: UploadImageUseCase,
     private val createClubRecruitmentUseCase: CreateClubRecruitmentUseCase
 ) : ViewModel(), ContainerHost<ClubRecruitCreateState, ClubRecruitCreateSideEffect> {
 
@@ -112,7 +112,7 @@ class ClubRecruitCreateViewModel @Inject constructor(
         reduce {
             state.copy(isLoading = true)
         }
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.CLUB,
             contentLength = fileSize,
             contentType = fileType,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitcreate/ClubRecruitCreateViewModel.kt
@@ -4,9 +4,9 @@ import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.CreateClubRecruitmentUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -20,8 +20,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubRecruitCreateViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase,
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
     private val createClubRecruitmentUseCase: CreateClubRecruitmentUseCase
 ) : ViewModel(), ContainerHost<ClubRecruitCreateState, ClubRecruitCreateSideEffect> {
 
@@ -103,7 +102,7 @@ class ClubRecruitCreateViewModel @Inject constructor(
         reduce { state.copy(recruitAlways = !state.recruitAlways) }
     }
 
-    fun getPreSignedUrl(
+    fun uploadImage(
         fileSize: Long,
         fileType: String,
         fileName: String,
@@ -113,18 +112,19 @@ class ClubRecruitCreateViewModel @Inject constructor(
         reduce {
             state.copy(isLoading = true)
         }
-        getClubPreSignedUrlUseCase(
-            fileSize,
-            fileType,
-            fileName
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
         ).onSuccess {
-            uploadImage(
-                preSignedUrl = it.preSignedUrl,
-                fileUrl = it.fileUrl,
-                mediaType = fileType,
-                mediaSize = fileSize,
-                imageUri = imageUri
-            )
+            reduce {
+                state.copy(
+                    recruitImageUrl = it,
+                    isLoading = false
+                )
+            }
         }.onFailure {
             intent {
                 reduce {
@@ -132,33 +132,6 @@ class ClubRecruitCreateViewModel @Inject constructor(
                 }
                 postSideEffect(ClubRecruitCreateSideEffect.ClubImageUploadFailure)
             }
-        }
-    }
-
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = intent {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
-        ).onSuccess {
-            reduce {
-                state.copy(
-                    recruitImageUrl = fileUrl,
-                    isLoading = false
-                )
-            }
-        }.onFailure {
-            reduce {
-                state.copy(isLoading = false)
-            }
-            postSideEffect(ClubRecruitCreateSideEffect.ClubImageUploadFailure)
         }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitmodify/ClubRecruitModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitmodify/ClubRecruitModifyViewModel.kt
@@ -5,10 +5,10 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.error.club.KoinClubException
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubRecruitmentUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubRecruitmentUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetClubPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.feature.club.model.RecruitmentStatus
 import `in`.koreatech.koin.feature.club.model.toParcelizeClubRecruitment
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
@@ -24,8 +24,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubRecruitModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val getClubPreSignedUrlUseCase: GetClubPreSignedUrlUseCase,
-    private val uploadFilesUseCase: UploadFileUseCase,
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
     private val getClubRecruitmentUseCase: GetClubRecruitmentUseCase,
     private val modifyClubRecruitmentUseCase: ModifyClubRecruitmentUseCase
 ) : ViewModel(), ContainerHost<ClubRecruitModifyState, ClubRecruitModifySideEffect> {
@@ -197,18 +196,19 @@ class ClubRecruitModifyViewModel @Inject constructor(
         reduce {
             state.copy(isLoading = true)
         }
-        getClubPreSignedUrlUseCase(
-            fileSize,
-            fileType,
-            fileName
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
         ).onSuccess {
-            uploadImage(
-                preSignedUrl = it.preSignedUrl,
-                fileUrl = it.fileUrl,
-                mediaType = fileType,
-                mediaSize = fileSize,
-                imageUri = imageUri
-            )
+            reduce {
+                state.copy(
+                    recruitImageUrl = it,
+                    isLoading = false
+                )
+            }
         }.onFailure {
             intent {
                 reduce {
@@ -216,33 +216,6 @@ class ClubRecruitModifyViewModel @Inject constructor(
                 }
                 postSideEffect(ClubRecruitModifySideEffect.ClubImageUploadFailure)
             }
-        }
-    }
-
-    private fun uploadImage(
-        preSignedUrl: String,
-        fileUrl: String,
-        mediaType: String,
-        mediaSize: Long,
-        imageUri: Uri
-    ) = intent {
-        uploadFilesUseCase(
-            preSignedUrl,
-            mediaType,
-            mediaSize,
-            imageUri.toString()
-        ).onSuccess {
-            reduce {
-                state.copy(
-                    recruitImageUrl = fileUrl,
-                    isLoading = false
-                )
-            }
-        }.onFailure {
-            reduce {
-                state.copy(isLoading = false)
-            }
-            postSideEffect(ClubRecruitModifySideEffect.ClubImageUploadFailure)
         }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitmodify/ClubRecruitModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubrecruitmodify/ClubRecruitModifyViewModel.kt
@@ -8,7 +8,7 @@ import `in`.koreatech.koin.domain.error.club.KoinClubException
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubRecruitmentUseCase
 import `in`.koreatech.koin.domain.usecase.club.ModifyClubRecruitmentUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.club.model.RecruitmentStatus
 import `in`.koreatech.koin.feature.club.model.toParcelizeClubRecruitment
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
@@ -24,7 +24,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @HiltViewModel
 class ClubRecruitModifyViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase,
+    private val uploadImageUseCase: UploadImageUseCase,
     private val getClubRecruitmentUseCase: GetClubRecruitmentUseCase,
     private val modifyClubRecruitmentUseCase: ModifyClubRecruitmentUseCase
 ) : ViewModel(), ContainerHost<ClubRecruitModifyState, ClubRecruitModifySideEffect> {
@@ -196,7 +196,7 @@ class ClubRecruitModifyViewModel @Inject constructor(
         reduce {
             state.copy(isLoading = true)
         }
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.CLUB,
             contentLength = fileSize,
             contentType = fileType,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddScreen.kt
@@ -64,7 +64,7 @@ fun ReviewAddScreen(
             val fileType = fileDetail.second
             val fileName = fileMeta.first
             val imageUri = fileMeta.second
-            viewModel.requestPresignedUrl(fileSize, fileType, fileName, imageUri)
+            viewModel.uploadPresignedUrl(fileSize, fileType, fileName, imageUri)
         },
         clearFileInfo = { viewModel.clearFileInfo() }
     )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddViewModel.kt
@@ -10,7 +10,7 @@ import `in`.koreatech.koin.core.analytics.EventExtra
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.model.store.Review
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.domain.usecase.store.WriteReviewUseCase
 import `in`.koreatech.koin.feature.store.model.StoreNavigationData
 import `in`.koreatech.koin.feature.store.model.StoreNavigationDataType
@@ -31,7 +31,7 @@ import org.orbitmvi.orbit.viewmodel.container
 class ReviewAddViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val writeReviewUseCase: WriteReviewUseCase,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
+    private val uploadImageUseCase: UploadImageUseCase
 ) : ViewModel(), ContainerHost<ReviewAddState, ReviewAddSideEffect> {
     override val container = container<ReviewAddState, ReviewAddSideEffect>(
         ReviewAddState()
@@ -99,7 +99,7 @@ class ReviewAddViewModel @Inject constructor(
     }
 
     fun uploadPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.MARKET,
             contentLength = fileSize,
             contentType = fileType,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewadd/ReviewAddViewModel.kt
@@ -9,8 +9,8 @@ import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventExtra
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.model.store.Review
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetMarketPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.domain.usecase.store.WriteReviewUseCase
 import `in`.koreatech.koin.feature.store.model.StoreNavigationData
 import `in`.koreatech.koin.feature.store.model.StoreNavigationDataType
@@ -31,8 +31,7 @@ import org.orbitmvi.orbit.viewmodel.container
 class ReviewAddViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val writeReviewUseCase: WriteReviewUseCase,
-    private val getMarketPreSignedUrlUseCase: GetMarketPreSignedUrlUseCase,
-    private val uploadFileUseCase: UploadFileUseCase
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
 ) : ViewModel(), ContainerHost<ReviewAddState, ReviewAddSideEffect> {
     override val container = container<ReviewAddState, ReviewAddSideEffect>(
         ReviewAddState()
@@ -99,19 +98,17 @@ class ReviewAddViewModel @Inject constructor(
         }
     }
 
-    fun requestPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
-        getMarketPreSignedUrlUseCase(fileSize, fileType, fileName).onSuccess { (fileUrl, presignedUrl) ->
-            uploadFile(presignedUrl, fileType, fileSize, imageUri, fileUrl)
-        }.onFailure {
-            postSideEffect(ReviewAddSideEffect.ShowImageUploadFailed)
-        }
-    }
-
-    private fun uploadFile(presignedUrl: String, mediaType: String, mediaSize: Long, imageUri: String, fileUrl: String) = intent {
-        uploadFileUseCase(presignedUrl, mediaType, mediaSize, imageUri).onSuccess {
+    fun uploadPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.MARKET,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri
+        ).onSuccess {
             reduce {
                 state.copy(
-                    imageUris = (state.imageUris + fileUrl).toImmutableList()
+                    imageUris = (state.imageUris + it).toImmutableList()
                 )
             }
         }.onFailure {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.core.toast.ToastUtil
 import `in`.koreatech.koin.feature.store.R
@@ -75,7 +74,7 @@ fun ReviewEditScreen(
             val fileType = fileDetail.second
             val fileName = fileMeta.first
             val imageUri = fileMeta.second
-            viewModel.requestPresignedUrl(fileSize, fileType, fileName, imageUri)
+            viewModel.uploadPresignedUrl(fileSize, fileType, fileName, imageUri)
         },
         clearFileInfo = { viewModel.clearFileInfo() }
     )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditViewModel.kt
@@ -6,8 +6,8 @@ import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.store.Review
 import `in`.koreatech.koin.domain.model.store.ReviewDetail
-import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
-import `in`.koreatech.koin.domain.usecase.presignedurl.GetMarketPreSignedUrlUseCase
+import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
 import `in`.koreatech.koin.domain.usecase.store.ModifyReviewUseCase
 import `in`.koreatech.koin.domain.usecase.store.SearchReviewUseCase
 import `in`.koreatech.koin.feature.store.model.StoreNavigationData
@@ -30,8 +30,7 @@ class ReviewEditViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val searchReviewUseCase: SearchReviewUseCase,
     private val modifyReviewUseCase: ModifyReviewUseCase,
-    private val getMarketPreSignedUrlUseCase: GetMarketPreSignedUrlUseCase,
-    private val uploadFileUseCase: UploadFileUseCase
+    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
 ) : ViewModel(), ContainerHost<ReviewEditState, ReviewEditSideEffect> {
     override val container = container<ReviewEditState, ReviewEditSideEffect>(
         ReviewEditState()
@@ -117,19 +116,17 @@ class ReviewEditViewModel @Inject constructor(
         }
     }
 
-    fun requestPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
-        getMarketPreSignedUrlUseCase(fileSize, fileType, fileName).onSuccess { (fileUrl, presignedUrl) ->
-            uploadFile(presignedUrl, fileType, fileSize, imageUri, fileUrl)
-        }.onFailure {
-            postSideEffect(ReviewEditSideEffect.ShowImageUploadFailed)
-        }
-    }
-
-    private fun uploadFile(presignedUrl: String, mediaType: String, mediaSize: Long, imageUri: String, fileUrl: String) = intent {
-        uploadFileUseCase(presignedUrl, mediaType, mediaSize, imageUri).onSuccess {
+    fun uploadPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
+        uploadPreSignedUrlV2UseCase(
+            domain = PreSignedUrlDomain.MARKET,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri
+        ).onSuccess {
             reduce {
                 state.copy(
-                    imageUris = (state.imageUris + fileUrl).toImmutableList()
+                    imageUris = (state.imageUris + it).toImmutableList()
                 )
             }
         }.onFailure {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewedit/ReviewEditViewModel.kt
@@ -7,7 +7,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.store.Review
 import `in`.koreatech.koin.domain.model.store.ReviewDetail
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
-import `in`.koreatech.koin.domain.usecase.presignedurl.UploadPreSignedUrlV2UseCase
+import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.domain.usecase.store.ModifyReviewUseCase
 import `in`.koreatech.koin.domain.usecase.store.SearchReviewUseCase
 import `in`.koreatech.koin.feature.store.model.StoreNavigationData
@@ -30,7 +30,7 @@ class ReviewEditViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val searchReviewUseCase: SearchReviewUseCase,
     private val modifyReviewUseCase: ModifyReviewUseCase,
-    private val uploadPreSignedUrlV2UseCase: UploadPreSignedUrlV2UseCase
+    private val uploadImageUseCase: UploadImageUseCase
 ) : ViewModel(), ContainerHost<ReviewEditState, ReviewEditSideEffect> {
     override val container = container<ReviewEditState, ReviewEditSideEffect>(
         ReviewEditState()
@@ -117,7 +117,7 @@ class ReviewEditViewModel @Inject constructor(
     }
 
     fun uploadPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
-        uploadPreSignedUrlV2UseCase(
+        uploadImageUseCase(
             domain = PreSignedUrlDomain.MARKET,
             contentLength = fileSize,
             contentType = fileType,


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1229 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
기존의 Presigned Url 업로드는 아래와 같은 과정을 통해 이루어졌습니다.
1. viewmodel에서 file size, type을 이용하여 API 호출 후, presigned url과 file url 획득
2. 다시 viewmodel에서 presigned url로 이미지 업로드 후 file url 최종 반환

이 과정에서 두개의 usecase를 호출하였으며, presigned url을 viewmodel에서 받아서 다시 usecase 호출 시 parameter로 넘겨주는 방식으로 작동했습니다.

코드로 설명하자면, 이전에는 다음과 같은 코드로 Presigned url을 활용한 이미지 업로드를 처리했습니다.

```
fun requestPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
    getMarketPreSignedUrlUseCase(fileSize, fileType, fileName).onSuccess { (fileUrl, presignedUrl) ->
        uploadFile(presignedUrl, fileType, fileSize, imageUri, fileUrl)
    }.onFailure {
        // 에러 처리
    }
}

private fun uploadFile(presignedUrl: String, mediaType: String, mediaSize: Long, imageUri: String, fileUrl: String) = intent {
    uploadFileUseCase(presignedUrl, mediaType, mediaSize, imageUri).onSuccess {
        // 업로드 성공
    }.onFailure {
        // 에러 처리
    }
}
```

`requestPresignedUrl()` 함수에서 presigned url 을 획득한 후, `uploadFile()` 함수에서 실제 업로드를 진행했습니다.

이에 따라 불필요하게 에러 처리를 두번 수행해야 했으며, viewmodel에서 presigned url을 굳이 알 필요가 없음에도 알게 된다는 문제점이 있었습니다.

또한, presigned url을 usecase를 통해 획득하고 실제 업로드가 진행되지 않을 경우, 이미지가 업로드 되지 않고 빈 file url만 남을 수 있는 문제가 있었습니다.

따라서, 하나의 usecase를 호출하여 이미지를 처리할 수 있도록 수정했습니다.

수정된 usecase를 활용한 이미지 업로드는 다음과 같습니다.

```
fun uploadPresignedUrl(fileSize: Long, fileType: String, fileName: String, imageUri: String) = intent {
    uploadImageUseCase(
        domain = PreSignedUrlDomain.MARKET,
        contentLength = fileSize,
        contentType = fileType,
        fileName = fileName,
        imageUri = imageUri
    ).onSuccess {
        // 업로드 성공
    }.onFailure {
        // 에러 처리
    }
}
```

새로운 usecase에서는 중복 에러 처리 문제를 수정하였으며, 하나의 usecase만으로 이미지 업로드를 처리할 수 있습니다.
또한, 기존에 도메인 별로 분리되어 있던 이미지 업로드 usecase를 하나로 통합하였으며, viewmodel에서 usecase 호출 시 어느 도메인인지 선언하도록 수정하였습니다.

추가로, 동아리와 상점 리뷰 화면에서 해당 usecase를 사용하도록 리팩토링 하였습니다.

### 논의 사항
- 해당 리팩토링을 제외한 로직은 일부러 건드리지 않았습니다.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다