### PR TITLE
[Koin Project][Fix] 채팅 불안정성 개선

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/network/NetworkModule.kt
@@ -12,7 +12,6 @@ import `in`.koreatech.koin.data.source.local.TokenLocalDataSource
 import `in`.koreatech.koin.data.stomp.KoinStomp
 import javax.inject.Singleton
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.runBlocking
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import org.hildan.krossbow.stomp.StompClient
@@ -72,9 +71,10 @@ object NetworkModule {
         tokenLocalDataSource: TokenLocalDataSource,
         stompClient: StompClient
     ): KoinStomp {
-        return runBlocking {
-            val authToken = tokenLocalDataSource.getAccessToken() ?: ""
-            KoinStomp(baseUrl, authToken, stompClient)
-        }
+        return KoinStomp(
+            baseUrl = baseUrl,
+            tokenProvider = { tokenLocalDataSource.getAccessToken() ?: "" },
+            stompClient = stompClient
+        )
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -1,9 +1,12 @@
 package `in`.koreatech.koin.data.stomp
 
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.retry
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationStrategy
 import kotlinx.serialization.serializer
@@ -20,26 +23,37 @@ class KoinStomp @Inject constructor(
     private val authToken: String,
     private val stompClient: StompClient
 ) {
+    private val mutex = Mutex()
     private var stompSession: StompSession? = null
 
     suspend fun connect(): StompSession {
-        Timber.d("Connecting to STOMP...")
-        return stompClient.connect(
-            url = "${baseUrl.replaceFirst("https", "wss")}/ws-stomp",
-            customStompConnectHeaders = mapOf("Authorization" to authToken)
-        ).also {
-            stompSession = it
-            Timber.d("STOMP connected.")
+        return mutex.withLock {
+            val session = stompSession
+            if (session != null) {
+                return@withLock session
+            }
+
+            Timber.d("Connecting to STOMP...")
+            stompClient.connect(
+                url = "${baseUrl.replaceFirst("https", "wss")}/ws-stomp",
+                customStompConnectHeaders = mapOf("Authorization" to authToken)
+            ).also {
+                stompSession = it
+                Timber.d("STOMP connected.")
+            }
         }
     }
 
     private suspend fun getSession(): StompSession {
-        return stompSession ?: connect()
+        val session = mutex.withLock { stompSession }
+        return session ?: connect()
     }
 
     suspend fun disconnect() {
-        stompSession?.disconnect()
-        stompSession = null
+        mutex.withLock {
+            stompSession?.disconnect()
+            stompSession = null
+        }
     }
 
     fun <T : Any> subscribe(
@@ -51,6 +65,7 @@ class KoinStomp @Inject constructor(
         }.retry { e ->
             if (e is WebSocketException) {
                 Timber.d("WebSocketException, reconnecting...")
+                mutex.withLock { stompSession = null }
                 connect()
                 Timber.d("Reconnected. Retrying subscription...")
                 return@retry true
@@ -68,7 +83,13 @@ class KoinStomp @Inject constructor(
         try {
             getSession().withJsonConversions().convertAndSend(StompSendHeaders(headers), body, serializer)
         } catch (e: Exception) {
-            Timber.e(e)
+            if (e is CancellationException) {
+                throw e
+            }
+            Timber.e("Websocket send failed: ${e.message}")
+            mutex.withLock { stompSession = null }
+            connect()
+            getSession().withJsonConversions().convertAndSend(StompSendHeaders(headers), body, serializer)
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
+++ b/data/src/main/java/in/koreatech/koin/data/stomp/KoinStomp.kt
@@ -20,7 +20,7 @@ import timber.log.Timber
 
 class KoinStomp @Inject constructor(
     private val baseUrl: String,
-    private val authToken: String,
+    private val tokenProvider: suspend () -> String,
     private val stompClient: StompClient
 ) {
     private val mutex = Mutex()
@@ -34,6 +34,7 @@ class KoinStomp @Inject constructor(
             }
 
             Timber.d("Connecting to STOMP...")
+            val authToken = tokenProvider()
             stompClient.connect(
                 url = "${baseUrl.replaceFirst("https", "wss")}/ws-stomp",
                 customStompConnectHeaders = mapOf("Authorization" to authToken)

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
@@ -82,10 +82,6 @@ fun ChatList(
         viewModel.fetchChatList()
     }
 
-    LifecycleEventEffect(Lifecycle.Event.ON_PAUSE) {
-        viewModel.disconnectWS()
-    }
-
     Scaffold(
         snackbarHost = {
             SnackbarHost(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
@@ -11,11 +11,16 @@ import `in`.koreatech.koin.domain.usecase.chat.SubscribeChatListUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import java.net.UnknownHostException
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.hildan.krossbow.stomp.LostReceiptException
 import org.hildan.krossbow.websocket.WebSocketConnectionException
 import org.orbitmvi.orbit.ContainerHost
@@ -34,6 +39,8 @@ class ChatListViewModel @Inject constructor(
 ) : ViewModel(), ContainerHost<ChatListState, ChatListSideEffect> {
     override val container = container<ChatListState, ChatListSideEffect>(ChatListState())
 
+    private val job = SupervisorJob()
+    private val coroutineScope = CoroutineScope(Dispatchers.IO + job)
     private val _connectChannel = Channel<Boolean>()
     val connectChannel = _connectChannel.receiveAsFlow()
 
@@ -85,14 +92,20 @@ class ChatListViewModel @Inject constructor(
         }
     }
 
-    fun disconnectWS() = intent { // We need to disconnect websocket on onCleared. So, we need to use coroutineScope instead of viewModelScope
-        chatWSDisconnectUseCase().onFailure {
-            // Sometimes the server closes the connection too quickly to send a RECEIPT, which is not really an error
-            // So, we can ignore LostReceiptException
-            // http://stomp.github.io/stomp-specification-1.2.html#Connection_Lingering
-            if (it !is LostReceiptException) {
-                Timber.e(it)
+    private suspend fun disconnectWS() {
+        try {
+            withTimeout(DISCONNECT_TIMEOUT_MS) {
+                chatWSDisconnectUseCase().onFailure {
+                    // Sometimes the server closes the connection too quickly to send a RECEIPT, which is not really an error
+                    // So, we can ignore LostReceiptException
+                    // http://stomp.github.io/stomp-specification-1.2.html#Connection_Lingering
+                    if (it !is LostReceiptException) {
+                        Timber.e(it)
+                    }
+                }
             }
+        } catch (_: TimeoutCancellationException) {
+            Timber.w("WebSocket disconnect timed out after ${DISCONNECT_TIMEOUT_MS}ms, continuing cleanup")
         }
     }
 
@@ -122,5 +135,20 @@ class ChatListViewModel @Inject constructor(
                 state.copy(chatList = data)
             }
         }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        coroutineScope.launch {
+            try {
+                disconnectWS()
+            } finally {
+                job.cancel()
+            }
+        }
+    }
+
+    companion object {
+        private const val DISCONNECT_TIMEOUT_MS = 5000L
     }
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoom.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoom.kt
@@ -192,6 +192,14 @@ fun handleSideEffect(
             ).show()
         }
 
+        ChatRoomSideEffect.FailedToSendMessage -> {
+            Toast.makeText(
+                context,
+                context.getString(R.string.failed_to_send_message),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
         ChatRoomSideEffect.FailedToUploadImage -> {
             Toast.makeText(
                 context,

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomSideEffect.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomSideEffect.kt
@@ -3,6 +3,8 @@ package `in`.koreatech.koin.feature.chat.ui.room
 sealed class ChatRoomSideEffect {
     data object FailedToConnectWS : ChatRoomSideEffect()
 
+    data object FailedToSendMessage : ChatRoomSideEffect()
+
     data object FailedToUploadImage : ChatRoomSideEffect()
 
     data object BlockUserSuccess : ChatRoomSideEffect()

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
@@ -27,11 +27,13 @@ import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeout
 import org.hildan.krossbow.stomp.LostReceiptException
 import org.hildan.krossbow.websocket.WebSocketConnectionException
 import org.hildan.krossbow.websocket.reconnection.WebSocketReconnectionException
@@ -231,11 +233,15 @@ class ChatRoomViewModel @Inject constructor(
                     timestamp = LocalDateTime.now().toString(),
                     isImage = true
                 )
-            )
-            reduce {
-                state.copy(
-                    uploadingImage = state.uploadingImage.filter { it.content != imageUri.toString() }
-                )
+            ).onSuccess {
+                reduce {
+                    state.copy(
+                        uploadingImage = state.uploadingImage.filter { it.content != imageUri.toString() }
+                    )
+                }
+            }.onFailure {
+                Timber.e(it)
+                postSideEffect(ChatRoomSideEffect.FailedToSendMessage)
             }
         }.onFailure {
             postSideEffect(ChatRoomSideEffect.FailedToUploadImage)
@@ -293,9 +299,13 @@ class ChatRoomViewModel @Inject constructor(
                 timestamp = LocalDateTime.now().toString(),
                 isImage = false
             )
-        )
-        reduce {
-            state.copy(chatInputValue = "")
+        ).onSuccess {
+            reduce {
+                state.copy(chatInputValue = "")
+            }
+        }.onFailure {
+            Timber.e(it)
+            postSideEffect(ChatRoomSideEffect.FailedToSendMessage)
         }
     }
 

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/ChatRoomViewModel.kt
@@ -193,14 +193,21 @@ class ChatRoomViewModel @Inject constructor(
         }
     }
 
-    fun disconnectWS() = coroutineScope.launch { // We need to disconnect websocket on onCleared. So, we need to use coroutineScope instead of viewModelScope
-        chatWSDisconnectUseCase().onFailure {
-            // Sometimes the server closes the connection too quickly to send a RECEIPT, which is not really an error
-            // So, we can ignore LostReceiptException
-            // http://stomp.github.io/stomp-specification-1.2.html#Connection_Lingering
-            if (it !is LostReceiptException) {
-                Timber.e(it)
+    private suspend fun disconnectWS() {
+        // We need to disconnect websocket on onCleared. So, we need to use coroutineScope instead of viewModelScope
+        try {
+            withTimeout(DISCONNECT_TIMEOUT_MS) {
+                chatWSDisconnectUseCase().onFailure {
+                    // Sometimes the server closes the connection too quickly to send a RECEIPT, which is not really an error
+                    // So, we can ignore LostReceiptException
+                    // http://stomp.github.io/stomp-specification-1.2.html#Connection_Lingering
+                    if (it !is LostReceiptException) {
+                        Timber.e(it)
+                    }
+                }
             }
+        } catch (e: TimeoutCancellationException) {
+            Timber.w("WebSocket disconnect timed out after ${DISCONNECT_TIMEOUT_MS}ms, continuing cleanup")
         }
     }
 
@@ -326,7 +333,13 @@ class ChatRoomViewModel @Inject constructor(
 
     override fun onCleared() {
         super.onCleared()
-        disconnectWS() // We need to disconnect websocket on onCleared. So, don't call job.cancel() manually.
+        coroutineScope.launch {
+            try {
+                disconnectWS()
+            } finally {
+                job.cancel()
+            }
+        }
     }
 
     fun changeBlockDialogState(dialogState: Boolean) = intent {
@@ -350,5 +363,6 @@ class ChatRoomViewModel @Inject constructor(
     companion object {
         const val ARTICLE_ID = "article_id"
         const val CHAT_ROOM_ID = "chat_room_id"
+        private const val DISCONNECT_TIMEOUT_MS = 5000L
     }
 }

--- a/feature/chat/src/main/res/values/strings.xml
+++ b/feature/chat/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="chat_toolbar_more">더보기</string>
     <string name="failed_to_upload_image">이미지를 업로드하지 못했습니다</string>
     <string name="failed_to_connect_to_server">서버에 연결하지 못했습니다</string>
+    <string name="failed_to_send_message">메시지를 전송하지 못했습니다</string>
     <string name="failed_to_block_user">사용자 차단에 실패했습니다</string>
     <string name="block_dialog_title">이 사용자를 차단하시겠습니까?</string>
     <string name="block_dialog_description">쪽지 수신 및 발신이 모두 차단됩니다.</string>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1264 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- race condition 방지를 위해 mutex lock을 적용했습니다.
- access token을 `runBlocking`이 아닌 suspend lambda로 넘기도록 수정했습니다.
- 메시지 발송 실패 시 토스트를 띄우도록 수정했습니다.
- `onCleared`에서 `disconnectWS`를 호출할 때, 정상적으로 완료되지 않아 memory leak이 발생하는 것을 방지하기 위해 `finally`에서 job.cancel()을 호출하도록 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다