### PR TITLE
[Campus][Feature] 분실물 세로 화면 고정 + 기존 article 의 분실물 string 제거

### DIFF
--- a/feature/article/src/main/res/values/strings.xml
+++ b/feature/article/src/main/res/values/strings.xml
@@ -1,61 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="lost_item">분실물</string>
-    <string name="found_item">습득물</string>
-
-    <string name="header_lost_title">잃어버렸어요</string>
-    <string name="header_found_title">주인을 찾아요</string>
-    <string name="header_lost_description">분실한 물건을 자세히 설명해주세요!</string>
-    <string name="header_found_description">습득한 물건을 자세히 설명해주세요!</string>
-
-    <string name="item_type_electronic_device">전자제품</string>
-    <string name="item_type_card">카드</string>
-    <string name="item_type_wallet">지갑</string>
-    <string name="item_type_id">신분증</string>
-    <string name="item_type_other">기타</string>
-    <string name="item_type_none" />
-
-    <string name="dropdown_type_all">물품 전체</string>
-
-    <string name="dropdown_item_all">모두보기</string>
-    <string name="dropdown_item_lost">분실물</string>
-    <string name="dropdown_item_found">습득물</string>
-
-    <string name="upload_image_of_found_item">습득물 사진을 업로드해주세요.</string>
-    <string name="upload_image_of_lost_item">분실물 사진을 업로드해주세요.</string>
     <string name="upload_image">사진 등록하기</string>
     <string name="upload_image_failed">사진 업로드에 실패했습니다.</string>
 
-    <string name="item_type">품목</string>
-    <string name="item_type_description">품목을 선택해주세요.</string>
-    <string name="item_type_required">품목이 선택되지 않았습니다.</string>
-
-    <string name="found_date">습득 일자</string>
-    <string name="found_date_hint">습득 일자를 입력해주세요.</string>
-    <string name="found_date_required">습득일자가 입력되지 않았습니다.</string>
-
-    <string name="lost_date">분실 일자</string>
-    <string name="lost_date_hint">분실 일자를 입력해주세요.</string>
-    <string name="lost_date_required">분실일자가 입력되지 않았습니다.</string>
-
-    <string name="found_location">습득 장소</string>
-    <string name="found_location_hint">습득 장소를 입력해주세요.</string>
-    <string name="found_location_required">습득장소가 입력되지 않았습니다.</string>
-
-    <string name="lost_location">분실 장소</string>
-    <string name="lost_location_hint">예상되는 분실 장소가 있다면 입력해주세요.</string>
-    <string name="lost_location_required" />
-
-    <string name="more_description">내용</string>
-    <string name="more_description_hint">물품이나 습득 장소에 대한 추가 설명이 있다면 작성해주세요.</string>
-
-    <string name="add_item">물품 추가</string>
     <string name="write_done">작성 완료</string>
     <string name="write_failed">글 작성에 실패했습니다.</string>
-
-    <string name="detail_student_association_info_1">분실물 수령을 희망하시는 분은 재실 시간 내에\n</string>
-    <string name="detail_student_association_info_2">학생회관 320호 총학생회 사무실</string>
-    <string name="detail_student_association_info_3">로 방문해 주시기 바랍니다.\n재실 시간은 공지 사항을 참고해 주시기 바랍니다.</string>
 
     <string name="detail_article_list_button">목록</string>
     <string name="detail_delete_button">삭제</string>
@@ -89,8 +38,6 @@
     <string name="article_ipp_simple">현장실습</string>
     <string name="article_student">학생생활</string>
     <string name="article_student_simple">학생</string>
-    <string name="request_login_dialog_title">게시글을 작성 하려면\n로그인이 필요해요.</string>
-    <string name="request_login_dialog_description">로그인 후 분실물 주인을 찾아주세요!</string>
 
     <string name="fab_write">글쓰기</string>
     <string name="fab_found">주인을 찾아요</string>
@@ -115,12 +62,7 @@
     <string name="report_submit">신고하기</string>
 
     <string name="report_failed">게시글 신고에 실패하였습니다</string>
-    <string name="article_reported">신고에 의해 숨김 처리 되었습니다. </string>
 
-    <string name="reported_article_click_toast">신고된 게시글은 더 이상 볼 수 없습니다.</string>
-
-    <string name="logging_lost_message_send">분실물 쪽지 보내기</string>
-    <string name="logging_found_message_send">습득물 쪽지 보내기</string>
     <string name="logging_report">신고하기</string>
 
     <string name="attachment">첨부파일</string>
@@ -171,10 +113,4 @@
 
     <string name="error_network_unknown">알 수 없는 오류가 발생했습니다.</string>
     <string name="request_notification_permission">설정에서 알림 권한을 허용해주세요</string>
-
-    <string name="lost_and_found_finding">찾는중</string>
-    <string name="lost_and_found_found">찾음</string>
-    <string name="lost_and_found_lost_message">물건을 찾았나요?</string>
-    <string name="lost_and_found_found_message">주인을 찾았나요?</string>
-    <string name="lost_and_found_dialog_message">상태 변경 시 되돌릴 수 없습니다.\n찾음으로 변경하시겠습니까?</string>
 </resources>

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/LostAndFoundActivity.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/LostAndFoundActivity.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.lostandfound.ui
 
+import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.LocalOnBackPressedDispatcherOwner
@@ -22,6 +23,11 @@ class LostAndFoundActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdgeWithLightStatusBar()
+
+        try {
+            requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
+        } catch (ignore: IllegalStateException) {
+        }
 
         val id = intent.data?.getQueryParameter("id")
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1214

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
분실물을 세로 화면으로 고정합니다.

기존 article 에 남은 분실물 관련 string 을 제거했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다