### PR TITLE
[Campus][Feature] 분실물 2차 QA 수정(디자인 수정, 오타 수정, 리스트 중복 처리, 자신 게시물 판단 로직 수정 등)

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -75,15 +75,6 @@ interface ArticleApi {
     ): ArticleLostAndFoundPaginationResponse
 
     /**
-     * 분실물 게시글 조회
-     * @param id 게시글 아이디
-     */
-    @GET("articles/lost-item/v2/{id}")
-    suspend fun fetchArticleLostAndFoundV2(
-        @Path("id") id: Int
-    ): ArticleLostAndFoundResponse
-
-    /**
      * 분실물 게시글 통계 조회
      */
     @GET("articles/lost-item/stats")

--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.data.api
 
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationResponse
-import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundResponse
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundStatsResponse
 import `in`.koreatech.koin.data.response.article.ArticlePaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleResponse

--- a/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/ArticleAuthApi.kt
@@ -83,4 +83,13 @@ interface ArticleAuthApi {
         @Query("author") author: String?,
         @Query("title") title: String?
     ): ArticleLostAndFoundPaginationResponse
+
+    /**
+     * 분실물 게시글 조회
+     * @param id 게시글 아이디
+     */
+    @GET("articles/lost-item/v2/{id}")
+    suspend fun fetchArticleLostAndFoundV2(
+        @Path("id") id: Int
+    ): ArticleLostAndFoundResponse
 }

--- a/data/src/main/java/in/koreatech/koin/data/response/article/ArticleLostAndFoundResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/article/ArticleLostAndFoundResponse.kt
@@ -77,7 +77,7 @@ data class ArticleLostAndFoundResponse(
             content = content,
             author = author,
             organization = organization?.toArticleLostAndFoundOrganization(),
-            isMine = isMine!!, // Should not be null
+            isMine = isMine ?: false, // Should not be null
             isFound = isFound,
             images = images?.map { it.toArticleLostAndFoundImage() },
             registeredAt = registeredAt,

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -112,7 +112,7 @@ class ArticleRemoteDataSource @Inject constructor(
     }
 
     suspend fun fetchArticleLostAndFoundV2(articleId: Int): ArticleLostAndFoundResponse {
-        return articleApi.fetchArticleLostAndFoundV2(articleId)
+        return articleAuthApi.fetchArticleLostAndFoundV2(articleId)
     }
 
     suspend fun uploadArticleLostAndFound(articleLostAndFound: List<ArticleLostAndFoundUpload>): Result<ArticleLostAndFoundResponse> {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/SlideUpText.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/SlideUpText.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import kotlinx.collections.immutable.ImmutableList
@@ -44,6 +45,7 @@ fun SlideUpText(
 
     AnimatedContent(
         targetState = text.value,
+        contentAlignment = Alignment.Center,
         transitionSpec = {
             slideInVertically { height -> height } + fadeIn() togetherWith
                 slideOutVertically { height -> -height } + fadeOut()
@@ -52,6 +54,7 @@ fun SlideUpText(
         Text(
             modifier = modifier,
             text = showedText,
+            maxLines = 1,
             style = style
         )
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -91,9 +91,12 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             articleId = route.articleId,
             onTopbarBackClick = onBackPressed,
             onSuccess = {
+                navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
+                    ?.savedStateHandle
+                    ?.set(REFRESH_LIST, true)
                 navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
                     popUpTo(navController.graph.startDestinationId) {
-                        inclusive = true
+                        inclusive = false
                     }
                     launchSingleTop = true
                 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -89,7 +89,14 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundDetailRoute>()
         LostAndFoundReport(
             articleId = route.articleId,
-            onSuccess = { navController.navigateUp() }
+            onSuccess = {
+                navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
+                    popUpTo(navController.graph.startDestinationId) {
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                }
+            }
         )
     }
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -89,6 +89,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundDetailRoute>()
         LostAndFoundReport(
             articleId = route.articleId,
+            onTopbarBackClick = onBackPressed,
             onSuccess = {
                 navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
                     popUpTo(navController.graph.startDestinationId) {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailState.kt
@@ -13,7 +13,6 @@ import kotlinx.parcelize.Parcelize
 data class LostAndFoundDetailState(
     val isLoading: Boolean = false,
     val isLoggedIn: Boolean = false,
-    val currentLoggedInUser: String = "",
     val showDeleteDialog: Boolean = false,
     val showFoundDialog: Boolean = false,
     val showLoginDialog: Boolean = false,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -54,16 +54,12 @@ class LostAndFoundDetailViewModel @Inject constructor(
                 when (it) {
                     is User.Student -> reduce {
                         state.copy(
-                            isLoggedIn = true,
-                            currentLoggedInUser = it.nickname ?: "",
-                            isMine = it.nickname == state.author
+                            isLoggedIn = true
                         )
                     }
                     is User.General -> reduce {
                         state.copy(
-                            isLoggedIn = true,
-                            currentLoggedInUser = it.nickname ?: "",
-                            isMine = it.nickname == state.author
+                            isLoggedIn = true
                         )
                     }
                     is User.Anonymous -> reduce {
@@ -100,7 +96,7 @@ class LostAndFoundDetailViewModel @Inject constructor(
                     registeredAt = article.registeredAt,
                     updatedAt = article.updatedAt,
                     organization = article.organization,
-                    isMine = state.currentLoggedInUser == article.author,
+                    isMine = article.isMine,
                     isAuthorWithdraw = article.author == "탈퇴한 사용자",
                     isLoading = false,
                     isFound = article.isFound

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -167,7 +167,10 @@ fun LostAndFoundList(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 24.dp),
+                    .padding(
+                        horizontal = 24.dp,
+                        vertical = 4.dp
+                    ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 ItemSearchTextField(

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
@@ -145,6 +146,7 @@ fun LostAndFoundList(
         },
         floatingActionButton = {
             LostAndFoundFAB(
+                modifier = Modifier.offset(y = 10.dp),
                 onClick = {
                     if (uiState.isLoggedIn) {
                         viewModel.setShowWriteBottomSheet(true)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -158,7 +158,7 @@ class LostAndFoundListViewModel @Inject constructor(
                 val filteredArticles = pagination.articleLostAndFoundHeader.map { it.toLostAndFoundItemState() }
                 reduce {
                     state.copy(
-                        searchedArticles = (state.searchedArticles + filteredArticles).toPersistentList(),
+                        searchedArticles = (state.searchedArticles + filteredArticles).distinctBy { it.id }.toPersistentList(),
                         searchedArticlesCurrentPage = pagination.currentPage,
                         searchedArticlesTotalPage = pagination.totalPage,
                         hasMoreArticles = pagination.currentPage < pagination.totalPage,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/ListItem.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/component/ListItem.kt
@@ -66,7 +66,7 @@ fun ListItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .clickable {
+            .clickable(enabled = !isReported) {
                 EventLogger.logCampusClickEvent(
                     AnalyticsConstant.Label.LostAndFound.LOST_ITEM_POST_ENTRY,
                     loggingEntry

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -89,6 +89,11 @@ fun handleSideEffect(
     when (sideEffect) {
         is LostAndFoundReportSideEffect.ReportSuccess -> {
             onSuccess()
+            Toast.makeText(
+                context,
+                context.getString(R.string.report_success),
+                Toast.LENGTH_SHORT
+            ).show()
         }
 
         is LostAndFoundReportSideEffect.ReportFailure -> {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.report
 
-import android.app.Activity
 import android.content.Context
 import android.widget.Toast
 import androidx.compose.foundation.layout.consumeWindowInsets

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReport.kt
@@ -29,6 +29,7 @@ import timber.log.Timber
 @Composable
 fun LostAndFoundReport(
     articleId: Int,
+    onTopbarBackClick: () -> Unit = {},
     onSuccess: () -> Unit,
     viewModel: LostAndFoundReportViewModel = hiltViewModel()
 ) {
@@ -45,7 +46,7 @@ fun LostAndFoundReport(
             topBar = {
                 KoinTopAppBar(
                     title = stringResource(R.string.report_title),
-                    onNavigationIconClick = { (context as Activity).finish() },
+                    onNavigationIconClick = onTopbarBackClick,
                     colors = TopAppBarDefaults.centerAlignedTopAppBarColors().copy(
                         containerColor = KoinTheme.colors.primary500,
                         navigationIconContentColor = KoinTheme.colors.neutral0,

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -134,7 +134,7 @@
     <string name="article_student">학생생활</string>
     <string name="article_student_simple">학생</string>
     <string name="request_login_dialog_title">게시글을 작성 하려면\n로그인이 필요해요.</string>
-    <string name="request_login_dialog_description">로그인 후 분실물 주인을 찾아주세요!</string>
+    <string name="request_login_dialog_description">로그인 후 글을 작성해주세요!</string>
 
     <string name="fab_write">글쓰기</string>
     <string name="fab_found">주인을 찾아요</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -224,7 +224,7 @@
 
     <string name="lost_and_found_update_found_fail">찾음으로 변경하지 못했습니다.</string>
 
-    <string name="lost_and_found_my_filter_can_use_logged_in">내 개시물 필터는\n로그인이 필요해요.</string>
+    <string name="lost_and_found_my_filter_can_use_logged_in">내 게시물 필터는\n로그인이 필요해요.</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_description">로그인 후 이용하세요!</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_positive">로그인하기</string>
     <string name="lost_and_found_my_filter_can_use_logged_in_negative">닫기</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
 
     <string name="report_submit">신고하기</string>
 
+    <string name="report_success">게시글이 신고되었습니다.</string>
     <string name="report_failed">게시글 신고에 실패하였습니다</string>
     <string name="article_reported">신고에 의해 숨김 처리 되었습니다. </string>
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1214

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
자신의 게시물 판단 조건을 `fetchArticleLostAndFoundV2` 의 반환값으로 처리하도록 수정
- 기존 방식에서 `fetchArticleLostAndFoundV2` 으로 바꾸기 위해 해당 api 를 authApi 로 수정했습니다. (isMine은 로그인 필요)
- 해당 api 결과인 isMine 을 받아옵니다.

신고화면 처리 로직 변경
- 신고에 성공하면 Toast message 를 출력합니다.
- 신고 후 갱신된 초기 List 화면으로 돌아옵니다. (이때 기존 state 값을 유지하기 위해 신규 refresh 방식을 사용했습니다.)
- 신고 후 해당 List item 은 클릭 이벤트가 발생하지 않습니다.
- 신고화면 에서 뒤로 갈 경우 activity 종료 대신 `onBackPressed` 를 호출합니다.

FAB(글쓰기 버튼) 위치를 좀 더 하단으로 이동
- offset 으로 10.dp 정도 아래로 내렸습니다. (UX 개선)

SlideUp message 수정
- 최대 1줄만 보여집니다.(overflow는 없습니다.)
- 중앙으로 정렬하여 항상 animation 이 대각선이 아닌 수직으로 움직이도록 합니다.

중복 key 값 오류 수정
- 게시글 fetch 후 `distinctBy { it.id }` 를 통해 중복 제거를 수행합니다.
(내부적으로 set 을 유지하여 재사용 한다면 비용을 더 절감할 수 있습니다만 큰 연산이 아니라 생각하여 이렇게 처리했습니다.)

검색창에 수직 padding 추가 (4 dp)
오타 수정( 개시글 -> 게시글 ), 새로운 디자인의 텍스트로 대체


### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다