### PR TITLE
[Campus][Feature] 분실물 글 작성 로그인 다이얼로그 추가

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -17,12 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import `in`.koreatech.koin.core.designsystem.component.dialog.ChoiceDialog
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
@@ -30,6 +27,7 @@ import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundFilterType.Aut
 import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.ItemSearchTextField
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.ListColumn
+import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LoginDialog
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundChip
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFAB
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFABBottomSheet
@@ -58,7 +56,7 @@ fun LostAndFoundList(
             selectedFoundType = uiState.foundFilterType,
             onApply = { first, second, third, fourth ->
                 if (!uiState.isLoggedIn && first == MY) {
-                    viewModel.setShowLoginDialog(true)
+                    viewModel.setShowFilterLoginDialog(true)
                 } else {
                     viewModel.setSearchFilter(
                         authorFilterType = first,
@@ -86,21 +84,31 @@ fun LostAndFoundList(
         )
     }
 
-    if (uiState.showLoginDialog) {
-        ChoiceDialog(
+    if (uiState.showFilterLoginDialog) {
+        LoginDialog(
             title = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in),
             description = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in_description),
-            positiveButtonText = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in_positive),
-            negativeButtonText = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in_negative),
             onPositive = {
                 navigateToLogin()
-                viewModel.setShowLoginDialog(false)
+                viewModel.setShowFilterLoginDialog(false)
             },
             onNegative = {
-                viewModel.setShowLoginDialog(false)
+                viewModel.setShowFilterLoginDialog(false)
+            }
+        )
+    }
+
+    if (uiState.showWriteLoginDialog) {
+        LoginDialog(
+            title = stringResource(id = R.string.request_login_dialog_title),
+            description = stringResource(id = R.string.request_login_dialog_description),
+            onPositive = {
+                navigateToLogin()
+                viewModel.setShowWriteLoginDialog(false)
             },
-            titleStyle = KoinTheme.typography.medium18.copy(color = KoinTheme.colors.neutral600, textAlign = TextAlign.Center),
-            descriptionStyle = KoinTheme.typography.regular14.copy(color = Color(0xFF8E8E8E))
+            onNegative = {
+                viewModel.setShowWriteLoginDialog(false)
+            }
         )
     }
 
@@ -115,7 +123,11 @@ fun LostAndFoundList(
         floatingActionButton = {
             LostAndFoundFAB(
                 onClick = {
-                    viewModel.setShowWriteBottomSheet(true)
+                    if (uiState.isLoggedIn) {
+                        viewModel.setShowWriteBottomSheet(true)
+                    } else {
+                        viewModel.setShowWriteLoginDialog(true)
+                    }
                 }
             )
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
@@ -12,7 +12,8 @@ import kotlinx.parcelize.Parcelize
 data class LostAndFoundListState(
     val isLoading: Boolean = false,
     val isLoggedIn: Boolean = false,
-    val showLoginDialog: Boolean = false,
+    val showFilterLoginDialog: Boolean = false,
+    val showWriteLoginDialog: Boolean = false,
     val isFirstPageLoading: Boolean = false,
     val showFilterBottomSheet: Boolean = false,
     val showWriteBottomSheet: Boolean = false,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -198,10 +198,18 @@ class LostAndFoundListViewModel @Inject constructor(
         }
     }
 
-    fun setShowLoginDialog(show: Boolean) = intent {
+    fun setShowFilterLoginDialog(show: Boolean) = intent {
         reduce {
             state.copy(
-                showLoginDialog = show
+                showFilterLoginDialog = show
+            )
+        }
+    }
+
+    fun setShowWriteLoginDialog(show: Boolean) = intent {
+        reduce {
+            state.copy(
+                showWriteLoginDialog = show
             )
         }
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/LoginDialog.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/LoginDialog.kt
@@ -1,0 +1,31 @@
+package `in`.koreatech.koin.feature.lostandfound.ui.list.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import `in`.koreatech.koin.core.designsystem.component.dialog.ChoiceDialog
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.feature.lostandfound.R
+
+@Composable
+fun LoginDialog(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+    onPositive: () -> Unit = {},
+    onNegative: () -> Unit = {}
+) {
+    ChoiceDialog(
+        modifier = modifier,
+        title = title,
+        description = description,
+        positiveButtonText = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in_positive),
+        negativeButtonText = stringResource(id = R.string.lost_and_found_my_filter_can_use_logged_in_negative),
+        onPositive = onPositive,
+        onNegative = onNegative,
+        titleStyle = KoinTheme.typography.medium18.copy(color = KoinTheme.colors.neutral600, textAlign = TextAlign.Center),
+        descriptionStyle = KoinTheme.typography.regular14.copy(color = Color(0xFF8E8E8E))
+    )
+}


### PR DESCRIPTION
## PR 개요
이슈 번호:

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
분실물 글 작성 시에 로그인 여부와 다이얼로그를 띄우도록 수정했습니다.
기존 `showLoginDialog` 상태를 `showFilterLoginDialog`, `showWriteLoginDialog` 의 두 상태로 나누었습니다.
그에 따라 중복되는 코드를 줄이기 위해 `LoginDialog` 라는 공통 component 를 만들어 사용했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다