### PR TITLE
[Koin Project][fix] 분실물 상세 페이지 text overflow 추가

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailHeader.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/component/DetailHeader.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.feature.lostandfound.ui.detail.component
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -11,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.component.LostItemTypeChip
@@ -52,13 +52,15 @@ fun DetailHeader(
         ) {
             LostItemTypeChip(category = category)
             Text(
-                modifier = Modifier.padding(start = 8.dp),
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(horizontal = 8.dp),
                 text = headerText,
                 fontWeight = FontWeight(500),
-                style = KoinTheme.typography.medium14
+                style = KoinTheme.typography.medium14,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis
             )
-
-            Spacer(modifier = Modifier.weight(1f))
 
             LostAndFoundStatusChip(
                 isFound = isFound


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1266

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 분실물 상세 페이지 text에 overflow를 추가하였습니다.
- 텍스트 줄 수를 3줄로 제한하였습니다.

### 논의 사항

### 스크린샷
<img width="250" height="200" alt="스크린샷 2026-02-10 오후 4 55 02" src="https://github.com/user-attachments/assets/ee90c1be-2ad4-422f-96f3-5f507aba709d" />


## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다