### PR TITLE
[Koin Project][Feature] AB 테스트 캐싱 로직 적용

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.ktlint) apply false
     alias(libs.plugins.compose.compiler) apply false
+    alias(libs.plugins.room) apply false
 }
 
 tasks.register<Delete>("clean") {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.koin.library)
     alias(libs.plugins.koin.hilt)
     alias(libs.plugins.kotlinx.serialization)
+    alias(libs.plugins.room)
 }
 
 android {
@@ -27,6 +28,11 @@ android {
             )
             buildConfigField("Boolean", "IS_DEBUG", "false")
         }
+    }
+
+    room {
+        schemaDirectory("debug", "$projectDir/schemas/debug")
+        schemaDirectory("$projectDir/schemas")
     }
 }
 

--- a/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/1.json
+++ b/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/1.json
@@ -1,0 +1,67 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "7787ae8e9cdeac716963c38fb24f1cf8",
+    "entities": [
+      {
+        "tableName": "cache_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `updated_time` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTime",
+            "columnName": "updated_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "store_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `image_url` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7787ae8e9cdeac716963c38fb24f1cf8')"
+    ]
+  }
+}

--- a/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/2.json
+++ b/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "b91f6eee3368376b81c32f62251f2baa",
+    "identityHash": "eb860deac68dac11585d27f75248f720",
     "entities": [
       {
         "tableName": "cache_metadata",
@@ -60,7 +60,7 @@
       },
       {
         "tableName": "abtest",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`, `access_history_id`))",
         "fields": [
           {
             "fieldPath": "title",
@@ -84,14 +84,15 @@
         "primaryKey": {
           "autoGenerate": false,
           "columnNames": [
-            "title"
+            "title",
+            "access_history_id"
           ]
         }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b91f6eee3368376b81c32f62251f2baa')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eb860deac68dac11585d27f75248f720')"
     ]
   }
 }

--- a/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/2.json
+++ b/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/2.json
@@ -1,0 +1,97 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "b91f6eee3368376b81c32f62251f2baa",
+    "entities": [
+      {
+        "tableName": "cache_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `updated_time` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTime",
+            "columnName": "updated_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "store_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `image_url` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "abtest",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessHistoryId",
+            "columnName": "access_history_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "variableName",
+            "columnName": "variable_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "title"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b91f6eee3368376b81c32f62251f2baa')"
+    ]
+  }
+}

--- a/data/schemas/in.koreatech.koin.data.db.AppDatabase/1.json
+++ b/data/schemas/in.koreatech.koin.data.db.AppDatabase/1.json
@@ -1,0 +1,67 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 1,
+    "identityHash": "7787ae8e9cdeac716963c38fb24f1cf8",
+    "entities": [
+      {
+        "tableName": "cache_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `updated_time` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTime",
+            "columnName": "updated_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "store_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `image_url` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7787ae8e9cdeac716963c38fb24f1cf8')"
+    ]
+  }
+}

--- a/data/schemas/in.koreatech.koin.data.db.AppDatabase/2.json
+++ b/data/schemas/in.koreatech.koin.data.db.AppDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "b91f6eee3368376b81c32f62251f2baa",
+    "identityHash": "eb860deac68dac11585d27f75248f720",
     "entities": [
       {
         "tableName": "cache_metadata",
@@ -60,7 +60,7 @@
       },
       {
         "tableName": "abtest",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`, `access_history_id`))",
         "fields": [
           {
             "fieldPath": "title",
@@ -84,14 +84,15 @@
         "primaryKey": {
           "autoGenerate": false,
           "columnNames": [
-            "title"
+            "title",
+            "access_history_id"
           ]
         }
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b91f6eee3368376b81c32f62251f2baa')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'eb860deac68dac11585d27f75248f720')"
     ]
   }
 }

--- a/data/schemas/in.koreatech.koin.data.db.AppDatabase/2.json
+++ b/data/schemas/in.koreatech.koin.data.db.AppDatabase/2.json
@@ -1,0 +1,97 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "b91f6eee3368376b81c32f62251f2baa",
+    "entities": [
+      {
+        "tableName": "cache_metadata",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `updated_time` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedTime",
+            "columnName": "updated_time",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        }
+      },
+      {
+        "tableName": "store_categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `image_url` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "image_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "abtest",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `access_history_id` TEXT NOT NULL, `variable_name` TEXT NOT NULL, PRIMARY KEY(`title`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accessHistoryId",
+            "columnName": "access_history_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "variableName",
+            "columnName": "variable_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "title"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'b91f6eee3368376b81c32f62251f2baa')"
+    ]
+  }
+}

--- a/data/src/main/java/in/koreatech/koin/data/constant/DBConstant.kt
+++ b/data/src/main/java/in/koreatech/koin/data/constant/DBConstant.kt
@@ -3,4 +3,5 @@ package `in`.koreatech.koin.data.constant
 object DBConstant {
     const val CACHE_METADATA = "cache_metadata"
     const val STORE_CATEGORIES = "store_categories"
+    const val ABTEST = "abtest"
 }

--- a/data/src/main/java/in/koreatech/koin/data/dao/ABTestDao.kt
+++ b/data/src/main/java/in/koreatech/koin/data/dao/ABTestDao.kt
@@ -1,0 +1,17 @@
+package `in`.koreatech.koin.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import `in`.koreatech.koin.data.constant.DBConstant
+import `in`.koreatech.koin.data.entity.ABTestEntity
+
+@Dao
+interface ABTestDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(abTestEntity: ABTestEntity)
+
+    @Query("SELECT * FROM ${DBConstant.ABTEST} WHERE title = :title AND access_history_id = :accessHistoryId")
+    suspend fun getABTest(title: String, accessHistoryId: String): ABTestEntity?
+}

--- a/data/src/main/java/in/koreatech/koin/data/db/AppDatabase.kt
+++ b/data/src/main/java/in/koreatech/koin/data/db/AppDatabase.kt
@@ -1,14 +1,24 @@
 package `in`.koreatech.koin.data.db
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
+import `in`.koreatech.koin.data.dao.ABTestDao
 import `in`.koreatech.koin.data.dao.CacheMetadataDao
 import `in`.koreatech.koin.data.dao.StoreCategoriesDao
+import `in`.koreatech.koin.data.entity.ABTestEntity
 import `in`.koreatech.koin.data.entity.CacheMetadataEntity
 import `in`.koreatech.koin.data.entity.StoreCategoriesEntity
 
-@Database(entities = [CacheMetadataEntity::class, StoreCategoriesEntity::class], version = 1)
+@Database(
+    entities = [CacheMetadataEntity::class, StoreCategoriesEntity::class, ABTestEntity::class],
+    version = 2,
+    autoMigrations = [
+        AutoMigration(from = 1, to = 2)
+    ]
+)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cacheMetadataDao(): CacheMetadataDao
     abstract fun storeCategoriesDao(): StoreCategoriesDao
+    abstract fun abTestDao(): ABTestDao
 }

--- a/data/src/main/java/in/koreatech/koin/data/di/database/DatabaseModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/database/DatabaseModule.kt
@@ -7,6 +7,7 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import `in`.koreatech.koin.data.dao.ABTestDao
 import `in`.koreatech.koin.data.dao.CacheMetadataDao
 import `in`.koreatech.koin.data.dao.StoreCategoriesDao
 import `in`.koreatech.koin.data.db.AppDatabase
@@ -37,5 +38,11 @@ object DatabaseModule {
     @Singleton
     fun provideStoreCategoriesDao(appDatabase: AppDatabase): StoreCategoriesDao {
         return appDatabase.storeCategoriesDao()
+    }
+
+    @Provides
+    @Singleton
+    fun provideAbTestDao(appDatabase: AppDatabase): ABTestDao {
+        return appDatabase.abTestDao()
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/di/source/LocalDataSourceModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/source/LocalDataSourceModule.kt
@@ -7,6 +7,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import `in`.koreatech.koin.core.qualifier.IoDispatcher
+import `in`.koreatech.koin.data.dao.ABTestDao
 import `in`.koreatech.koin.data.dao.CacheMetadataDao
 import `in`.koreatech.koin.data.dao.StoreCategoriesDao
 import `in`.koreatech.koin.data.source.datastore.ArticleDataStore
@@ -65,9 +66,10 @@ object LocalDataSourceModule {
     @Provides
     @Singleton
     fun provideUserLocalDataSource(
-        @ApplicationContext applicationContext: Context
+        @ApplicationContext applicationContext: Context,
+        abTestDao: ABTestDao
     ): UserLocalDataSource {
-        return UserLocalDataSource(applicationContext)
+        return UserLocalDataSource(applicationContext, abTestDao)
     }
 
     @Provides

--- a/data/src/main/java/in/koreatech/koin/data/entity/ABTestEntity.kt
+++ b/data/src/main/java/in/koreatech/koin/data/entity/ABTestEntity.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.data.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import `in`.koreatech.koin.data.constant.DBConstant
+
+@Entity(tableName = DBConstant.ABTEST)
+data class ABTestEntity(
+    @PrimaryKey val title: String,
+    @ColumnInfo(name = "access_history_id") val accessHistoryId: String,
+    @ColumnInfo(name = "variable_name") val variableName: String
+)

--- a/data/src/main/java/in/koreatech/koin/data/entity/ABTestEntity.kt
+++ b/data/src/main/java/in/koreatech/koin/data/entity/ABTestEntity.kt
@@ -2,12 +2,14 @@ package `in`.koreatech.koin.data.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
-import androidx.room.PrimaryKey
 import `in`.koreatech.koin.data.constant.DBConstant
 
-@Entity(tableName = DBConstant.ABTEST)
+@Entity(
+    tableName = DBConstant.ABTEST,
+    primaryKeys = ["title", "access_history_id"]
+)
 data class ABTestEntity(
-    @PrimaryKey val title: String,
+    @ColumnInfo(name = "title") val title: String,
     @ColumnInfo(name = "access_history_id") val accessHistoryId: String,
     @ColumnInfo(name = "variable_name") val variableName: String
 )

--- a/data/src/main/java/in/koreatech/koin/data/mapper/UserMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/UserMapper.kt
@@ -1,11 +1,13 @@
 package `in`.koreatech.koin.data.mapper
 
+import `in`.koreatech.koin.data.entity.ABTestEntity
 import `in`.koreatech.koin.data.request.user.GeneralUserRequest
 import `in`.koreatech.koin.data.request.user.StudentUserRequest
 import `in`.koreatech.koin.data.response.user.CodeRequestCountResponse
 import `in`.koreatech.koin.data.response.user.GeneralUserResponse
 import `in`.koreatech.koin.data.response.user.RefreshResponse
 import `in`.koreatech.koin.data.response.user.StudentUserResponse
+import `in`.koreatech.koin.domain.model.user.ABTest
 import `in`.koreatech.koin.domain.model.user.AuthToken
 import `in`.koreatech.koin.domain.model.user.CodeCount
 import `in`.koreatech.koin.domain.model.user.Gender
@@ -141,3 +143,8 @@ fun CodeRequestCountResponse.toCodeCount() =
         remainingCount = this.remainingCount,
         currentCount = this.currentCount
     )
+
+fun ABTestEntity.toABTest() = ABTest(
+    variableName = variableName,
+    accessHistoryId = accessHistoryId
+)

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -199,10 +199,13 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun postABTestAssign(title: String): ABTest {
-        userRemoteDataSource.postABTestAssign(ABTestRequest(title)).let {
-            userLocalDataSource.insertCachedABTest(title, it.accessHistoryId, it.variableName)
-            return ABTest(it.variableName, it.accessHistoryId)
+        val (variableName, accessHistoryId) = userRemoteDataSource.postABTestAssign(ABTestRequest(title))
+
+        runCatching {
+            userLocalDataSource.insertCachedABTest(title, accessHistoryId, variableName)
         }
+
+        return ABTest(variableName, accessHistoryId)
     }
 
     override suspend fun getCachedABTest(title: String): ABTest {

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -200,8 +200,14 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun postABTestAssign(title: String): ABTest {
         userRemoteDataSource.postABTestAssign(ABTestRequest(title)).let {
+            userLocalDataSource.insertCachedABTest(title, it.accessHistoryId, it.variableName)
             return ABTest(it.variableName, it.accessHistoryId)
         }
+    }
+
+    override suspend fun getCachedABTest(title: String): ABTest {
+        val accessHistoryId = tokenLocalDataSource.getAccessHistoryId() ?: throw IllegalStateException("Access history id is not found")
+        return userLocalDataSource.getCachedABTest(title, accessHistoryId)
     }
 
     override suspend fun updateUserPassword(

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.safeApiCall
 import `in`.koreatech.koin.data.mapper.toCodeCount
 import `in`.koreatech.koin.data.mapper.toUser
 import `in`.koreatech.koin.data.mapper.toUserRequest
@@ -201,7 +202,7 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun postABTestAssign(title: String): ABTest {
         val (variableName, accessHistoryId) = userRemoteDataSource.postABTestAssign(ABTestRequest(title))
 
-        runCatching {
+        safeApiCall {
             userLocalDataSource.insertCachedABTest(title, accessHistoryId, variableName)
         }
 

--- a/data/src/main/java/in/koreatech/koin/data/source/local/UserLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/UserLocalDataSource.kt
@@ -9,10 +9,14 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.google.gson.Gson
 import dagger.hilt.android.qualifiers.ApplicationContext
+import `in`.koreatech.koin.data.dao.ABTestDao
+import `in`.koreatech.koin.data.entity.ABTestEntity
+import `in`.koreatech.koin.data.mapper.toABTest
 import `in`.koreatech.koin.data.mapper.toInt
 import `in`.koreatech.koin.data.mapper.toUser
 import `in`.koreatech.koin.data.response.user.GeneralUserResponse
 import `in`.koreatech.koin.data.response.user.StudentUserResponse
+import `in`.koreatech.koin.domain.model.user.ABTest
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.model.user.UserType
 import javax.inject.Inject
@@ -20,7 +24,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
 class UserLocalDataSource @Inject constructor(
-    @ApplicationContext applicationContext: Context
+    @ApplicationContext applicationContext: Context,
+    private val abTestDao: ABTestDao
 ) {
     private val Context.userDataStore: DataStore<Preferences> by preferencesDataStore(
         name = PREF_NAME
@@ -130,6 +135,14 @@ class UserLocalDataSource @Inject constructor(
                     }
                 }
         }
+    }
+
+    suspend fun getCachedABTest(title: String, accessHistoryId: String): ABTest {
+        return abTestDao.getABTest(title, accessHistoryId)?.toABTest() ?: throw IllegalStateException("No cached AB Test")
+    }
+
+    suspend fun insertCachedABTest(title: String, accessHistoryId: String, variableName: String) {
+        abTestDao.insert(ABTestEntity(title, accessHistoryId, variableName))
     }
 
     private companion object {

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
@@ -49,6 +49,8 @@ interface UserRepository {
 
     suspend fun postABTestAssign(title: String): ABTest
 
+    suspend fun getCachedABTest(title: String): ABTest
+
     suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount>
 
     suspend fun requestEmailVerification(email: String): Result<CodeCount>

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
@@ -20,6 +20,8 @@ class ABTestUseCase @Inject constructor(
                 }
             }
             userRepository.postABTestAssign(title).variableName
+        }.recoverCatching {
+            userRepository.getCachedABTest(title).variableName
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
@@ -21,6 +21,8 @@ class ABTestUseCase @Inject constructor(
                 }
             }
             userRepository.postABTestAssign(title).variableName
+        }.onFailure {
+            if (it is CancellationException) throw it
         }.recoverCatching {
             userRepository.getCachedABTest(title).variableName
         }.onFailure {

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/ABTestUseCase.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.domain.usecase.user
 import `in`.koreatech.koin.domain.repository.TokenRepository
 import `in`.koreatech.koin.domain.repository.UserRepository
 import javax.inject.Inject
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
@@ -22,6 +23,8 @@ class ABTestUseCase @Inject constructor(
             userRepository.postABTestAssign(title).variableName
         }.recoverCatching {
             userRepository.getCachedABTest(title).variableName
+        }.onFailure {
+            if (it is CancellationException) throw it
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -108,8 +108,8 @@ androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navi
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "androidxNavigation" }
 androidx-navigation-dynamic-features-fragment = { group = "androidx.navigation", name = "navigation-dynamic-features-fragment", version.ref = "androidxNavigation" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidxRecyclerview" }
-androidx-room-compiler = { group = "androidx.room", name="room-compiler", version.ref = "androidxRoom" }
-androidx-room-ktx = { group = "androidx.room", name="room-ktx", version.ref="androidxRoom" }
+androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "androidxRoom" }
+androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "androidxRoom" }
 androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidxSecurityCrypto" }
 androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxTestEspresso" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestJunit" }
@@ -207,7 +207,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 oss-license-plugin = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
-room = { id = "androidx.room", version.ref = "androidxRoom"}
+room = { id = "androidx.room", version.ref = "androidxRoom" }
 
 koin-application = { id = "in.koreatech.plugin.application" }
 koin-feature = { id = "in.koreatech.plugin.feature" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -207,6 +207,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 oss-license-plugin = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
+room = { id = "androidx.room", version.ref = "androidxRoom"}
 
 koin-application = { id = "in.koreatech.plugin.application" }
 koin-feature = { id = "in.koreatech.plugin.feature" }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1270

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- AB 테스트에 캐싱을 추가했습니다.
- 기존 AB 테스트의 경우, 네트워크 실패 등의 사유로 인해 AB 테스트 결과를 받아오지 못했을 경우, 무조건 A안이 적용되는 문제가 있었습니다.
- 따라서, 종료된 AB 테스트거나, B안인 경우에도 네트워크 요청이 실패할 경우 A안이 적용되는 문제가 있었습니다.
- 이를 해결하기 위해, AB 테스트를 API로부터 받아올 때, Room을 활용해 캐싱하도록 수정했습니다.
- 만약 캐싱된 데이터가 없는 상태로 요청이 실패할 경우, 기존과 동일하게 A안이 적용됩니다.
- Room schemaDirectory를 추가했습니다.
- DB 버전을 1에서 2로 올리고, automigration을 적용했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다