### PR TITLE
[Refactor][Koin Project] HttpException 매핑을 위한 mapHttpFailure 함수 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -15,9 +15,7 @@ import `in`.koreatech.koin.data.request.user.SmsVerifyRequest
 import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.source.local.UserLocalDataSource
 import `in`.koreatech.koin.data.source.remote.UserRemoteDataSource
-import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.data.util.mapHttpFailure
-import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.user.KoinUserException
 import `in`.koreatech.koin.domain.model.user.ABTest
 import `in`.koreatech.koin.domain.model.user.AuthToken

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -217,41 +217,19 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount> {
         return runCatching {
             userRemoteDataSource.sendSMS(SmsSendRequest(phoneNumber)).toCodeCount()
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            429 -> KoinUserException.VerificationCodeRequestCountExceededException()
-                            400 -> KoinUserException.PhoneNumberInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.PhoneNumberInvalidException(),
+            e429 = KoinUserException.VerificationCodeRequestCountExceededException()
+        )
     }
 
     override suspend fun requestEmailVerification(email: String): Result<CodeCount> {
         return runCatching {
             userRemoteDataSource.sendEmail(EmailSendRequest(email)).toCodeCount()
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            429 -> KoinUserException.VerificationCodeRequestCountExceededException()
-                            400 -> KoinUserException.EmailInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> throw exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.EmailInvalidException(),
+            e429 = KoinUserException.VerificationCodeRequestCountExceededException()
+        )
     }
 
     override suspend fun verifyCertificationCode(phoneNumber: String, verificationCode: String): Result<Unit> {
@@ -262,21 +240,10 @@ class UserRepositoryImpl @Inject constructor(
                     verificationCode = verificationCode
                 )
             )
-        }.onFailure {
-            return Result.failure(
-                when (it) {
-                    is HttpException -> {
-                        when (it.code()) {
-                            404 -> KoinUserException.VerificationCodeExpiredException()
-                            400 -> KoinUserException.VerificationCodeInvalidException()
-                            else -> it.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> it
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.VerificationCodeInvalidException(),
+            e404 = KoinUserException.VerificationCodeExpiredException()
+        )
     }
 
     override suspend fun verifyEmailCode(email: String, verificationCode: String): Result<Unit> {
@@ -287,61 +254,28 @@ class UserRepositoryImpl @Inject constructor(
                     verificationCode = verificationCode
                 )
             )
-        }.onFailure {
-            return Result.failure(
-                when (it) {
-                    is HttpException -> {
-                        when (it.code()) {
-                            404 -> KoinUserException.VerificationCodeExpiredException()
-                            400 -> KoinUserException.VerificationCodeInvalidException()
-                            else -> it.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> it
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.VerificationCodeInvalidException(),
+            e404 = KoinUserException.VerificationCodeExpiredException()
+        )
     }
 
     override suspend fun checkIdExists(loginId: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.idExists(loginId)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            404 -> KoinUserException.LoginIdNotFoundException()
-                            400 -> KoinUserException.LoginIdInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.LoginIdInvalidException(),
+            e404 = KoinUserException.LoginIdNotFoundException()
+        )
     }
 
     override suspend fun checkIdMatchEmail(loginId: String, email: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.idMatchEmail(loginId, email)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            404 -> KoinUserException.LoginIdNotFoundException()
-                            400 -> KoinUserException.LoginIdNotMatchEmailException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.LoginIdNotMatchEmailException(),
+            e404 = KoinUserException.LoginIdNotFoundException()
+        )
     }
 
     override suspend fun checkIdMatchPhone(loginId: String, phone: String): Result<Unit> {
@@ -350,21 +284,10 @@ class UserRepositoryImpl @Inject constructor(
                 loginId,
                 phone
             )
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            404 -> KoinUserException.LoginIdNotFoundException()
-                            400 -> KoinUserException.LoginIdNotMatchPhoneException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.LoginIdNotMatchPhoneException(),
+            e404 = KoinUserException.LoginIdNotFoundException()
+        )
     }
 
     override suspend fun resetPasswordByEmail(loginId: String, email: String, newPassword: String): Result<Unit> {
@@ -374,120 +297,58 @@ class UserRepositoryImpl @Inject constructor(
                 email,
                 newPassword
             )
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            404 -> KoinUserException.LoginIdNotFoundException()
-                            400 -> KoinUserException.LoginIdNotMatchEmailException()
-                            401 -> KoinUserException.UnauthorizedException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.LoginIdNotMatchEmailException(),
+            e401 = KoinUserException.UnauthorizedException(),
+            e404 = KoinUserException.LoginIdNotFoundException()
+        )
     }
 
     override suspend fun resetPasswordBySms(loginId: String, phone: String, newPassword: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.resetPasswordBySms(loginId, phone, newPassword)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            404 -> KoinUserException.LoginIdNotFoundException()
-                            400 -> KoinUserException.LoginIdNotMatchPhoneException()
-                            401 -> KoinUserException.UnauthorizedException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.LoginIdNotMatchPhoneException(),
+            e401 = KoinUserException.UnauthorizedException(),
+            e404 = KoinUserException.LoginIdNotFoundException()
+        )
     }
 
     override suspend fun checkEmailExists(email: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkEmailExists(email)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> when (exception.code()) {
-                        400 -> KoinUserException.EmailInvalidException()
-                        404 -> KoinUserException.EmailNotFoundException()
-                        else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.EmailInvalidException(),
+            e404 = KoinUserException.EmailNotFoundException()
+        )
     }
 
     override suspend fun checkPhoneExists(phone: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkPhoneExists(phone)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> when (exception.code()) {
-                        400 -> KoinUserException.PhoneNumberInvalidException()
-                        404 -> KoinUserException.PhoneNumberNotFoundException()
-                        else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.PhoneNumberInvalidException(),
+            e404 = KoinUserException.PhoneNumberNotFoundException()
+        )
     }
 
     override suspend fun findLoginIdByEmail(email: String, verificationCode: String): Result<String> {
         return runCatching {
             userRemoteDataSource.findLoginIdByEmail(EmailVerifyRequest(email, verificationCode)).loginId
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            400 -> KoinUserException.EmailInvalidException()
-                            401 -> KoinUserException.UnauthorizedException()
-                            404 -> KoinUserException.EmailNotFoundException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.EmailInvalidException(),
+            e401 = KoinUserException.UnauthorizedException(),
+            e404 = KoinUserException.EmailNotFoundException()
+        )
     }
 
     override suspend fun findLoginIdBySms(phone: String, verificationCode: String): Result<String> {
         return runCatching {
             userRemoteDataSource.findLoginIdBySms(SmsVerifyRequest(phone, verificationCode)).loginId
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            400 -> KoinUserException.PhoneNumberInvalidException()
-                            401 -> KoinUserException.UnauthorizedException()
-                            404 -> KoinUserException.PhoneNumberNotFoundException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure(
+            e400 = KoinUserException.PhoneNumberInvalidException(),
+            e401 = KoinUserException.UnauthorizedException(),
+            e404 = KoinUserException.PhoneNumberNotFoundException()
+        )
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -16,8 +16,8 @@ import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.source.local.UserLocalDataSource
 import `in`.koreatech.koin.data.source.remote.UserRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
+import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
-import `in`.koreatech.koin.domain.error.KoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.user.KoinUserException
 import `in`.koreatech.koin.domain.model.user.ABTest
 import `in`.koreatech.koin.domain.model.user.AuthToken
@@ -163,38 +163,27 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun updateUser(user: User) {
-        runCatching {
-            when (user) {
-                User.Anonymous -> throw IllegalAccessException("Updating anonymous user is not supported")
-                is User.Student -> {
-                    userRemoteDataSource.updateStudentUser(user.toUserRequest())
-                    userLocalDataSource.updateUserInfo(user)
-                }
-
-                is User.General -> {
-                    userRemoteDataSource.updateGeneralUser(user.toUserRequest())
-                    userLocalDataSource.updateUserInfo(user)
-                }
+    override suspend fun updateUser(user: User): Result<Unit> = runCatching {
+        when (user) {
+            User.Anonymous -> throw IllegalAccessException("Updating anonymous user is not supported")
+            is User.Student -> {
+                userRemoteDataSource.updateStudentUser(user.toUserRequest())
+                userLocalDataSource.updateUserInfo(user)
             }
-        }.onSuccess {
-            userLocalDataSource.updateUserInfo(user)
-        }.onFailure {
-            throw if (it is HttpException) {
-                when (it.code()) {
-                    400 -> KoinUserException.DataInvalidException()
-                    401 -> KoinUserException.UnauthorizedException()
-                    404 -> KoinUserException.UserNotFoundException()
-                    409 -> KoinUserException.NicknameOrEmailConflictException()
-                    else -> it.getErrorResponse().let { errorResponse ->
-                        KoinUnknownErrorException(errorResponse.code, errorResponse.message, errorResponse.errorTraceId)
-                    }
-                }
-            } else {
-                it
+
+            is User.General -> {
+                userRemoteDataSource.updateGeneralUser(user.toUserRequest())
+                userLocalDataSource.updateUserInfo(user)
             }
         }
-    }
+    }.onSuccess {
+        userLocalDataSource.updateUserInfo(user)
+    }.mapHttpFailure(
+        e400 = KoinUserException.DataInvalidException(),
+        e401 = KoinUserException.UnauthorizedException(),
+        e404 = KoinUserException.UserNotFoundException(),
+        e409 = KoinUserException.NicknameOrEmailConflictException()
+    )
 
     override suspend fun deleteDeviceToken() {
         tokenLocalDataSource.removeDeviceToken()

--- a/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.data.util
 
 import com.google.gson.Gson
 import `in`.koreatech.koin.data.response.ErrorResponse
+import `in`.koreatech.koin.domain.error.KoinErrorException
 import `in`.koreatech.koin.domain.error.KoinUnknownErrorException
 import retrofit2.HttpException
 
@@ -11,4 +12,33 @@ fun HttpException.getErrorResponse(): ErrorResponse {
 
 fun ErrorResponse.toKoinUnknownErrorException(): KoinUnknownErrorException {
     return KoinUnknownErrorException(this.code, this.message, this.errorTraceId)
+}
+
+
+fun <T> Result<T>.mapHttpFailure(
+    e400: KoinErrorException? = null,
+    e401: KoinErrorException? = null,
+    e403: KoinErrorException? = null,
+    e404: KoinErrorException? = null,
+    e409: KoinErrorException? = null,
+    e429: KoinErrorException? = null,
+    e500: KoinErrorException? = null
+): Result<T> {
+    val exception = exceptionOrNull() ?: return this
+    if (exception is HttpException) {
+        val default = exception.getErrorResponse().toKoinUnknownErrorException()
+        val mapped = when (exception.code()) {
+            400 -> e400
+            401 -> e401
+            403 -> e403
+            404 -> e404
+            409 -> e409
+            429 -> e429
+            in 500..599 -> e500
+            else -> null
+        } ?: default
+
+        return Result.failure(mapped)
+    }
+    return this
 }

--- a/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
+++ b/data/src/main/java/in/koreatech/koin/data/util/NetworkUtil.kt
@@ -14,7 +14,6 @@ fun ErrorResponse.toKoinUnknownErrorException(): KoinUnknownErrorException {
     return KoinUnknownErrorException(this.code, this.message, this.errorTraceId)
 }
 
-
 fun <T> Result<T>.mapHttpFailure(
     e400: KoinErrorException? = null,
     e401: KoinErrorException? = null,

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
@@ -35,7 +35,7 @@ interface UserRepository {
 
     suspend fun isUserEmailDuplicated(email: String): Boolean // TODO: Remove after new sign up release
 
-    suspend fun updateUser(user: User)
+    suspend fun updateUser(user: User): Result<Unit>
 
     suspend fun deleteDeviceToken()
 

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UpdateGeneralUserInfoUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UpdateGeneralUserInfoUseCase.kt
@@ -16,16 +16,14 @@ class UpdateGeneralUserInfoUseCase @Inject constructor(
         gender: Gender,
         phoneNumber: String
     ): Result<Unit> {
-        return runCatching {
-            val user = (beforeUser as User.General).copy(
-                email = email.ifEmpty { null },
-                name = name,
-                nickname = nickname.ifEmpty { null },
-                gender = gender,
-                phoneNumber = phoneNumber
-            )
+        val user = (beforeUser as User.General).copy(
+            email = email.ifEmpty { null },
+            name = name,
+            nickname = nickname.ifEmpty { null },
+            gender = gender,
+            phoneNumber = phoneNumber
+        )
 
-            userRepository.updateUser(user)
-        }
+        return userRepository.updateUser(user)
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UpdateStudentUserInfoUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UpdateStudentUserInfoUseCase.kt
@@ -18,18 +18,16 @@ class UpdateStudentUserInfoUseCase @Inject constructor(
         studentNumber: String,
         major: String
     ): Result<Unit> {
-        return runCatching {
-            val user = (beforeUser as User.Student).copy(
-                email = email.ifEmpty { null },
-                name = name,
-                nickname = nickname.ifEmpty { null },
-                gender = gender,
-                phoneNumber = phoneNumber,
-                studentNumber = studentNumber,
-                major = major
-            )
+        val user = (beforeUser as User.Student).copy(
+            email = email.ifEmpty { null },
+            name = name,
+            nickname = nickname.ifEmpty { null },
+            gender = gender,
+            phoneNumber = phoneNumber,
+            studentNumber = studentNumber,
+            major = major
+        )
 
-            userRepository.updateUser(user)
-        }
+        return userRepository.updateUser(user)
     }
 }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1254 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `HttpException`을 매핑하기 위한 `mapHttpFailure` 함수를 추가했습니다.
- `UserRepository`에 적용했습니다.

기존의 `HttpException`을 매핑하는 로직은 다음과 같았습니다.

```
runCatching {
    userRemoteDataSource.findLoginIdBySms(SmsVerifyRequest(phone, verificationCode)).loginId
}.onFailure { exception ->
    return Result.failure(
        when (exception) {
            is HttpException -> {
                when (exception.code()) {
                    400 -> KoinUserException.PhoneNumberInvalidException()
                    401 -> KoinUserException.UnauthorizedException()
                    404 -> KoinUserException.PhoneNumberNotFoundException()
                    else -> exception.getErrorResponse().toKoinUnknownErrorException()
                }
            }

            else -> exception
        }
    )
}
```

`onFailure` 안에서 `HttpException`을 필터링하고, 다시 status code에 따라 분기처리를 진행하고, else 처리까지 진행했습니다.

이와 동일한 코드가 반복되었고, 이는 심각한 코드 중복과 유지 보수의 어려움을 유발했습니다.

따라서, `HttpException`을 매핑하기 위한 `mapHttpFailure` 함수를 추가하여 이 문제를 해결했습니다.

해당 함수를 적용한 코드는 다음과 같습니다.
```
runCatching {
    userRemoteDataSource.findLoginIdBySms(SmsVerifyRequest(phone, verificationCode)).loginId
}.mapHttpFailure(
    e400 = KoinUserException.PhoneNumberInvalidException(),
    e401 = KoinUserException.UnauthorizedException(),
    e404 = KoinUserException.PhoneNumberNotFoundException()
)
```
status code에 맞는 Exception을 parameter로 넘겨주면 mapping이 가능합니다.

선언되지 않은 HttpException일 경우, `KoinUnknownErrorException`이 반환됩니다.

### 논의 사항
X
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다