### PR TITLE
[Koin Project][Refactor] 채팅 컴포넌트 색상 리팩토링

### DIFF
--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -331,27 +331,25 @@ fun ChatBubblePreview() {
     KoinSurface {
         Column {
             ChatBubble(
-                message =
-                    ConvertedChatMessage(
-                        userId = 0,
-                        userNickname = "Me",
-                        content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
-                        timestamp = LocalDateTime.now(),
-                        isImage = false,
-                        isSentByMe = true
-                    )
+                message = ConvertedChatMessage(
+                    userId = 0,
+                    userNickname = "Me",
+                    content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
+                    timestamp = LocalDateTime.now(),
+                    isImage = false,
+                    isSentByMe = true
+                )
             )
 
             ChatBubble(
-                message =
-                    ConvertedChatMessage(
-                        userId = 0,
-                        userNickname = "Me",
-                        content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
-                        timestamp = LocalDateTime.now(),
-                        isImage = false,
-                        isSentByMe = false
-                    )
+                message = ConvertedChatMessage(
+                    userId = 0,
+                    userNickname = "Me",
+                    content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
+                    timestamp = LocalDateTime.now(),
+                    isImage = false,
+                    isSentByMe = false
+                )
             )
         }
     }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.feature.chat.ui.room.component
 import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,6 +18,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -40,10 +42,43 @@ import java.time.format.DateTimeFormatter
 
 private val chatBubbleDefaultModifier = Modifier.padding(horizontal = 24.dp, vertical = 8.dp)
 
+object ChatBubbleDefaults {
+    @Composable
+    fun colors(
+        bubbleContainerColorFromMe: Color = KoinTheme.colors.neutral100.copy(alpha = 0.8f),
+        bubbleContainerColorFromOther: Color = KoinTheme.colors.info100,
+        bubbleContentColor: Color = KoinTheme.colors.neutral800,
+        bubbleTimeStampColor: Color = KoinTheme.colors.neutral500,
+        userNicknameColor: Color = KoinTheme.colors.neutral600,
+        iconContainerColor: Color = KoinTheme.colors.primary500,
+        iconBorderColor: Color = Color.Unspecified
+    ): ChatBubbleColors = ChatBubbleColors(
+        bubbleContainerColorFromMe = bubbleContainerColorFromMe,
+        bubbleContainerColorFromOther = bubbleContainerColorFromOther,
+        bubbleContentColor = bubbleContentColor,
+        timeStampColor = bubbleTimeStampColor,
+        userNicknameColor = userNicknameColor,
+        iconContainerColor = iconContainerColor,
+        iconBorderColor = iconBorderColor
+    )
+}
+
+@Immutable
+class ChatBubbleColors(
+    val bubbleContainerColorFromMe: Color,
+    val bubbleContainerColorFromOther: Color,
+    val bubbleContentColor: Color,
+    val timeStampColor: Color,
+    val userNicknameColor: Color,
+    val iconContainerColor: Color,
+    val iconBorderColor: Color
+)
+
 @Composable
 fun ChatBubble(
     message: ConvertedChatMessage,
     modifier: Modifier = Modifier,
+    colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
     chatPartnerProfileImage: Uri? = null,
     onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
 ) {
@@ -51,6 +86,7 @@ fun ChatBubble(
         ChatBubbleFromMe(
             message = message,
             onShowImageChange = onShowImageChange,
+            colors = colors,
             modifier = modifier.then(chatBubbleDefaultModifier)
         )
     } else {
@@ -58,6 +94,7 @@ fun ChatBubble(
             message = message,
             chatPartnerProfileImage = chatPartnerProfileImage,
             onShowImageChange = onShowImageChange,
+            colors = colors,
             modifier = modifier.then(chatBubbleDefaultModifier)
         )
     }
@@ -67,6 +104,7 @@ fun ChatBubble(
 private fun ChatBubbleFromMe(
     message: ConvertedChatMessage,
     modifier: Modifier = Modifier,
+    colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
     onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
 ) {
     Row(
@@ -77,14 +115,13 @@ private fun ChatBubbleFromMe(
         Text(
             text = message.timestamp.format(DateTimeFormatter.ofPattern("HH:mm")),
             style = KoinTheme.typography.regular12,
-            color = KoinTheme.colors.neutral500
+            color = colors.bubbleContentColor
         )
         Spacer(modifier = Modifier.width(12.dp))
         Box(
-            modifier =
-            Modifier
+            modifier = Modifier
                 .background(
-                    color = KoinTheme.colors.neutral100.copy(alpha = 0.8f),
+                    color = colors.bubbleContainerColorFromMe,
                     shape = KoinTheme.shapes.small
                 )
                 .then(
@@ -101,7 +138,10 @@ private fun ChatBubbleFromMe(
                     onShowImageChange = onShowImageChange
                 )
             } else {
-                ChatBubbleText(message.content)
+                ChatBubbleText(
+                    textColor = colors.bubbleContentColor,
+                    message = message.content
+                )
             }
         }
     }
@@ -111,6 +151,7 @@ private fun ChatBubbleFromMe(
 private fun ChatBubbleFromOther(
     message: ConvertedChatMessage,
     modifier: Modifier = Modifier,
+    colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
     chatPartnerProfileImage: Uri? = null,
     onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
 ) {
@@ -124,17 +165,16 @@ private fun ChatBubbleFromOther(
                 Image(
                     painter = painterResource(id = R.drawable.ic_chat_user_image),
                     contentDescription = stringResource(id = R.string.chat_user_profile_image),
-                    modifier =
-                    Modifier
+                    modifier = Modifier
                         .clip(KoinTheme.shapes.small)
-                        .background(KoinTheme.colors.primary500)
+                        .border(width = 1.dp, color = colors.iconBorderColor, shape = KoinTheme.shapes.small)
+                        .background(colors.iconContainerColor)
                         .padding(2.dp)
                         .size(24.dp)
                 )
             } else {
                 AsyncImage(
-                    model =
-                    ImageRequest.Builder(LocalContext.current)
+                    model = ImageRequest.Builder(LocalContext.current)
                         .data(chatPartnerProfileImage)
                         .crossfade(true)
                         .build(),
@@ -146,7 +186,7 @@ private fun ChatBubbleFromOther(
             Text(
                 text = message.userNickname,
                 style = KoinTheme.typography.regular12,
-                color = KoinTheme.colors.neutral600
+                color = colors.userNicknameColor
             )
         }
         Spacer(modifier = Modifier.height(8.dp))
@@ -156,10 +196,9 @@ private fun ChatBubbleFromOther(
             horizontalArrangement = Arrangement.Start
         ) {
             Box(
-                modifier =
-                Modifier
+                modifier = Modifier
                     .background(
-                        color = KoinTheme.colors.info100,
+                        color = colors.bubbleContainerColorFromOther,
                         shape = KoinTheme.shapes.small
                     )
                     .then(
@@ -176,25 +215,31 @@ private fun ChatBubbleFromOther(
                         onShowImageChange = onShowImageChange
                     )
                 } else {
-                    ChatBubbleText(message.content)
+                    ChatBubbleText(
+                        textColor = colors.bubbleContentColor,
+                        message = message.content
+                    )
                 }
             }
             Spacer(modifier = Modifier.width(12.dp))
             Text(
                 text = message.timestamp.format(DateTimeFormatter.ofPattern("HH:mm")),
                 style = KoinTheme.typography.regular12,
-                color = KoinTheme.colors.neutral500
+                color = colors.timeStampColor
             )
         }
     }
 }
 
 @Composable
-private fun ChatBubbleText(message: String) {
+private fun ChatBubbleText(
+    textColor: Color,
+    message: String
+) {
     Text(
         text = message,
         style = KoinTheme.typography.regular12,
-        color = KoinTheme.colors.neutral800
+        color = textColor
     )
 }
 
@@ -205,12 +250,12 @@ private fun ChatBubbleImage(
 ) {
     Box {
         SubcomposeAsyncImage(
-            modifier =
-            Modifier.clip(KoinTheme.shapes.small).noRippleClickable {
-                onShowImageChange(true, Uri.parse(imageUrl))
-            },
-            model =
-            ImageRequest.Builder(LocalContext.current)
+            modifier = Modifier
+                .clip(KoinTheme.shapes.small)
+                .noRippleClickable {
+                    onShowImageChange(true, Uri.parse(imageUrl))
+                },
+            model = ImageRequest.Builder(LocalContext.current)
                 .data(imageUrl)
                 .crossfade(true)
                 .build(),
@@ -265,16 +310,30 @@ private fun ChatBubbleImage(
 @Composable
 fun ChatBubblePreview() {
     KoinSurface {
-        ChatBubble(
-            message =
-            ConvertedChatMessage(
-                userId = 0,
-                userNickname = "Me",
-                content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
-                timestamp = LocalDateTime.now(),
-                isImage = false,
-                isSentByMe = true
+        Column {
+            ChatBubble(
+                message =
+                    ConvertedChatMessage(
+                        userId = 0,
+                        userNickname = "Me",
+                        content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
+                        timestamp = LocalDateTime.now(),
+                        isImage = false,
+                        isSentByMe = true
+                    )
             )
-        )
+
+            ChatBubble(
+                message =
+                    ConvertedChatMessage(
+                        userId = 0,
+                        userNickname = "Me",
+                        content = "투명 케이스가 끼워져 있었어요! \n담헌실학관 401호 앞에 떨어져있었어요",
+                        timestamp = LocalDateTime.now(),
+                        isImage = false,
+                        isSentByMe = false
+                    )
+            )
+        }
     }
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -61,6 +61,25 @@ object ChatBubbleDefaults {
         iconContainerColor = iconContainerColor,
         iconBorderColor = iconBorderColor
     )
+
+    @Composable
+    fun purpleColors(
+        bubbleContainerColorFromMe: Color = KoinTheme.colors.neutral200,
+        bubbleContainerColorFromOther: Color = KoinTheme.colors.neutral100,
+        bubbleContentColor: Color = KoinTheme.colors.neutral800,
+        bubbleTimeStampColor: Color = KoinTheme.colors.neutral500,
+        userNicknameColor: Color = KoinTheme.colors.neutral600,
+        iconContainerColor: Color = Color.Unspecified,
+        iconBorderColor: Color = Color.Unspecified
+    ): ChatBubbleColors = ChatBubbleColors(
+        bubbleContainerColorFromMe = bubbleContainerColorFromMe,
+        bubbleContainerColorFromOther = bubbleContainerColorFromOther,
+        bubbleContentColor = bubbleContentColor,
+        timeStampColor = bubbleTimeStampColor,
+        userNicknameColor = userNicknameColor,
+        iconContainerColor = iconContainerColor,
+        iconBorderColor = iconBorderColor
+    )
 }
 
 @Immutable

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -134,7 +134,7 @@ private fun ChatBubbleFromMe(
         Text(
             text = message.timestamp.format(DateTimeFormatter.ofPattern("HH:mm")),
             style = KoinTheme.typography.regular12,
-            color = colors.bubbleContentColor
+            color = colors.timeStampColor
         )
         Spacer(modifier = Modifier.width(12.dp))
         Box(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
@@ -21,6 +22,15 @@ object ChatDateTitleDefaults {
     fun colors(
         containerColor: Color = KoinTheme.colors.neutral200.copy(alpha = 0.8f),
         contentColor: Color = KoinTheme.colors.primary600
+    ): ChatDateTitleColors = ChatDateTitleColors(
+        containerColor = containerColor,
+        contentColor = contentColor
+    )
+
+    @Composable
+    fun purpleColors(
+        containerColor: Color = RebrandKoinTheme.colors.neutral100,
+        contentColor: Color = RebrandKoinTheme.colors.primary600
     ): ChatDateTitleColors = ChatDateTitleColors(
         containerColor = containerColor,
         contentColor = contentColor

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
@@ -6,37 +6,55 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
+object ChatDateTitleDefaults {
+    @Composable
+    fun colors(
+        containerColor: Color = KoinTheme.colors.neutral200.copy(alpha = 0.8f),
+        contentColor: Color = KoinTheme.colors.primary600
+    ): ChatDateTitleColors = ChatDateTitleColors(
+        containerColor = containerColor,
+        contentColor = contentColor
+    )
+}
+
+@Immutable
+class ChatDateTitleColors(
+    val containerColor: Color,
+    val contentColor: Color
+)
+
 @Composable
 fun ChatDateTitle(
     date: LocalDate,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    colors: ChatDateTitleColors = ChatDateTitleDefaults.colors()
 ) {
     Box(
-        modifier =
-        modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(vertical = 12.dp, horizontal = 24.dp),
         contentAlignment = Alignment.Center
     ) {
         Text(
-            modifier =
-            Modifier
+            modifier = Modifier
                 .background(
-                    color = KoinTheme.colors.neutral200.copy(alpha = 0.8f),
+                    color = colors.containerColor,
                     shape = KoinTheme.shapes.medium
                 )
                 .padding(vertical = 4.dp, horizontal = 12.dp),
             text = date.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일")),
             style = KoinTheme.typography.medium12,
-            color = KoinTheme.colors.primary600
+            color = colors.contentColor
         )
     }
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.component.tab.KoinSurface
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.chat.R
 import `in`.koreatech.koin.feature.chat.ui.CHAT_MESSAGE_MAX_LENGTH
 
@@ -49,6 +50,23 @@ object ChatInputDefaults {
         textContainerColor: Color = KoinTheme.colors.neutral0,
         placeholderContentColor: Color = KoinTheme.colors.neutral500,
         backgroundColor: Color = KoinTheme.colors.neutral100
+    ): ChatInputColors = ChatInputColors(
+        iconContentColor = iconContentColor,
+        iconContainerColor = iconContainerColor,
+        textContentColor = textContentColor,
+        textContainerColor = textContainerColor,
+        placeholderContentColor = placeholderContentColor,
+        backgroundColor = backgroundColor
+    )
+
+    @Composable
+    fun purpleColors(
+        iconContentColor: Color = RebrandKoinTheme.colors.primary600,
+        iconContainerColor: Color = RebrandKoinTheme.colors.neutral0,
+        textContentColor: Color = RebrandKoinTheme.colors.neutral800,
+        textContainerColor: Color = RebrandKoinTheme.colors.neutral0,
+        placeholderContentColor: Color = RebrandKoinTheme.colors.neutral500,
+        backgroundColor: Color = RebrandKoinTheme.colors.neutral100
     ): ChatInputColors = ChatInputColors(
         iconContentColor = iconContentColor,
         iconContainerColor = iconContainerColor,
@@ -176,7 +194,8 @@ fun ChatInputPreview() {
             value = "",
             onValueChange = {},
             onImageButtonClick = {},
-            onSendClick = {}
+            onSendClick = {},
+            colors = ChatInputDefaults.purpleColors()
         )
     }
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
@@ -133,7 +133,8 @@ fun ChatInput(
                     )
                     .padding(vertical = 8.dp, horizontal = 12.dp)
                     .fillMaxHeight()
-                    .weight(1f)
+                    .weight(1f),
+                colors = colors
             )
 
             Icon(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
@@ -1,6 +1,5 @@
 package `in`.koreatech.koin.feature.chat.ui.room.component
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -17,10 +16,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -38,7 +40,34 @@ object ChatInputDefaults {
             WindowInsets.systemBars.only(
                 WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom
             )
+
+    @Composable
+    fun colors(
+        iconContentColor: Color = KoinTheme.colors.primary600,
+        iconContainerColor: Color = KoinTheme.colors.info200,
+        textContentColor: Color = KoinTheme.colors.neutral800,
+        textContainerColor: Color = KoinTheme.colors.neutral0,
+        placeholderContentColor: Color = KoinTheme.colors.neutral500,
+        backgroundColor: Color = KoinTheme.colors.neutral100
+    ): ChatInputColors = ChatInputColors(
+        iconContentColor = iconContentColor,
+        iconContainerColor = iconContainerColor,
+        textContentColor = textContentColor,
+        textContainerColor = textContainerColor,
+        placeholderContentColor = placeholderContentColor,
+        backgroundColor = backgroundColor
+    )
 }
+
+@Immutable
+class ChatInputColors(
+    val iconContentColor: Color,
+    val iconContainerColor: Color,
+    val textContentColor: Color,
+    val textContainerColor: Color,
+    val placeholderContentColor: Color,
+    val backgroundColor: Color
+)
 
 @Composable
 fun ChatInput(
@@ -47,31 +76,30 @@ fun ChatInput(
     onImageButtonClick: () -> Unit,
     onSendClick: () -> Unit,
     modifier: Modifier = Modifier,
-    windowInsets: WindowInsets = ChatInputDefaults.windowInsets
+    windowInsets: WindowInsets = ChatInputDefaults.windowInsets,
+    colors: ChatInputColors = ChatInputDefaults.colors()
 ) {
     Column(
-        modifier =
-        modifier
+        modifier = modifier
             .fillMaxWidth()
-            .background(KoinTheme.colors.neutral100)
+            .background(colors.backgroundColor)
             .padding(16.dp)
             .windowInsetsPadding(windowInsets)
     ) {
         Row(
-            modifier =
-            Modifier
+            modifier = Modifier
                 .fillMaxWidth()
                 .height(intrinsicSize = IntrinsicSize.Max),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Image(
-                modifier =
-                Modifier
-                    .background(KoinTheme.colors.info200, KoinTheme.shapes.medium)
+            Icon(
+                modifier = Modifier
+                    .background(colors.iconContainerColor, KoinTheme.shapes.medium)
                     .noRippleClickable { onImageButtonClick() }
                     .padding(12.dp),
                 painter = painterResource(id = R.drawable.ic_chat_add_photo),
+                tint = colors.iconContentColor,
                 contentDescription = stringResource(id = R.string.chat_add_image)
             )
 
@@ -79,11 +107,10 @@ fun ChatInput(
                 value = value,
                 onValueChange = onValueChange,
                 placeholder = stringResource(id = R.string.chat_input_placeholder),
-                modifier =
-                Modifier
+                modifier = Modifier
                     .padding(horizontal = 8.dp)
                     .background(
-                        color = KoinTheme.colors.neutral0,
+                        color = colors.textContainerColor,
                         shape = KoinTheme.shapes.medium
                     )
                     .padding(vertical = 8.dp, horizontal = 12.dp)
@@ -91,13 +118,13 @@ fun ChatInput(
                     .weight(1f)
             )
 
-            Image(
-                modifier =
-                Modifier
-                    .background(KoinTheme.colors.info200, KoinTheme.shapes.medium)
+            Icon(
+                modifier = Modifier
+                    .background(colors.iconContainerColor, KoinTheme.shapes.medium)
                     .noRippleClickable { onSendClick() }
                     .padding(12.dp),
                 painter = painterResource(id = R.drawable.ic_chat_send),
+                tint = colors.iconContentColor,
                 contentDescription = stringResource(id = R.string.chat_send)
             )
         }
@@ -109,12 +136,13 @@ fun ChatTextField(
     value: String,
     onValueChange: (String) -> Unit,
     modifier: Modifier = Modifier,
-    placeholder: String = ""
+    placeholder: String = "",
+    colors: ChatInputColors = ChatInputDefaults.colors()
 ) {
     BasicTextField(
         modifier = modifier,
         value = value,
-        textStyle = KoinTheme.typography.regular14,
+        textStyle = KoinTheme.typography.regular14.copy(color = colors.textContentColor),
         onValueChange = {
             if (value.length < CHAT_MESSAGE_MAX_LENGTH) {
                 onValueChange(it)
@@ -130,7 +158,7 @@ fun ChatTextField(
                     Text(
                         text = placeholder,
                         style = KoinTheme.typography.regular12,
-                        color = KoinTheme.colors.neutral500
+                        color = colors.placeholderContentColor
                     )
                 }
                 innerTextField()


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1283 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 콜밴팟 채팅 컴포넌트 색상이 기존과 다르기 때문에, 색상을 커스텀 가능하게 수정했습니다.
- 콜밴팟 채팅 색상을 추가했습니다. (`purpleColors`)
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customizable color themes for chat interface components including message bubbles, message date separators, and input fields, enabling flexible visual styling tailored to user preferences or application branding requirements.
  * Multiple built-in theme presets are now available to simplify switching between different color schemes while maintaining consistent visual appearance throughout the entire chat experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->