### PR TITLE
[Campus][Feature] 분실물 QA 수정 1차

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -75,15 +75,6 @@ interface ArticleApi {
     ): ArticleLostAndFoundPaginationResponse
 
     /**
-     * 분실물 게시글 조회
-     * @param id 게시글 아이디
-     */
-    @GET("articles/lost-item/v2/{id}")
-    suspend fun fetchArticleLostAndFoundV2(
-        @Path("id") id: Int
-    ): ArticleLostAndFoundResponse
-
-    /**
      * 분실물 게시글 통계 조회
      */
     @GET("articles/lost-item/stats")

--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.data.api
 
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationResponse
-import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundResponse
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundStatsResponse
 import `in`.koreatech.koin.data.response.article.ArticlePaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleResponse

--- a/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
@@ -77,7 +77,7 @@ interface ArticleAuthApi {
         @Query("type") type: String?,
         @Query("page") page: Int,
         @Query("limit") limit: Int,
-        @Query("category") category: String?,
+        @Query("category") category: List<String>,
         @Query("foundStatus") foundStatus: String?,
         @Query("sort") sort: String?,
         @Query("author") author: String?,

--- a/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
@@ -83,4 +83,13 @@ interface ArticleAuthApi {
         @Query("author") author: String?,
         @Query("title") title: String?
     ): ArticleLostAndFoundPaginationResponse
+
+    /**
+     * 분실물 게시글 조회
+     * @param id 게시글 아이디
+     */
+    @GET("articles/lost-item/v2/{id}")
+    suspend fun fetchArticleLostAndFoundV2(
+        @Path("id") id: Int
+    ): ArticleLostAndFoundResponse
 }

--- a/data/src/main/java/in/koreatech/koin/data/mapper/ArticleMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/ArticleMapper.kt
@@ -12,7 +12,7 @@ fun List<ArticleLostAndFoundUpload>.toArticleLostAndFoundRequest(): ArticleLostA
 fun ArticleLostAndFoundUpload.toArticleLostAndFoundBody(): ArticleLostAndFoundRequest.ArticleLostAndFoundBody {
     return ArticleLostAndFoundRequest.ArticleLostAndFoundBody(
         category = category,
-        foundPlace = foundPlace,
+        foundPlace = foundPlace.ifEmpty { "장소 미상" },
         foundDate = foundDate,
         content = content,
         images = images,

--- a/data/src/main/java/in/koreatech/koin/data/response/article/ArticleLostAndFoundResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/article/ArticleLostAndFoundResponse.kt
@@ -77,7 +77,7 @@ data class ArticleLostAndFoundResponse(
             content = content,
             author = author,
             organization = organization?.toArticleLostAndFoundOrganization(),
-            isMine = isMine!!, // Should not be null
+            isMine = isMine ?: false, // Should not be null
             isFound = isFound,
             images = images?.map { it.toArticleLostAndFoundImage() },
             registeredAt = registeredAt,

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -85,7 +85,7 @@ class ArticleRemoteDataSource @Inject constructor(
         type: String?,
         page: Int,
         limit: Int,
-        category: String?,
+        category: List<String>,
         foundStatus: String?,
         sort: String?,
         author: String?,

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -112,7 +112,7 @@ class ArticleRemoteDataSource @Inject constructor(
     }
 
     suspend fun fetchArticleLostAndFoundV2(articleId: Int): ArticleLostAndFoundResponse {
-        return articleApi.fetchArticleLostAndFoundV2(articleId)
+        return articleAuthApi.fetchArticleLostAndFoundV2(articleId)
     }
 
     suspend fun uploadArticleLostAndFound(articleLostAndFound: List<ArticleLostAndFoundUpload>): Result<ArticleLostAndFoundResponse> {

--- a/domain/src/main/java/in/koreatech/koin/domain/model/article/LostAndFoundFilterParams.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/article/LostAndFoundFilterParams.kt
@@ -4,7 +4,7 @@ data class LostAndFoundFilterParams(
     val type: String? = null,
     val page: Int = 1,
     val limit: Int = 10,
-    val category: String = "ALL",
+    val category: List<String> = emptyList(),
     val foundStatus: String = "ALL",
     val sort: String = "LATEST",
     val author: String = "ALL",

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
@@ -336,14 +336,14 @@ fun EditArticleItemDetail(
         Text(
             style = KoinTheme.typography.medium14,
             text = buildAnnotatedString {
-                append(
-                    when (type) {
-                        LostOrFoundType.LOST -> stringResource(id = R.string.lost_location)
-                        LostOrFoundType.FOUND -> stringResource(id = R.string.found_location)
+                when (type) {
+                    LostOrFoundType.LOST -> append(stringResource(id = R.string.lost_location))
+                    LostOrFoundType.FOUND -> {
+                        append(stringResource(id = R.string.found_location))
+                        withStyle(style = SpanStyle(color = Color(0xFFC82A2A))) {
+                            append("*")
+                        }
                     }
-                )
-                withStyle(style = SpanStyle(color = Color(0xFFC82A2A))) {
-                    append("*")
                 }
             }
         )

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
@@ -325,7 +325,7 @@ fun EditArticleItemDetail(
                         )
                     }
                 }
-                HorizontalDivider(color = KoinTheme.colors.neutral300, thickness = 1.dp)
+                HorizontalDivider(color = KoinTheme.colors.neutral300)
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -339,7 +339,7 @@ fun EditArticleItemDetail(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "초기화",
+                            text = stringResource(id = R.string.date_reset),
                             style = KoinTheme.typography.medium14,
                             color = KoinTheme.colors.primary600,
                             modifier = Modifier
@@ -354,7 +354,7 @@ fun EditArticleItemDetail(
                             modifier = Modifier.width(24.dp)
                         )
                         Text(
-                            text = "확인",
+                            text = stringResource(id = R.string.date_confirm),
                             style = KoinTheme.typography.medium14,
                             color = KoinTheme.colors.primary600,
                             modifier = Modifier

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
@@ -345,7 +345,7 @@ fun EditArticleItemDetail(
                             modifier = Modifier
                                 .clickable {
                                     yearPickerState.selectedItemIndex = yearList.indexOf(now.year.toString())
-                                    monthPickerState.selectedItemIndex =monthList.indexOf(now.month.toString())
+                                    monthPickerState.selectedItemIndex = monthList.indexOf(now.month.toString())
                                     dayPickerState.selectedItemIndex = dayList.indexOf(now.dayOfMonth.toString())
                                 }
                                 .padding(all = 4.dp)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/EditArticleItemDetail.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.feature.lostandfound.component
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,7 +14,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -319,6 +322,46 @@ fun EditArticleItemDetail(
                             KoinTheme.typography.medium16.copy(
                                 textAlign = TextAlign.Center
                             )
+                        )
+                    }
+                }
+                HorizontalDivider(color = KoinTheme.colors.neutral300, thickness = 1.dp)
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(color = KoinTheme.colors.neutral100)
+                ) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 2.dp, horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "초기화",
+                            style = KoinTheme.typography.medium14,
+                            color = KoinTheme.colors.primary600,
+                            modifier = Modifier
+                                .clickable {
+                                    yearPickerState.selectedItemIndex = yearList.indexOf(now.year.toString())
+                                    monthPickerState.selectedItemIndex =monthList.indexOf(now.month.toString())
+                                    dayPickerState.selectedItemIndex = dayList.indexOf(now.dayOfMonth.toString())
+                                }
+                                .padding(all = 4.dp)
+                        )
+                        Spacer(
+                            modifier = Modifier.width(24.dp)
+                        )
+                        Text(
+                            text = "확인",
+                            style = KoinTheme.typography.medium14,
+                            color = KoinTheme.colors.primary600,
+                            modifier = Modifier
+                                .clickable {
+                                    isPickerExpanded = false
+                                }
+                                .padding(all = 4.dp)
                         )
                     }
                 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostItemTypeChip.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostItemTypeChip.kt
@@ -67,6 +67,6 @@ fun ReadOnlyTextChip(
 @Composable
 private fun LostItemTypeChipPreview() {
     KoinTheme {
-        LostItemTypeChip(category = LostItemCategory.OTHER)
+        LostItemTypeChip(category = LostItemCategory.NONE)
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostItemTypeChip.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostItemTypeChip.kt
@@ -67,6 +67,6 @@ fun ReadOnlyTextChip(
 @Composable
 private fun LostItemTypeChipPreview() {
     KoinTheme {
-        LostItemTypeChip(category = LostItemCategory.NONE)
+        LostItemTypeChip(category = LostItemCategory.OTHER)
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/SlideUpText.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/SlideUpText.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import kotlinx.collections.immutable.ImmutableList
@@ -44,6 +45,7 @@ fun SlideUpText(
 
     AnimatedContent(
         targetState = text.value,
+        contentAlignment = Alignment.Center,
         transitionSpec = {
             slideInVertically { height -> height } + fadeIn() togetherWith
                 slideOutVertically { height -> -height } + fadeOut()
@@ -52,6 +54,7 @@ fun SlideUpText(
         Text(
             modifier = modifier,
             text = showedText,
+            maxLines = 1,
             style = style
         )
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/enums/LostItemCategory.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/enums/LostItemCategory.kt
@@ -23,7 +23,7 @@ enum class LostItemCategory(
                 "지갑" -> WALLET
                 "전자제품" -> ELECTRONIC_DEVICE
                 "기타" -> OTHER
-                else -> NONE
+                else -> OTHER
             }
         }
 
@@ -34,7 +34,7 @@ enum class LostItemCategory(
                 WALLET -> "지갑"
                 ELECTRONIC_DEVICE -> "전자제품"
                 OTHER -> "기타"
-                NONE -> ""
+                NONE -> "기타"
             }
         }
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
@@ -21,5 +21,5 @@ sealed class LostAndFoundNavType {
 
 const val ARTICLE_ID = "articleId"
 const val CHAT_ARTICLE_ID = "article_id"
-
 const val LOST_OR_FOUND_TYPE = "lostOrFoundType"
+const val REFRESH_LIST = "refresh_list"

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
@@ -22,4 +22,4 @@ sealed class LostAndFoundNavType {
 const val ARTICLE_ID = "articleId"
 const val CHAT_ARTICLE_ID = "article_id"
 const val LOST_OR_FOUND_TYPE = "lostOrFoundType"
-const val REFRESH_LIST = "refresh_list"
+const val CANCEL_REFRESH_LIST = "cancel_refresh_list"

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -54,6 +54,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             if (backStackEntry.savedStateHandle.contains(CANCEL_REFRESH_LIST)) {
                 isCancelRefresh = backStackEntry.savedStateHandle[CANCEL_REFRESH_LIST] ?: false
             }
+            backStackEntry.savedStateHandle.remove<Boolean>(CANCEL_REFRESH_LIST)
         }
         val navigator = rememberNavigator()
         val context = LocalContext.current

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -91,9 +91,12 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             articleId = route.articleId,
             onTopbarBackClick = onBackPressed,
             onSuccess = {
+                navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
+                    ?.savedStateHandle
+                    ?.set(REFRESH_LIST, true)
                 navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
                     popUpTo(navController.graph.startDestinationId) {
-                        inclusive = true
+                        inclusive = false
                     }
                     launchSingleTop = true
                 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -19,7 +19,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     onBackPressed: () -> Unit
 ) {
     composable<LostAndFoundNavType.LostAndFoundListRoute> { backStackEntry ->
-        val refreshFlow = backStackEntry.savedStateHandle.getStateFlow("refresh_list", false).collectAsStateWithLifecycle()
+        val refreshFlow = backStackEntry.savedStateHandle.getStateFlow(REFRESH_LIST, false).collectAsStateWithLifecycle()
         val navigator = rememberNavigator()
         val context = LocalContext.current
         LostAndFoundList(
@@ -49,7 +49,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             refreshLostAndFoundList = {
                 navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
                     ?.savedStateHandle
-                    ?.set("refresh_list", true)
+                    ?.set(REFRESH_LIST, true)
             },
             navigateToArticleList = {
                 navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -30,7 +30,6 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
                     handle[CANCEL_REFRESH_LIST] = cancelRefresh
                 }
             }
-
     }
 
     val navigateToList = { cancelRefresh: Boolean ->

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -84,9 +84,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         LostAndFoundDetail(
             navigateToArticleList = navigateToList,
             onTopbarBackClick = onBackPressed,
-            refreshList = {
-                cancelRefreshList(false)
-            },
+            refreshList = { cancelRefreshList(false) },
             navigateToChatRoom = { articleId ->
                 val intent = navigator.navigateToChatRoom(context)
                 intent.putExtra(CHAT_ARTICLE_ID, articleId)
@@ -117,17 +115,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         LostAndFoundReport(
             articleId = route.articleId,
             onTopbarBackClick = onBackPressed,
-            onSuccess = {
-                navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
-                    ?.savedStateHandle
-                    ?.set(REFRESH_LIST, true)
-                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        inclusive = false
-                    }
-                    launchSingleTop = true
-                }
-            }
+            onSuccess = { navigateToList(false) }
         )
     }
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -1,7 +1,11 @@
 package `in`.koreatech.koin.feature.lostandfound.navigation
 
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -18,12 +22,44 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     navController: NavController,
     onBackPressed: () -> Unit
 ) {
+    val cancelRefreshList = { cancelRefresh: Boolean ->
+        navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
+            ?.savedStateHandle
+            ?.let { handle ->
+                if (handle.get<Boolean>(CANCEL_REFRESH_LIST) != false) {
+                    handle[CANCEL_REFRESH_LIST] = cancelRefresh
+                }
+            }
+
+    }
+
+    val navigateToList = { cancelRefresh: Boolean ->
+        cancelRefreshList(cancelRefresh)
+        navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
+            popUpTo(navController.graph.startDestinationId) {
+                inclusive = false
+            }
+            launchSingleTop = true
+        }
+    }
+
+    val onBackPressed = {
+        cancelRefreshList(true)
+        onBackPressed()
+    }
+
     composable<LostAndFoundNavType.LostAndFoundListRoute> { backStackEntry ->
-        val refreshFlow = backStackEntry.savedStateHandle.getStateFlow(REFRESH_LIST, false).collectAsStateWithLifecycle()
+        var isCancelRefresh by remember { mutableStateOf(false) }
+
+        LaunchedEffect(Unit) {
+            if (backStackEntry.savedStateHandle.contains(CANCEL_REFRESH_LIST)) {
+                isCancelRefresh = backStackEntry.savedStateHandle[CANCEL_REFRESH_LIST] ?: false
+            }
+        }
         val navigator = rememberNavigator()
         val context = LocalContext.current
         LostAndFoundList(
-            doRefresh = refreshFlow.value,
+            cancelRefresh = isCancelRefresh,
             onTopbarBackClick = onBackPressed,
             navigateArticleDetail = { articleId ->
                 navController.navigate(LostAndFoundNavType.LostAndFoundDetailRoute(articleId))
@@ -46,20 +82,11 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val navigator = rememberNavigator()
         val context = LocalContext.current
         LostAndFoundDetail(
-            refreshLostAndFoundList = {
-                navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
-                    ?.savedStateHandle
-                    ?.set(REFRESH_LIST, true)
-            },
-            navigateToArticleList = {
-                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        inclusive = false
-                    }
-                    launchSingleTop = true
-                }
-            },
+            navigateToArticleList = navigateToList,
             onTopbarBackClick = onBackPressed,
+            refreshList = {
+                cancelRefreshList(false)
+            },
             navigateToChatRoom = { articleId ->
                 val intent = navigator.navigateToChatRoom(context)
                 intent.putExtra(CHAT_ARTICLE_ID, articleId)
@@ -96,14 +123,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     composable<LostAndFoundNavType.LostAndFoundWriteRoute> {
         LostAndFoundWriteArticle(
             onBackClick = onBackPressed,
-            onComplete = {
-                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
-                    popUpTo(navController.graph.startDestinationId) {
-                        inclusive = true
-                    }
-                    launchSingleTop = true
-                }
-            }
+            onComplete = { navigateToList(false) }
         )
     }
 
@@ -111,11 +131,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         LostAndFoundModify(
             onBackClick = onBackPressed,
             onComplete = { articleId ->
-                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
-                    popUpTo<LostAndFoundNavType.LostAndFoundDetailRoute> {
-                        inclusive = true
-                    }
-                }
+                navigateToList(false)
                 navController.navigate(LostAndFoundNavType.LostAndFoundDetailRoute(articleId))
             }
         )

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -89,7 +89,14 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundDetailRoute>()
         LostAndFoundReport(
             articleId = route.articleId,
-            onSuccess = { navController.navigateUp() }
+            onSuccess = {
+                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
+            }
         )
     }
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -89,6 +89,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundDetailRoute>()
         LostAndFoundReport(
             articleId = route.articleId,
+            onTopbarBackClick = onBackPressed,
             onSuccess = {
                 navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
                     popUpTo(navController.graph.startDestinationId) {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -193,9 +193,7 @@ fun LostAndFoundDetail(
                             isLoggedIn = uiState.isLoggedIn,
                             isAuthorWithdraw = uiState.isAuthorWithdraw,
                             isWriterAdmin = uiState.organization != null,
-                            onArticleListClick = {
-                                navigateToArticleList
-                            },
+                            onArticleListClick = navigateToArticleList,
                             onDeleteArticleClick = {
                                 viewModel.deleteArticle()
                             },

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -137,6 +137,14 @@ fun LostAndFoundDetail(
             val enableRecentArticleHeight = remember(layoutHeightDp.value) {
                 mutableStateOf(screenHeightDp - (contentPadding.calculateTopPadding() + contentPadding.calculateBottomPadding()) - layoutHeightDp.value)
             }
+
+            val itemHeightDp = 48.dp
+            val headerHeight = 54.dp
+            val finalRecentArticleHeight = remember(enableRecentArticleHeight.value) {
+                val availableHeight = enableRecentArticleHeight.value - headerHeight
+                val visibleItemCount = (availableHeight / itemHeightDp).toInt()
+                headerHeight + (itemHeightDp * (visibleItemCount + 0.65f))
+            }
             Layout(
                 content = {
                     Column {
@@ -238,8 +246,8 @@ fun LostAndFoundDetail(
 
             RecentArticleList(
                 modifier = Modifier
-                    .heightIn(min = 300.dp, max = screenHeightDp)
-                    .height(enableRecentArticleHeight.value),
+                    .heightIn(min = 275.dp, max = screenHeightDp)
+                    .height(finalRecentArticleHeight),
                 recentArticles = recentArticles,
                 isLoadingMore = uiState.isLoadingMoreArticles,
                 hasMoreArticles = uiState.hasMoreArticles,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetail.kt
@@ -50,9 +50,9 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun LostAndFoundDetail(
     viewModel: LostAndFoundDetailViewModel = hiltViewModel(),
     modifier: Modifier = Modifier,
-    navigateToArticleList: () -> Unit = {},
     onTopbarBackClick: () -> Unit = {},
-    refreshLostAndFoundList: () -> Unit = {},
+    refreshList: () -> Unit = {},
+    navigateToArticleList: (cancelRefresh: Boolean) -> Unit = {},
     navigateToRecentArticle: (articleId: Int) -> Unit = {},
     navigateToChatRoom: (articleId: Int) -> Unit = {},
     navigateToLogin: (articleId: Int) -> Unit = {},
@@ -64,7 +64,9 @@ fun LostAndFoundDetail(
         topBar = {
             KoinTopAppBar(
                 title = stringResource(R.string.lost_and_found),
-                onNavigationIconClick = onTopbarBackClick
+                onNavigationIconClick = {
+                    onTopbarBackClick()
+                }
             )
         }
     ) { contentPadding ->
@@ -84,8 +86,8 @@ fun LostAndFoundDetail(
                         loggingLostOrFound
                     )
                     viewModel.setFound()
+                    refreshList()
                     viewModel.setShowFoundDialog(false)
-                    refreshLostAndFoundList()
                 },
                 onNegative = {
                     viewModel.setShowFoundDialog(false)
@@ -121,7 +123,7 @@ fun LostAndFoundDetail(
         }
 
         viewModel.collectSideEffect {
-            handleSideEffect(it, context, navigateToArticleList, refreshLostAndFoundList)
+            handleSideEffect(it, context, navigateToArticleList)
         }
 
         Column(
@@ -201,7 +203,9 @@ fun LostAndFoundDetail(
                             isLoggedIn = uiState.isLoggedIn,
                             isAuthorWithdraw = uiState.isAuthorWithdraw,
                             isWriterAdmin = uiState.organization != null,
-                            onArticleListClick = navigateToArticleList,
+                            onArticleListClick = {
+                                navigateToArticleList(true)
+                            },
                             onDeleteArticleClick = {
                                 viewModel.deleteArticle()
                             },
@@ -269,8 +273,7 @@ fun LostAndFoundDetail(
 private fun handleSideEffect(
     sideEffect: LostAndFoundDetailSideEffect,
     context: Context,
-    navigateToArticleList: () -> Unit = {},
-    refreshLostAndFoundList: () -> Unit = {}
+    navigateToArticleList: (cancelRefresh: Boolean) -> Unit = {}
 ) {
     when (sideEffect) {
         is LostAndFoundDetailSideEffect.DeleteArticle -> {
@@ -279,8 +282,7 @@ private fun handleSideEffect(
                 context.getString(R.string.detail_delete_toast),
                 Toast.LENGTH_SHORT
             ).show()
-            refreshLostAndFoundList()
-            navigateToArticleList()
+            navigateToArticleList(false)
         }
 
         LostAndFoundDetailSideEffect.DeleteArticleFailed -> {
@@ -297,8 +299,7 @@ private fun handleSideEffect(
                 context.getString(R.string.detail_deleted_article),
                 Toast.LENGTH_SHORT
             ).show()
-            refreshLostAndFoundList()
-            navigateToArticleList()
+            navigateToArticleList(true)
         }
 
         LostAndFoundDetailSideEffect.UpdateFoundFail -> {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
@@ -13,7 +13,6 @@ import kotlinx.parcelize.Parcelize
 data class LostAndFoundDetailState(
     val isLoading: Boolean = false,
     val isLoggedIn: Boolean = false,
-    val currentLoggedInUser: String = "",
     val showDeleteDialog: Boolean = false,
     val showFoundDialog: Boolean = false,
     val showLoginDialog: Boolean = false,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -54,16 +54,12 @@ class LostAndFoundDetailViewModel @Inject constructor(
                 when (it) {
                     is User.Student -> reduce {
                         state.copy(
-                            isLoggedIn = true,
-                            currentLoggedInUser = it.nickname ?: "",
-                            isMine = it.nickname == state.author
+                            isLoggedIn = true
                         )
                     }
                     is User.General -> reduce {
                         state.copy(
-                            isLoggedIn = true,
-                            currentLoggedInUser = it.nickname ?: "",
-                            isMine = it.nickname == state.author
+                            isLoggedIn = true
                         )
                     }
                     is User.Anonymous -> reduce {
@@ -100,7 +96,7 @@ class LostAndFoundDetailViewModel @Inject constructor(
                     registeredAt = article.registeredAt,
                     updatedAt = article.updatedAt,
                     organization = article.organization,
-                    isMine = state.currentLoggedInUser == article.author,
+                    isMine = article.isMine,
                     isAuthorWithdraw = article.author == "탈퇴한 사용자",
                     isLoading = false,
                     isFound = article.isFound

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -167,7 +167,10 @@ fun LostAndFoundList(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp),
+                    .padding(
+                        horizontal = 24.dp,
+                        vertical = 4.dp
+                    ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 ItemSearchTextField(

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -58,7 +58,7 @@ fun LostAndFoundList(
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
             .collect {
-                if(cancelRefresh) {
+                if (cancelRefresh) {
                     cancelRefresh = false
                 } else {
                     viewModel.fetchLostAndFoundItem()

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -145,6 +146,7 @@ fun LostAndFoundList(
         },
         floatingActionButton = {
             LostAndFoundFAB(
+                modifier = Modifier.offset(y = 10.dp),
                 onClick = {
                     if (uiState.isLoggedIn) {
                         viewModel.setShowWriteBottomSheet(true)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -16,8 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,11 +37,13 @@ import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFA
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFABBottomSheet
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFilterBottomSheet
 import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import org.orbitmvi.orbit.compose.collectAsState
 
 @Composable
 fun LostAndFoundList(
-    doRefresh: Boolean,
+    cancelRefresh: Boolean,
     viewModel: LostAndFoundListViewModel = hiltViewModel(),
     onTopbarBackClick: () -> Unit = {},
     navigateToLogin: () -> Unit = {},
@@ -51,13 +52,18 @@ fun LostAndFoundList(
 ) {
     val uiState by viewModel.collectAsState()
 
-    val refresh = remember(doRefresh) { mutableStateOf(doRefresh) }
-
-    LaunchedEffect(refresh) {
-        if (doRefresh) {
-            viewModel.fetchLostAndFoundItem()
-            refresh.value = false
-        }
+    LaunchedEffect(Unit, cancelRefresh) {
+        var cancelRefresh = cancelRefresh
+        snapshotFlow { uiState.searchQuery }
+            .debounce(SEARCH_DEBOUNCE_MS)
+            .distinctUntilChanged()
+            .collect {
+                if(cancelRefresh) {
+                    cancelRefresh = false
+                } else {
+                    viewModel.fetchLostAndFoundItem()
+                }
+            }
     }
 
     if (uiState.showFilterBottomSheet) {
@@ -220,3 +226,5 @@ fun LostAndFoundList(
         }
     }
 }
+
+const val SEARCH_DEBOUNCE_MS = 250L

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
@@ -20,7 +20,7 @@ data class LostAndFoundListState(
     val showFilterBottomSheet: Boolean = false,
     val showWriteBottomSheet: Boolean = false,
     val searchQuery: String = "",
-    val categoryFilterType: CategoryFilterType = CategoryFilterType.ALL,
+    val categoryFilterType: ImmutableList<CategoryFilterType> = persistentListOf(CategoryFilterType.ALL),
     val lostOrFoundFilterType: LostOrFoundFilterType = LostOrFoundFilterType.ALL,
     val foundFilterType: FoundFilterType = FoundFilterType.ALL,
     val authorFilterType: AuthorFilterType = AuthorFilterType.ALL,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListState.kt
@@ -16,7 +16,7 @@ data class LostAndFoundListState(
     val isLoggedIn: Boolean = false,
     val showFilterLoginDialog: Boolean = false,
     val showWriteLoginDialog: Boolean = false,
-    val isFirstPageLoading: Boolean = false,
+    val isFirstPageLoading: Boolean = true,
     val showFilterBottomSheet: Boolean = false,
     val showWriteBottomSheet: Boolean = false,
     val searchQuery: String = "",

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.list
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -22,6 +23,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -40,6 +42,8 @@ class LostAndFoundListViewModel @Inject constructor(
     override val container = container<LostAndFoundListState, Nothing>(
         initialState = LostAndFoundListState()
     )
+
+    private var doneFirstEmit = false
 
     companion object {
         const val SEARCH_DEBOUNCE_MS = 300L
@@ -231,7 +235,11 @@ class LostAndFoundListViewModel @Inject constructor(
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
             .onEach { query ->
-                fetchLostAndFoundItem()
+                if (!doneFirstEmit) {
+                    doneFirstEmit = true
+                } else {
+                    fetchLostAndFoundItem()
+                }
             }
             .launchIn(viewModelScope)
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.list
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -23,7 +22,6 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -91,7 +89,7 @@ class LostAndFoundListViewModel @Inject constructor(
         val filterParams = LostAndFoundFilterParams(
             page = 1,
             limit = PAGE_SIZE,
-            category = state.categoryFilterType.value,
+            category = state.categoryFilterType.map { it.value },
             foundStatus = state.foundFilterType.value,
             author = state.authorFilterType.value,
             type = type,
@@ -142,7 +140,7 @@ class LostAndFoundListViewModel @Inject constructor(
         val filterParams = LostAndFoundFilterParams(
             page = nextPage,
             limit = PAGE_SIZE,
-            category = state.categoryFilterType.value,
+            category = state.categoryFilterType.map { it.value },
             foundStatus = state.foundFilterType.value,
             author = state.authorFilterType.value,
             type = type,
@@ -173,14 +171,14 @@ class LostAndFoundListViewModel @Inject constructor(
     fun setSearchFilter(
         authorFilterType: AuthorFilterType,
         lostOrFoundFilterType: LostOrFoundFilterType,
-        categoryFilterType: CategoryFilterType,
+        categoryFilterType: List<CategoryFilterType>,
         foundFilterType: FoundFilterType
     ) = intent {
         reduce {
             state.copy(
                 authorFilterType = authorFilterType,
                 lostOrFoundFilterType = lostOrFoundFilterType,
-                categoryFilterType = categoryFilterType,
+                categoryFilterType = categoryFilterType.toPersistentList(),
                 foundFilterType = foundFilterType
             )
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -158,7 +158,7 @@ class LostAndFoundListViewModel @Inject constructor(
                 val filteredArticles = pagination.articleLostAndFoundHeader.map { it.toLostAndFoundItemState() }
                 reduce {
                     state.copy(
-                        searchedArticles = (state.searchedArticles + filteredArticles).toPersistentList(),
+                        searchedArticles = (state.searchedArticles + filteredArticles).distinctBy { it.id }.toPersistentList(),
                         searchedArticlesCurrentPage = pagination.currentPage,
                         searchedArticlesTotalPage = pagination.totalPage,
                         hasMoreArticles = pagination.currentPage < pagination.totalPage,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -20,12 +20,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -41,14 +35,9 @@ class LostAndFoundListViewModel @Inject constructor(
     override val container = container<LostAndFoundListState, Nothing>(
         initialState = LostAndFoundListState()
     )
-    companion object {
-        const val SEARCH_DEBOUNCE_MS = 300L
-    }
 
     init {
         initUserInfo()
-        fetchLostAndFoundItem()
-        observeQuery()
     }
 
     private fun initUserInfo() = viewModelScope.launch {
@@ -223,17 +212,5 @@ class LostAndFoundListViewModel @Inject constructor(
                 searchQuery = query
             )
         }
-    }
-
-    private fun observeQuery() {
-        container.stateFlow
-            .map { it.searchQuery }
-            .debounce(SEARCH_DEBOUNCE_MS)
-            .distinctUntilChanged()
-            .drop(1)
-            .onEach { query ->
-                fetchLostAndFoundItem()
-            }
-            .launchIn(viewModelScope)
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -224,19 +225,14 @@ class LostAndFoundListViewModel @Inject constructor(
         }
     }
 
-    private var doneFirstEmit = false
-
     private fun observeQuery() {
         container.stateFlow
             .map { it.searchQuery }
             .debounce(SEARCH_DEBOUNCE_MS)
             .distinctUntilChanged()
+            .drop(1)
             .onEach { query ->
-                if (!doneFirstEmit) {
-                    doneFirstEmit = true
-                } else {
-                    fetchLostAndFoundItem()
-                }
+                fetchLostAndFoundItem()
             }
             .launchIn(viewModelScope)
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -42,9 +42,6 @@ class LostAndFoundListViewModel @Inject constructor(
     override val container = container<LostAndFoundListState, Nothing>(
         initialState = LostAndFoundListState()
     )
-
-    private var doneFirstEmit = false
-
     companion object {
         const val SEARCH_DEBOUNCE_MS = 300L
     }
@@ -228,6 +225,8 @@ class LostAndFoundListViewModel @Inject constructor(
             )
         }
     }
+
+    private var doneFirstEmit = false
 
     private fun observeQuery() {
         container.stateFlow

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FABBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FABBottomsheet.kt
@@ -13,12 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FABBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FABBottomsheet.kt
@@ -13,13 +13,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -28,6 +31,7 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -39,6 +43,7 @@ fun LostAndFoundFABBottomSheet(
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true
     )
+    val scope = rememberCoroutineScope()
 
     ModalBottomSheet(
         sheetState = sheetState,
@@ -47,13 +52,17 @@ fun LostAndFoundFABBottomSheet(
         dragHandle = null
     ) {
         LostAndFoundFABContent(
-            onDismissRequest = onDismissRequest,
+            onDismissRequest = {
+                scope.launch { sheetState.hide() }
+                onDismissRequest()
+            },
             onFindOwnerClick = onFindOwnerClick,
             onLostItemClick = onLostItemClick
         )
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LostAndFoundFABContent(
     onDismissRequest: () -> Unit,
@@ -109,8 +118,8 @@ fun LostAndFoundFABContent(
                 text = stringResource(R.string.finding_btn),
                 icon = ImageVector.vectorResource(R.drawable.ic_found),
                 onClick = {
-                    onFindOwnerClick()
                     onDismissRequest()
+                    onFindOwnerClick()
                 }
             )
             Spacer(modifier = Modifier.height(16.dp))
@@ -118,8 +127,8 @@ fun LostAndFoundFABContent(
                 text = stringResource(R.string.lost_btn),
                 icon = ImageVector.vectorResource(R.drawable.ic_lost),
                 onClick = {
-                    onLostItemClick()
                     onDismissRequest()
+                    onLostItemClick()
                 }
             )
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -317,33 +318,30 @@ fun FilterDuplicateSection(
             color = KoinTheme.colors.neutral800,
             modifier = Modifier.padding(bottom = 12.dp)
         )
-        val chunkedItems = remember(items) { items.chunked(3) }
-        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-            chunkedItems.forEach { rowItems ->
-                Row(
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    modifier = Modifier.fillMaxWidth()
-                ) {
-                    rowItems.forEach { item ->
-                        FilterChipCustom(
-                            text = stringResource(item.stringRes),
-                            isSelected = item in selectedItems,
-                            onClick = {
-                                onItemSelected(
-                                    if (item in selectedItems) {
-                                        if (selectedItems.size > AT_LEAST_COUNT) {
-                                            (selectedItems - item).toPersistentList()
-                                        } else {
-                                            return@FilterChipCustom
-                                        }
-                                    } else {
-                                        (selectedItems + item).toPersistentList()
-                                    }
-                                )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            maxItemsInEachRow = 3,
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            items.forEach { item ->
+                FilterChipCustom(
+                    text = stringResource(item.stringRes),
+                    isSelected = item in selectedItems,
+                    onClick = {
+                        onItemSelected(
+                            if (item in selectedItems) {
+                                if (selectedItems.size > AT_LEAST_COUNT) {
+                                    (selectedItems - item).toPersistentList()
+                                } else {
+                                    return@FilterChipCustom
+                                }
+                            } else {
+                                (selectedItems + item).toPersistentList()
                             }
                         )
                     }
-                }
+                )
             }
         }
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +45,7 @@ import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundFilterType.Fou
 import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundFilterType.LostOrFoundFilterType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -63,6 +65,7 @@ fun LostAndFoundFilterBottomSheet(
     val sheetState = rememberModalBottomSheetState(
         skipPartiallyExpanded = true
     )
+    val scope = rememberCoroutineScope()
 
     ModalBottomSheet(
         sheetState = sheetState,
@@ -97,7 +100,10 @@ fun LostAndFoundFilterBottomSheet(
                 )
             },
 
-            onDismissRequest = onDismissRequest
+            onDismissRequest = {
+                scope.launch { sheetState.hide() }
+                onDismissRequest()
+            }
         )
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
@@ -330,8 +330,12 @@ fun FilterDuplicateSection(
                             isSelected = item in selectedItems,
                             onClick = {
                                 onItemSelected(
-                                    if (item in selectedItems && selectedItems.size > AT_LEAST_COUNT) {
-                                        (selectedItems - item).toPersistentList()
+                                    if (item in selectedItems) {
+                                        if (selectedItems.size > AT_LEAST_COUNT) {
+                                            (selectedItems - item).toPersistentList()
+                                        } else {
+                                            return@FilterChipCustom
+                                        }
                                     } else {
                                         (selectedItems + item).toPersistentList()
                                     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
@@ -302,6 +302,7 @@ fun FilterSection(
     }
 }
 private const val AT_LEAST_COUNT = 1
+
 @Composable
 fun FilterDuplicateSection(
     title: String,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/FilterBottomsheet.kt
@@ -45,6 +45,7 @@ import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundFilterType.Fou
 import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundFilterType.LostOrFoundFilterType
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -53,9 +54,9 @@ fun LostAndFoundFilterBottomSheet(
     onDismissRequest: () -> Unit,
     selectedAuthorType: AuthorFilterType,
     selectedLostOrFoundType: LostOrFoundFilterType,
-    selectedCategoryType: CategoryFilterType,
+    selectedCategoryType: ImmutableList<CategoryFilterType>,
     selectedFoundType: FoundFilterType,
-    onApply: (AuthorFilterType, LostOrFoundFilterType, CategoryFilterType, FoundFilterType) -> Unit
+    onApply: (AuthorFilterType, LostOrFoundFilterType, ImmutableList<CategoryFilterType>, FoundFilterType) -> Unit
 ) {
     var selectedAuthorType by remember { mutableStateOf(selectedAuthorType) }
     var selectedLostOrFoundType by remember { mutableStateOf(selectedLostOrFoundType) }
@@ -81,13 +82,25 @@ fun LostAndFoundFilterBottomSheet(
 
             onAuthorTypeChange = { selectedAuthorType = it as AuthorFilterType },
             onLostOrFoundTypeChange = { selectedLostOrFoundType = it as LostOrFoundFilterType },
-            onCategoryTypeChange = { selectedCategoryType = it as CategoryFilterType },
+            onCategoryTypeChange = {
+                val newSelectedCategories = it.map { type -> type as CategoryFilterType }
+                selectedCategoryType = if (
+                    selectedCategoryType.size == 1 &&
+                    selectedCategoryType.first() == CategoryFilterType.ALL
+                ) {
+                    (newSelectedCategories - CategoryFilterType.ALL).toPersistentList()
+                } else if (CategoryFilterType.ALL in newSelectedCategories) {
+                    persistentListOf(CategoryFilterType.ALL)
+                } else {
+                    newSelectedCategories.toPersistentList()
+                }
+            },
             onFoundTypeChange = { selectedFoundType = it as FoundFilterType },
 
             onReset = {
                 selectedAuthorType = AuthorFilterType.ALL
                 selectedLostOrFoundType = LostOrFoundFilterType.ALL
-                selectedCategoryType = CategoryFilterType.ALL
+                selectedCategoryType = persistentListOf(CategoryFilterType.ALL)
                 selectedFoundType = FoundFilterType.ALL
             },
 
@@ -112,11 +125,11 @@ fun LostAndFoundFilterBottomSheet(
 fun FilterBottomSheetContent(
     selectedAuthorType: AuthorFilterType,
     selectedLostOrFoundType: LostOrFoundFilterType,
-    selectedCategoryType: CategoryFilterType,
+    selectedCategoryType: ImmutableList<CategoryFilterType>,
     selectedFoundType: FoundFilterType,
     onAuthorTypeChange: (LostAndFoundFilterType) -> Unit,
     onLostOrFoundTypeChange: (LostAndFoundFilterType) -> Unit,
-    onCategoryTypeChange: (LostAndFoundFilterType) -> Unit,
+    onCategoryTypeChange: (ImmutableList<LostAndFoundFilterType>) -> Unit,
     onFoundTypeChange: (LostAndFoundFilterType) -> Unit,
     onReset: () -> Unit,
     onApplyClick: () -> Unit,
@@ -176,7 +189,7 @@ fun FilterBottomSheetContent(
                 onItemSelected = onLostOrFoundTypeChange
             )
             HorizontalDivider(color = KoinTheme.colors.neutral300)
-            FilterSection(
+            FilterDuplicateSection(
                 title = stringResource(R.string.filter_list_type),
                 items = persistentListOf(
                     CategoryFilterType.ALL,
@@ -186,7 +199,7 @@ fun FilterBottomSheetContent(
                     CategoryFilterType.ELECTRONIC,
                     CategoryFilterType.OTHER
                 ),
-                selectedItem = selectedCategoryType,
+                selectedItems = selectedCategoryType,
                 onItemSelected = onCategoryTypeChange
             )
             HorizontalDivider(color = KoinTheme.colors.neutral300)
@@ -281,6 +294,48 @@ fun FilterSection(
                             text = stringResource(item.stringRes),
                             isSelected = item == selectedItem,
                             onClick = { onItemSelected(item) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+private const val AT_LEAST_COUNT = 1
+@Composable
+fun FilterDuplicateSection(
+    title: String,
+    items: ImmutableList<LostAndFoundFilterType>,
+    selectedItems: ImmutableList<LostAndFoundFilterType>,
+    onItemSelected: (ImmutableList<LostAndFoundFilterType>) -> Unit
+) {
+    Column(modifier = Modifier.padding(vertical = 12.dp)) {
+        Text(
+            text = title,
+            style = KoinTheme.typography.bold16,
+            color = KoinTheme.colors.neutral800,
+            modifier = Modifier.padding(bottom = 12.dp)
+        )
+        val chunkedItems = remember(items) { items.chunked(3) }
+        Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            chunkedItems.forEach { rowItems ->
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    rowItems.forEach { item ->
+                        FilterChipCustom(
+                            text = stringResource(item.stringRes),
+                            isSelected = item in selectedItems,
+                            onClick = {
+                                onItemSelected(
+                                    if (item in selectedItems && selectedItems.size > AT_LEAST_COUNT) {
+                                        (selectedItems - item).toPersistentList()
+                                    } else {
+                                        (selectedItems + item).toPersistentList()
+                                    }
+                                )
+                            }
                         )
                     }
                 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/ListItem.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/ListItem.kt
@@ -66,7 +66,7 @@ fun ListItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable {
+            .clickable(enabled = !isReported) {
                 EventLogger.logCampusClickEvent(
                     AnalyticsConstant.Label.LostAndFound.LOST_ITEM_POST_ENTRY,
                     loggingEntry

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
@@ -13,6 +13,7 @@ import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.lostandfound.IMAGE_MAX_COUNT
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory.Companion.getCategoryKoreanWord
+import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.navigation.ARTICLE_ID
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -151,7 +152,7 @@ class LostAndFoundModifyViewModel @Inject constructor(
         reduce {
             state.copy(
                 foundPlace = foundPlace,
-                locationRequired = foundPlace.isEmpty()
+                locationRequired = foundPlace.isEmpty() && state.lostOrFoundType == LostOrFoundType.FOUND
             )
         }
     }
@@ -170,7 +171,7 @@ class LostAndFoundModifyViewModel @Inject constructor(
         reduce {
             state.copy(
                 itemTypeRequired = state.category == LostItemCategory.NONE,
-                locationRequired = state.foundPlace.isEmpty()
+                locationRequired = state.foundPlace.isEmpty() && state.lostOrFoundType == LostOrFoundType.FOUND
             )
         }
         modifyArticle()

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
@@ -13,7 +13,6 @@ import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.lostandfound.IMAGE_MAX_COUNT
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory.Companion.getCategoryKoreanWord
-import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.navigation.ARTICLE_ID
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -186,11 +185,6 @@ class LostAndFoundModifyViewModel @Inject constructor(
             it.imageUrl in state.images
         }.map { it.id }
         val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-        if (state.lostOrFoundType == LostOrFoundType.LOST && state.foundPlace.isEmpty()) {
-            reduce {
-                state.copy(foundPlace = "장소 미상")
-            }
-        }
         modifyArticleLostAndFoundUseCase(
             articleId = state.articleId,
             category = state.category.getCategoryKoreanWord(),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/modify/LostAndFoundModifyViewModel.kt
@@ -13,6 +13,7 @@ import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.feature.lostandfound.IMAGE_MAX_COUNT
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory
 import `in`.koreatech.koin.feature.lostandfound.enums.LostItemCategory.Companion.getCategoryKoreanWord
+import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.navigation.ARTICLE_ID
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -185,6 +186,11 @@ class LostAndFoundModifyViewModel @Inject constructor(
             it.imageUrl in state.images
         }.map { it.id }
         val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        if (state.lostOrFoundType == LostOrFoundType.LOST && state.foundPlace.isEmpty()) {
+            reduce {
+                state.copy(foundPlace = "장소 미상")
+            }
+        }
         modifyArticleLostAndFoundUseCase(
             articleId = state.articleId,
             category = state.category.getCategoryKoreanWord(),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -89,6 +89,11 @@ fun handleSideEffect(
     when (sideEffect) {
         is LostAndFoundReportSideEffect.ReportSuccess -> {
             onSuccess()
+            Toast.makeText(
+                context,
+                context.getString(R.string.report_success),
+                Toast.LENGTH_SHORT
+            ).show()
         }
 
         is LostAndFoundReportSideEffect.ReportFailure -> {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.report
 
-import android.app.Activity
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.layout.consumeWindowInsets

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -29,6 +29,7 @@ import timber.log.Timber
 @Composable
 fun LostAndFoundReport(
     articleId: Int,
+    onTopbarBackClick: () -> Unit = {},
     onSuccess: () -> Unit,
     viewModel: LostAndFoundReportViewModel = hiltViewModel()
 ) {
@@ -45,7 +46,7 @@ fun LostAndFoundReport(
             topBar = {
                 KoinTopAppBar(
                     title = stringResource(R.string.report_title),
-                    onNavigationIconClick = { (context as Activity).finish() },
+                    onNavigationIconClick = onTopbarBackClick,
                     colors = TopAppBarDefaults.centerAlignedTopAppBarColors().copy(
                         containerColor = KoinTheme.colors.primary500,
                         navigationIconContentColor = KoinTheme.colors.neutral0,

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -73,6 +73,9 @@
     <string name="lost_date">분실 일자</string>
     <string name="lost_date_hint">분실 일자를 입력해주세요.</string>
     <string name="lost_date_required">분실일자가 입력되지 않았습니다.</string>
+    
+    <string name="date_reset">초기화</string>
+    <string name="date_confirm">확인</string>
 
     <string name="found_location">습득 장소</string>
     <string name="found_location_hint">습득 장소를 입력해주세요.</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="article_student">학생생활</string>
     <string name="article_student_simple">학생</string>
     <string name="request_login_dialog_title">게시글을 작성 하려면\n로그인이 필요해요.</string>
-    <string name="request_login_dialog_description">로그인 후 분실물 주인을 찾아주세요!</string>
+    <string name="request_login_dialog_description">로그인 후 글을 작성해주세요!</string>
 
     <string name="fab_write">글쓰기</string>
     <string name="fab_found">주인을 찾아요</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
 
     <string name="lost_and_found_update_found_fail">찾음으로 변경하지 못했습니다.</string>
 
-    <string name="lost_and_found_my_filter_can_use_logged_in">내 개시물 필터는\n로그인이 필요해요.</string>
+    <string name="lost_and_found_my_filter_can_use_logged_in">내 게시물 필터는\n로그인이 필요해요.</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_description">로그인 후 이용하세요!</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_positive">로그인하기</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_negative">닫기</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
 
     <string name="report_submit">신고하기</string>
 
+    <string name="report_success">게시글이 신고되었습니다.</string>
     <string name="report_failed">게시글 신고에 실패하였습니다</string>
     <string name="article_reported">신고에 의해 숨김 처리 되었습니다. </string>
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1214

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
리스트 정보가 가 2번 fetch 되는 현상을 수정했습니다.
- `searchQuery` 를 `stateFlow` 로 구독하면서 방출되는 emit 이 뒤늦게 fetch 되는 현상을 수정했습니다.
 drop 으로 버려도 state 가 바뀌며 계속 호출되고 `stateFlow` 만 쓰자니 처음 fetch 되는 속도가 너무 느려 내부 bool 값으로 처리했습니다.

bottomSheet 에서 다른 화면으로 넘어갈 때 늦게 닫히는 현상을 수정했습니다.
- 내부에 scope 를 통하여 `sheetState.hide()` 를 직접 호출해 닫습니다. 여는 작업은 uiState 로 하기에 false 반환은 계속 수행합니다.

필터 선택에서 분실물 종류는 중복 선택이 가능하도록 바꿨습니다.
- 전체 비활성 상태에서 전체를 누르면 모든 선택이 사라지고 전체만 남습니다.
- 전체만 활성 상태에서 다른 선택지를 누르면 전체가 취소되고 다른 선택지가 선택됩니다.
- 같은 항목을 재 클릭 시 클릭 이벤트 자체를 취소합니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다