### PR TITLE
[Koin Project][Refactor] 일부 Repository를 mapHttpException으로 리팩토링

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -6,6 +6,7 @@ import `in`.koreatech.koin.data.response.article.ArticleKeywordWrapperResponse
 import `in`.koreatech.koin.data.source.local.ArticleLocalDataSource
 import `in`.koreatech.koin.data.source.remote.ArticleRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
+import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.article.KoinArticleException
 import `in`.koreatech.koin.domain.model.article.Article
@@ -289,14 +290,7 @@ class ArticleRepositoryImpl @Inject constructor(
     override suspend fun fetchArticleLostAndFoundStats(): Result<ArticleLostAndFoundStats> {
         return runCatching {
             articleRemoteDataSource.fetchArticleLostAndFoundStats().toArticleLostAndFoundStats()
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> exception.getErrorResponse().toKoinUnknownErrorException()
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 
     override suspend fun updateItemFound(
@@ -309,14 +303,7 @@ class ArticleRepositoryImpl @Inject constructor(
             } else {
                 throw HttpException(response)
             }
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> exception.getErrorResponse().toKoinUnknownErrorException()
-                    else -> exception
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 
     override suspend fun modifyArticleLostAndFound(
@@ -345,21 +332,11 @@ class ArticleRepositoryImpl @Inject constructor(
             } else {
                 throw HttpException(response)
             }
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            400 -> KoinArticleException.CanNotFoundItemException()
-                            401 -> KoinArticleException.UnauthorizedUserException()
-                            403 -> KoinArticleException.ForbiddenAuthor()
-                            404 -> KoinArticleException.NotFoundImage()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-                    else -> exception
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinArticleException.CanNotFoundItemException()
+            on(401) throws KoinArticleException.UnauthorizedUserException()
+            on(403) throws KoinArticleException.ForbiddenAuthor()
+            on(404) throws KoinArticleException.NotFoundImage()
         }
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -5,9 +5,7 @@ import `in`.koreatech.koin.data.request.article.toRequest
 import `in`.koreatech.koin.data.response.article.ArticleKeywordWrapperResponse
 import `in`.koreatech.koin.data.source.local.ArticleLocalDataSource
 import `in`.koreatech.koin.data.source.remote.ArticleRemoteDataSource
-import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.data.util.mapHttpFailure
-import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.article.KoinArticleException
 import `in`.koreatech.koin.domain.model.article.Article
 import `in`.koreatech.koin.domain.model.article.ArticleHeader
@@ -290,7 +288,7 @@ class ArticleRepositoryImpl @Inject constructor(
     override suspend fun fetchArticleLostAndFoundStats(): Result<ArticleLostAndFoundStats> {
         return runCatching {
             articleRemoteDataSource.fetchArticleLostAndFoundStats().toArticleLostAndFoundStats()
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 
     override suspend fun updateItemFound(
@@ -303,7 +301,7 @@ class ArticleRepositoryImpl @Inject constructor(
             } else {
                 throw HttpException(response)
             }
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 
     override suspend fun modifyArticleLostAndFound(

--- a/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.data.repository
 import `in`.koreatech.koin.data.mapper.toChatMessageRequest
 import `in`.koreatech.koin.data.response.chat.toChatListItem
 import `in`.koreatech.koin.data.source.remote.ChatRemoteDataSource
+import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.domain.error.chat.KoinChatException
 import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import `in`.koreatech.koin.domain.model.chat.ChatMessage
@@ -35,17 +36,11 @@ class ChatRepositoryImpl @Inject constructor(
     override suspend fun getChatRoomFromArticleId(articleId: Int): Result<ChatRoom> {
         return runCatching {
             chatRemoteDataSource.getChatRoomFromArticleId(articleId).toChatRoom()
+        }.mapHttpFailure {
+            on(403) throws KoinChatException.BlockedException()
         }.onFailure {
             return Result.failure(
                 when (it) {
-                    is HttpException -> {
-                        if (it.code() == 403) {
-                            KoinChatException.BlockedException()
-                        } else {
-                            it
-                        }
-                    }
-
                     is CancellationException -> throw it
                     else -> it
                 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ChatRepositoryImpl.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import retrofit2.HttpException
 
 class ChatRepositoryImpl @Inject constructor(
     private val chatRemoteDataSource: ChatRemoteDataSource

--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -10,6 +10,7 @@ import `in`.koreatech.koin.data.request.user.StudentInfoRequestV2
 import `in`.koreatech.koin.data.source.local.SignupTermsLocalDataSource
 import `in`.koreatech.koin.data.source.remote.UserRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
+import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.signup.SignupAlreadySentEmailException
 import `in`.koreatech.koin.domain.error.user.KoinUserException
@@ -89,40 +90,18 @@ class SignupRepositoryImpl @Inject constructor(
     override suspend fun isUsernameDuplicatedV2(nickname: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkNicknameV2(nickname)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            409 -> KoinUserException.NicknameConflictException()
-                            400 -> KoinUserException.NicknameInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.NicknameInvalidException()
+            on(409) throws KoinUserException.NicknameConflictException()
         }
     }
 
     override suspend fun isPhoneDuplicated(phone: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkPhoneNumberDuplicate(phone)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            409 -> KoinUserException.PhoneNumberConflictException()
-                            400 -> KoinUserException.PhoneNumberInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.PhoneNumberInvalidException()
+            on(409) throws KoinUserException.PhoneNumberConflictException()
         }
     }
 
@@ -160,40 +139,18 @@ class SignupRepositoryImpl @Inject constructor(
     override suspend fun isLoginIdDuplicated(loginId: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkLoginId(loginId)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            409 -> KoinUserException.LoginIdConflictException()
-                            400 -> KoinUserException.LoginIdInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginIdInvalidException()
+            on(409) throws KoinUserException.LoginIdConflictException()
         }
     }
 
     override suspend fun isEmailDuplicated(email: String): Result<Unit> {
         return runCatching {
             userRemoteDataSource.checkEmail(email)
-        }.onFailure { exception ->
-            return Result.failure(
-                when (exception) {
-                    is HttpException -> {
-                        when (exception.code()) {
-                            409 -> KoinUserException.EmailConflictException()
-                            400 -> KoinUserException.EmailInvalidException()
-                            else -> exception.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> exception
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.EmailInvalidException()
+            on(409) throws KoinUserException.EmailConflictException()
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/SignupRepositoryImpl.kt
@@ -11,7 +11,6 @@ import `in`.koreatech.koin.data.source.local.SignupTermsLocalDataSource
 import `in`.koreatech.koin.data.source.remote.UserRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.data.util.mapHttpFailure
-import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.signup.SignupAlreadySentEmailException
 import `in`.koreatech.koin.domain.error.user.KoinUserException
 import `in`.koreatech.koin.domain.model.term.Term

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -35,6 +35,7 @@ import `in`.koreatech.koin.data.source.local.CacheLocalDataSource
 import `in`.koreatech.koin.data.source.local.StoreLocalDataSource
 import `in`.koreatech.koin.data.source.remote.StoreRemoteDataSource
 import `in`.koreatech.koin.data.util.getErrorResponse
+import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.store.KoinStoreException
 import `in`.koreatech.koin.domain.model.owner.menu.StoreMenuCategory
@@ -248,17 +249,7 @@ class StoreRepositoryImpl @Inject constructor(
     override suspend fun getShopSearchRelatedListV2(keyword: String): Result<OrderableShopSearchRelated> {
         return runCatching {
             storeRemoteDataSource.getShopSearchRelatedV2(keyword).toOrderableShopSearchRelated()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        e.getErrorResponse().toKoinUnknownErrorException()
-                    }
-
-                    else -> e
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 
     override suspend fun getOrderableShops(
@@ -269,19 +260,8 @@ class StoreRepositoryImpl @Inject constructor(
     ): Result<List<Shop>> {
         return runCatching {
             storeRemoteDataSource.getOrderableShops(sorter, filter, categoryFilter, minimumOrderAmount).map { it.toShop() }
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
@@ -292,359 +272,152 @@ class StoreRepositoryImpl @Inject constructor(
             }.map {
                 it.toShop()
             }
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopSummary(shopId).toShopSummary()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopDetail(shopId: Int): Result<ShopDetail> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopDetail(shopId).toShopDetail()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopDelivery(shopId: Int): Result<ShopDeliveryAvailable> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopDelivery(shopId).toShopDeliveryAvailable()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopMenus(shopId: Int): Result<List<ShopMenus>> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopMenus(shopId).map { it.toShopMenus() }
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopMenu(shopId: Int, menuId: Int): Result<ShopMenu> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopMenu(shopId, menuId).toShopMenu()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.MenuNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.MenuNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopMenuGroups(shopId: Int): Result<List<ShopMenusGroup>> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopMenuGroups(shopId).map { it.toShopMenusGroup() }
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            404 -> KoinStoreException.ShopNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(404) throws KoinStoreException.ShopNotFoundException()
         }
     }
 
     override suspend fun getOrderableShopSearchRelated(query: String): Result<OrderableShopSearchRelated> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopSearchRelated(query).toOrderableShopSearchRelated()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        e.getErrorResponse().toKoinUnknownErrorException()
-                    }
-
-                    else -> e
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 
     override suspend fun updateCartItem(cartMenuItemId: Int, cartItem: CartItem): Result<Unit> {
         return runCatching {
             storeRemoteDataSource.updateCartItem(cartMenuItemId, cartItem.toCartItemRequest())
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> when (e.getErrorResponse().code) {
-                                "REQUIRED_OPTION_GROUP_MISSING" -> KoinStoreException.RequiredOptionGroupMissingException()
-                                "MIN_SELECTION_NOT_MET" -> KoinStoreException.MinimumSelectionNotMetException()
-                                "MAX_SELECTION_EXCEEDED" -> KoinStoreException.MaxSelectionExceededException()
-                                "INVALID_OPTION_IN_GROUP" -> KoinStoreException.InvalidOptionInGroupException()
-                                else -> KoinStoreException.BadRequestException()
-                            }
-
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> when (e.getErrorResponse().code) {
-                                "CART_MENU_ITEM_NOT_FOUND" -> KoinStoreException.CartItemNotFoundException()
-                                "MENU_OPTION_NOT_FOUND" -> KoinStoreException.MenuOptionNotFoundException()
-                                "MENU_PRICE_NOT_FOUND" -> KoinStoreException.MenuPriceNotFoundException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400, "REQUIRED_OPTION_GROUP_MISSING") throws KoinStoreException.RequiredOptionGroupMissingException()
+            on(400, "MIN_SELECTION_NOT_MET") throws KoinStoreException.MinimumSelectionNotMetException()
+            on(400, "MAX_SELECTION_EXCEEDED") throws KoinStoreException.MaxSelectionExceededException()
+            on(400, "INVALID_OPTION_IN_GROUP") throws KoinStoreException.InvalidOptionInGroupException()
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404, "CART_MENU_ITEM_NOT_FOUND") throws KoinStoreException.CartItemNotFoundException()
+            on(404, "MENU_OPTION_NOT_FOUND") throws KoinStoreException.MenuOptionNotFoundException()
+            on(404, "MENU_PRICE_NOT_FOUND") throws KoinStoreException.MenuPriceNotFoundException()
         }
     }
 
     override suspend fun updateCartItemQuantity(cartMenuItemId: Int, quantity: Int): Result<Unit> {
         return runCatching {
             storeRemoteDataSource.updateCartItemQuantity(cartMenuItemId, quantity)
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> KoinStoreException.InvalidQuantityException()
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> when (e.getErrorResponse().code) {
-                                "CART_MENU_ITEM_NOT_FOUND" -> KoinStoreException.CartItemNotFoundException()
-                                "CART_NOT_FOUND" -> KoinStoreException.CartNotFoundException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400) throws KoinStoreException.InvalidQuantityException()
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404, "CART_MENU_ITEM_NOT_FOUND") throws KoinStoreException.CartItemNotFoundException()
+            on(404, "CART_NOT_FOUND") throws KoinStoreException.CartNotFoundException()
         }
     }
 
     override suspend fun addCartItem(cartAdd: CartAdd): Result<Unit> {
         return runCatching {
             storeRemoteDataSource.addCartItem(cartAdd.toCartAddRequest())
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> when (e.getErrorResponse().code) {
-                                "DIFFERENT_SHOP_ITEM_IN_CART" -> KoinStoreException.DifferentShopItemInCartException()
-                                "MENU_SOLD_OUT" -> KoinStoreException.MenuSoldOutException()
-                                "REQUIRED_OPTION_GROUP_MISSING" -> KoinStoreException.RequiredOptionGroupMissingException()
-                                "MAX_SELECTION_EXCEEDED" -> KoinStoreException.MaxSelectionExceededException()
-                                "INVALID_MENU_IN_SHOP" -> KoinStoreException.InvalidMenuInShopException()
-                                "SHOP_CLOSED" -> KoinStoreException.ShopClosedException()
-                                else -> KoinStoreException.BadRequestException()
-                            }
-
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> when (e.getErrorResponse().code) {
-                                "NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE" -> KoinStoreException.MenuPriceNotFoundException()
-                                "NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION" -> KoinStoreException.MenuOptionNotFoundException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400, "DIFFERENT_SHOP_ITEM_IN_CART") throws KoinStoreException.DifferentShopItemInCartException()
+            on(400, "MENU_SOLD_OUT") throws KoinStoreException.MenuSoldOutException()
+            on(400, "REQUIRED_OPTION_GROUP_MISSING") throws KoinStoreException.RequiredOptionGroupMissingException()
+            on(400, "MAX_SELECTION_EXCEEDED") throws KoinStoreException.MaxSelectionExceededException()
+            on(400, "INVALID_MENU_IN_SHOP") throws KoinStoreException.InvalidMenuInShopException()
+            on(400, "SHOP_CLOSED") throws KoinStoreException.ShopClosedException()
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404, "NOT_FOUND_ORDERABLE_SHOP_MENU_PRICE") throws KoinStoreException.MenuPriceNotFoundException()
+            on(404, "NOT_FOUND_ORDERABLE_SHOP_MENU_OPTION") throws KoinStoreException.MenuOptionNotFoundException()
         }
     }
 
     override suspend fun getCartItems(type: String): Result<Cart> {
         return runCatching {
             storeRemoteDataSource.getCartItems(type).toCart()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> when (e.getErrorResponse().code) {
-                                "SHOP_NOT_DELIVERABLE" -> KoinStoreException.ShopNotDeliverableException()
-                                "SHOP_NOT_TAKEOUT_AVAILABLE" -> KoinStoreException.ShopNotTakeoutAvailableException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            401 -> KoinStoreException.UnauthorizedException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400, "SHOP_NOT_DELIVERABLE") throws KoinStoreException.ShopNotDeliverableException()
+            on(400, "SHOP_NOT_TAKEOUT_AVAILABLE") throws KoinStoreException.ShopNotTakeoutAvailableException()
+            on(401) throws KoinStoreException.UnauthorizedException()
         }
     }
 
     override suspend fun validateCartItems(orderType: String): Result<Unit> {
         return runCatching {
             storeRemoteDataSource.validateCartItems(orderType)
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> when (e.getErrorResponse().code) {
-                                "ORDER_AMOUNT_BELOW_MINIMUM" -> KoinStoreException.OrderAmountBelowMinimumException()
-                                "SHOP_CLOSED" -> KoinStoreException.ShopClosedException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> KoinStoreException.CartNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400, "ORDER_AMOUNT_BELOW_MINIMUM") throws KoinStoreException.OrderAmountBelowMinimumException()
+            on(400, "SHOP_CLOSED") throws KoinStoreException.ShopClosedException()
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404) throws KoinStoreException.CartNotFoundException()
         }
     }
 
     override suspend fun getCartSummary(orderableShopId: Int): Result<CartSummary> {
         return runCatching {
             storeRemoteDataSource.getCartSummary(orderableShopId).toCartSummary()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            401 -> KoinStoreException.UnauthorizedException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(401) throws KoinStoreException.UnauthorizedException()
         }
     }
 
     override suspend fun getCartPaymentSummary(type: String): Result<CartPaymentSummary> {
         return runCatching {
             storeRemoteDataSource.getCartPaymentSummary(type).toCartPaymentSummary()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            400 -> when (e.getErrorResponse().code) {
-                                "SHOP_NOT_DELIVERABLE" -> KoinStoreException.ShopNotDeliverableException()
-                                "SHOP_NOT_TAKEOUT_AVAILABLE" -> KoinStoreException.ShopNotTakeoutAvailableException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            401 -> KoinStoreException.UnauthorizedException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(400, "SHOP_NOT_DELIVERABLE") throws KoinStoreException.ShopNotDeliverableException()
+            on(400, "SHOP_NOT_TAKEOUT_AVAILABLE") throws KoinStoreException.ShopNotTakeoutAvailableException()
+            on(401) throws KoinStoreException.UnauthorizedException()
         }
     }
 
     override suspend fun getCartItemEdit(cartMenuItemId: Int): Result<CartItemEdit> {
         return runCatching {
             storeRemoteDataSource.getCartItemEdit(cartMenuItemId).toCartItemEdit()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> KoinStoreException.CartItemNotFoundException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404) throws KoinStoreException.CartItemNotFoundException()
         }
     }
 
@@ -652,24 +425,9 @@ class StoreRepositoryImpl @Inject constructor(
         return runCatching {
             storeRemoteDataSource.resetCart()
             Unit
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> when (e.getErrorResponse().code) {
-                                "CART_NOT_FOUND" -> KoinStoreException.CartNotFoundException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404, "CART_NOT_FOUND") throws KoinStoreException.CartNotFoundException()
         }
     }
 
@@ -677,58 +435,25 @@ class StoreRepositoryImpl @Inject constructor(
         return runCatching {
             storeRemoteDataSource.deleteCartItem(cartMenuItemId)
             Unit
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            401 -> KoinStoreException.UnauthorizedException()
-                            404 -> when (e.getErrorResponse().code) {
-                                "CART_MENU_ITEM_NOT_FOUND" -> KoinStoreException.CartNotFoundException()
-                                "CART_NOT_FOUND" -> KoinStoreException.CartNotFoundException()
-                                else -> e.getErrorResponse().toKoinUnknownErrorException()
-                            }
-
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(401) throws KoinStoreException.UnauthorizedException()
+            on(404, "CART_MENU_ITEM_NOT_FOUND") throws KoinStoreException.CartItemNotFoundException()
+            on(404, "CART_NOT_FOUND") throws KoinStoreException.CartNotFoundException()
         }
     }
 
     override suspend fun getCartItemsCount(): Result<CartItemsCount> {
         return runCatching {
             storeRemoteDataSource.getCartItemsCount().toCartItemsCount()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        when (e.code()) {
-                            401 -> KoinStoreException.UnauthorizedException()
-                            else -> e.getErrorResponse().toKoinUnknownErrorException()
-                        }
-                    }
-
-                    else -> e
-                }
-            )
+        }.mapHttpFailure {
+            on(401) throws KoinStoreException.UnauthorizedException()
         }
     }
 
     override suspend fun getOrderInProgress(): Result<List<OrderInProgress>> {
         return runCatching {
             storeRemoteDataSource.getOrderInProgress().map { it.toOrderInProgress() }
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> e.getErrorResponse().toKoinUnknownErrorException()
-                    else -> e
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 
     override suspend fun getOrderHistories(
@@ -741,16 +466,6 @@ class StoreRepositoryImpl @Inject constructor(
     ): Result<OrderHistoryRelated> {
         return runCatching {
             storeRemoteDataSource.getOrderHistories(page, limit, period, status, type, query).toOrderHistoryRelated()
-        }.onFailure { e ->
-            return Result.failure(
-                when (e) {
-                    is HttpException -> {
-                        e.getErrorResponse().toKoinUnknownErrorException()
-                    }
-
-                    else -> e
-                }
-            )
-        }
+        }.mapHttpFailure {  }
     }
 }

--- a/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/StoreRepositoryImpl.kt
@@ -34,9 +34,7 @@ import `in`.koreatech.koin.data.request.user.ReviewRequest
 import `in`.koreatech.koin.data.source.local.CacheLocalDataSource
 import `in`.koreatech.koin.data.source.local.StoreLocalDataSource
 import `in`.koreatech.koin.data.source.remote.StoreRemoteDataSource
-import `in`.koreatech.koin.data.util.getErrorResponse
 import `in`.koreatech.koin.data.util.mapHttpFailure
-import `in`.koreatech.koin.data.util.toKoinUnknownErrorException
 import `in`.koreatech.koin.domain.error.store.KoinStoreException
 import `in`.koreatech.koin.domain.model.owner.menu.StoreMenuCategory
 import `in`.koreatech.koin.domain.model.store.BenefitCategoryList
@@ -249,7 +247,7 @@ class StoreRepositoryImpl @Inject constructor(
     override suspend fun getShopSearchRelatedListV2(keyword: String): Result<OrderableShopSearchRelated> {
         return runCatching {
             storeRemoteDataSource.getShopSearchRelatedV2(keyword).toOrderableShopSearchRelated()
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 
     override suspend fun getOrderableShops(
@@ -328,7 +326,7 @@ class StoreRepositoryImpl @Inject constructor(
     override suspend fun getOrderableShopSearchRelated(query: String): Result<OrderableShopSearchRelated> {
         return runCatching {
             storeRemoteDataSource.getOrderableShopSearchRelated(query).toOrderableShopSearchRelated()
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 
     override suspend fun updateCartItem(cartMenuItemId: Int, cartItem: CartItem): Result<Unit> {
@@ -453,7 +451,7 @@ class StoreRepositoryImpl @Inject constructor(
     override suspend fun getOrderInProgress(): Result<List<OrderInProgress>> {
         return runCatching {
             storeRemoteDataSource.getOrderInProgress().map { it.toOrderInProgress() }
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 
     override suspend fun getOrderHistories(
@@ -466,6 +464,6 @@ class StoreRepositoryImpl @Inject constructor(
     ): Result<OrderHistoryRelated> {
         return runCatching {
             storeRemoteDataSource.getOrderHistories(page, limit, period, status, type, query).toOrderHistoryRelated()
-        }.mapHttpFailure {  }
+        }.mapHttpFailure { }
     }
 }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1280 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- #1281 에서 구현한 `mapHttpException`으로 리팩토링 했습니다.
- 중복된 에러 처리 로직 제거로 약 78%의 코드량이 감소하였습니다.
### 논의 사항
- 단순히 `HttpException`을 `KoinUnknownErrorException`으로 매핑 할 경우, `mapHttpException {}`으로 작성해야 하는데, 더 나은 방법이 있을까요
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다