### PR TITLE
[Fix][Koin Project] 상점 상세 메뉴 카테고리 스크롤 로직 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -178,7 +179,7 @@ fun StoreDetailScreen(
 
     LaunchedEffect(uiState.selectedCategoryId) {
         if (currentToolbarHeightDp.value != rememberState.headerCollapsedHeightPx.pxToDp) return@LaunchedEffect // Don't scroll if toolbar not collapsed
-        listState.animateScrollToItem(uiState.categories.indexOfFirst { it.menuGroupId == uiState.selectedCategoryId } + 2)
+        listState.animateScrollToItem(uiState.categories.indexOfFirst { it.menuGroupId == uiState.selectedCategoryId } + 2, -menuCategoryHeight.value)
     }
 
     LaunchedEffect(Unit) {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -215,7 +215,7 @@ fun StoreDetailScreen(
             snapshotFlow { listState.firstVisibleItemIndex },
             snapshotFlow { listState.layoutInfo.visibleItemsInfo.lastIndex }
         ) { index, _ ->
-            index
+            index + 1
         }.collect { index ->
             val visibleCategory = if (!listState.isScrolledToTheEnd()) {
                 uiState.categories.getOrNull(index - 2)

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.animateScrollBy
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -142,17 +141,18 @@ fun StoreDetailScreen(
     val menuCategoryHeight = remember { mutableStateOf(0) }
     val coroutineScope = rememberCoroutineScope()
 
-    viewModel.collectSideEffect {
+    viewModel.collectSideEffect { sideEffect ->
         handleSideEffect(
-            sideEffect = it,
+            sideEffect = sideEffect,
             context = context,
             checkPermission = {
                 permissionLauncher.launch(Manifest.permission.CALL_PHONE)
             },
             navigateToCart = navigateToCart,
-            collapseToolbar = {
+            scrollToMenuCategory = { categoryId ->
                 coroutineScope.launch {
-                    rememberState.collapseHeader()
+                    rememberState.snapOffset(-rememberState.range)
+                    listState.animateScrollToItem(uiState.categories.indexOfFirst { it.menuGroupId == categoryId } + 2, -menuCategoryHeight.value)
                 }
             }
         )
@@ -175,11 +175,6 @@ fun StoreDetailScreen(
                 }
             }
             .launchIn(coroutineScope)
-    }
-
-    LaunchedEffect(uiState.selectedCategoryId) {
-        if (currentToolbarHeightDp.value != rememberState.headerCollapsedHeightPx.pxToDp) return@LaunchedEffect // Don't scroll if toolbar not collapsed
-        listState.animateScrollToItem(uiState.categories.indexOfFirst { it.menuGroupId == uiState.selectedCategoryId } + 2, -menuCategoryHeight.value)
     }
 
     LaunchedEffect(Unit) {
@@ -507,7 +502,7 @@ fun handleSideEffect(
     context: Context,
     checkPermission: () -> Unit = {},
     navigateToCart: () -> Unit = {},
-    collapseToolbar: () -> Unit = {}
+    scrollToMenuCategory: (categoryId: Int) -> Unit = {}
 ) {
     when (sideEffect) {
         StoreDetailSideEffect.NavigateToCart -> {
@@ -526,8 +521,8 @@ fun handleSideEffect(
             context.startActivity(intent)
         }
 
-        StoreDetailSideEffect.CollapseToolbar -> {
-            collapseToolbar()
+        is StoreDetailSideEffect.ScrollToMenuCategory -> {
+            scrollToMenuCategory(sideEffect.categoryId)
         }
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailScreen.kt
@@ -170,7 +170,7 @@ fun StoreDetailScreen(
         snapshotFlow { isCartModified }
             .distinctUntilChanged()
             .onEach {
-                if (it && uiState.isLoggedIn) {
+                if (it && uiState.isLogin) {
                     viewModel.getCart(uiState.cartType)
                 }
             }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailSideEffect.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailSideEffect.kt
@@ -4,5 +4,5 @@ sealed class StoreDetailSideEffect {
     data object NavigateToCart : StoreDetailSideEffect()
     data object CheckCallPermission : StoreDetailSideEffect()
     data object PermissionDenied : StoreDetailSideEffect()
-    data object CollapseToolbar : StoreDetailSideEffect()
+    data class ScrollToMenuCategory(val categoryId: Int) : StoreDetailSideEffect()
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailState.kt
@@ -29,7 +29,6 @@ data class StoreDetailState(
     val isLoading: Boolean = true,
     val storeId: Int = -1,
     val cartItemCount: Int = 0,
-    val isLoggedIn: Boolean = false,
     val showSignInDialog: Boolean = false,
     val minimumOrderAmount: Int = 0,
     val cart: Cart = Cart.Empty,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
@@ -7,7 +7,6 @@ import `in`.koreatech.koin.core.developer.DeveloperOption
 import `in`.koreatech.koin.core.developer.DeveloperOptionUtil
 import `in`.koreatech.koin.domain.error.store.KoinStoreException
 import `in`.koreatech.koin.domain.model.cart.CartType
-import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.orderShop.GetOrderShopMenuUseCase
 import `in`.koreatech.koin.domain.usecase.orderShop.GetOrderShopOriginInfoUseCase
 import `in`.koreatech.koin.domain.usecase.orderShop.GetOrderShopSummaryUseCase
@@ -67,8 +66,6 @@ class StoreDetailViewModel @Inject constructor(
             val isOrderableShop = savedStateHandle.get<Boolean>(IS_ORDERABLE_SHOP) ?: true
             checkNotNull(storeId)
 
-            getUserType()
-
             intent {
                 reduce {
                     state.copy(
@@ -86,25 +83,6 @@ class StoreDetailViewModel @Inject constructor(
             fetchReview(storeId)
             checkToken()
         }
-
-    private fun getUserType() = intent {
-        getUserStatusUseCase().collect {
-            when (it) {
-                is User.Student,
-                is User.General -> {
-                    reduce {
-                        state.copy(isLoggedIn = true)
-                    }
-                }
-
-                is User.Anonymous -> {
-                    reduce {
-                        state.copy(isLoggedIn = false)
-                    }
-                }
-            }
-        }
-    }
 
     private fun fetchOrderStoreNotice(id: Int) = intent {
         getOrderShopOriginInfoUseCase(id).also { result ->
@@ -281,7 +259,7 @@ class StoreDetailViewModel @Inject constructor(
     }
 
     fun navigateToCart() = intent {
-        if (state.isLoggedIn) {
+        if (state.isLogin) {
             postSideEffect(StoreDetailSideEffect.NavigateToCart)
         } else {
             reduce {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/StoreDetailViewModel.kt
@@ -300,7 +300,7 @@ class StoreDetailViewModel @Inject constructor(
                 selectedCategoryId = categoryId
             )
         }
-        postSideEffect(StoreDetailSideEffect.CollapseToolbar)
+        postSideEffect(StoreDetailSideEffect.ScrollToMenuCategory(categoryId))
     }
 
     fun changeCategory(categoryId: Int) = blockingIntent {

--- a/feature/store/src/main/res/values/strings.xml
+++ b/feature/store/src/main/res/values/strings.xml
@@ -130,7 +130,7 @@
     <string name="store_banner_title">에서</string>
     <string name="store_banner_subtitle">코인 전용 할인혜택 받기!</string>
 
-    <string name="store_main_widget">주문</string>
+    <string name="store_main_widget">주변상점</string>
     <string name="store_cart_min_select">%1$d가지 선택</string>
     <string name="store_cart_add_menu">장바구니 추가</string>
     <string name="store_cart_price">가격 : %1$,d원</string>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1251

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 메뉴 카테고리 선택 시 스크롤이 되면서 카테고리 이름이 가려지는 문제를 수정했습니다.
- header 영역이 expand된 상태에서 카테고리 선택 시 스크롤이 정상적으로 되지 않는 문제를 수정했습니다.
- 중복된 로그인에 대한 상태를 제거했습니다.
- 메인 화면 위젯 제목을 수정했습니다.
- 스크롤 시 잘못된 메뉴 카테고리가 선택되는 문제를 수정했습니다.

### 논의 사항

### 스크린샷
|전|후|
|---|---|
|https://github.com/user-attachments/assets/a6cb9ec8-2e49-4bac-877f-772f25688ef5| https://github.com/user-attachments/assets/4275f507-5f0d-45f8-9ba4-784bad54364e|
## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다