### PR TITLE
[Koin Project][Chore] DiningRepository UseCase 단위 테스트 추가

### DIFF
--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDiningRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDiningRepository.kt
@@ -1,0 +1,21 @@
+package `in`.koreatech.koin.domain.repository
+
+import `in`.koreatech.koin.domain.model.dining.Dining
+
+class FakeDiningRepository : DiningRepository {
+    private var fakeDinings: List<Dining> = emptyList()
+    private var shouldThrow: Boolean = false
+
+    fun setFakeDinings(dinings: List<Dining>) {
+        fakeDinings = dinings
+    }
+
+    fun setShouldThrow(shouldThrow: Boolean) {
+        this.shouldThrow = shouldThrow
+    }
+
+    override suspend fun getDining(date: String): List<Dining> {
+        if (shouldThrow) throw RuntimeException("Network error")
+        return fakeDinings
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDiningRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDiningRepository.kt
@@ -5,6 +5,8 @@ import `in`.koreatech.koin.domain.model.dining.Dining
 class FakeDiningRepository : DiningRepository {
     private var fakeDinings: List<Dining> = emptyList()
     private var shouldThrow: Boolean = false
+    var lastRequestedDate: String? = null
+        private set
 
     fun setFakeDinings(dinings: List<Dining>) {
         fakeDinings = dinings
@@ -15,6 +17,7 @@ class FakeDiningRepository : DiningRepository {
     }
 
     override suspend fun getDining(date: String): List<Dining> {
+        lastRequestedDate = date
         if (shouldThrow) throw RuntimeException("Network error")
         return fakeDinings
     }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dining/GetDiningUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dining/GetDiningUseCaseTest.kt
@@ -1,0 +1,84 @@
+package `in`.koreatech.koin.domain.usecase.dining
+
+import `in`.koreatech.koin.domain.model.dining.Dining
+import `in`.koreatech.koin.domain.repository.FakeDiningRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetDiningUseCaseTest {
+
+    private lateinit var diningRepository: FakeDiningRepository
+
+    private fun makeDining(id: Int, type: String, menu: List<String>) = Dining(
+        id = id,
+        date = "2024-01-01",
+        type = type,
+        place = "A코너",
+        priceCard = "3000",
+        priceCash = "3000",
+        kcal = "600",
+        menu = menu,
+        imageUrl = "",
+        createdAt = "",
+        updatedAt = "",
+        soldOutAt = "",
+        changedAt = ""
+    )
+
+    @Before
+    fun setUp() {
+        diningRepository = FakeDiningRepository()
+    }
+
+    @Test
+    fun `식단 목록을 그대로 반환한다`() = runTest {
+        val dinings = listOf(
+            makeDining(1, "조식", listOf("김치찌개", "밥")),
+            makeDining(2, "중식", listOf("비빔밥")),
+            makeDining(3, "석식", listOf("미운영"))
+        )
+        diningRepository.setFakeDinings(dinings)
+
+        val result = GetDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertEquals(dinings.size, result.getOrThrow().size)
+        assertEquals(dinings, result.getOrThrow())
+    }
+
+    @Test
+    fun `미운영 식단도 필터링 없이 반환한다`() = runTest {
+        val dinings = listOf(
+            makeDining(1, "조식", listOf("미운영")),
+            makeDining(2, "중식", listOf("미운영"))
+        )
+        diningRepository.setFakeDinings(dinings)
+
+        val result = GetDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `식단이 없으면 빈 목록을 반환한다`() = runTest {
+        diningRepository.setFakeDinings(emptyList())
+
+        val result = GetDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `저장소 호출 실패 시 실패 결과를 반환한다`() = runTest {
+        diningRepository.setShouldThrow(true)
+
+        val result = GetDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isFailure)
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dining/GetNotOperationFilteredDiningUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dining/GetNotOperationFilteredDiningUseCaseTest.kt
@@ -1,0 +1,118 @@
+package `in`.koreatech.koin.domain.usecase.dining
+
+import `in`.koreatech.koin.domain.model.dining.Dining
+import `in`.koreatech.koin.domain.repository.FakeDiningRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetNotOperationFilteredDiningUseCaseTest {
+
+    private lateinit var diningRepository: FakeDiningRepository
+
+    private fun makeDining(menu: List<String>) = Dining(
+        id = 1,
+        date = "2024-01-01",
+        type = "조식",
+        place = "A코너",
+        priceCard = "3000",
+        priceCash = "3000",
+        kcal = "600",
+        menu = menu,
+        imageUrl = "",
+        createdAt = "",
+        updatedAt = "",
+        soldOutAt = "",
+        changedAt = ""
+    )
+
+    @Before
+    fun setUp() {
+        diningRepository = FakeDiningRepository()
+    }
+
+    @Test
+    fun `정상 운영 중인 식단만 포함된 목록을 반환한다`() = runTest {
+        val operating1 = makeDining(listOf("김치찌개", "된장국", "밥"))
+        val operating2 = makeDining(listOf("비빔밥", "미역국"))
+        diningRepository.setFakeDinings(listOf(operating1, operating2))
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertEquals(2, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `미운영 식단은 목록에서 제외된다`() = runTest {
+        val operating = makeDining(listOf("김치찌개", "된장국"))
+        val notOperating = makeDining(listOf("미운영"))
+        diningRepository.setFakeDinings(listOf(operating, notOperating))
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        val dinings = result.getOrThrow()
+        assertEquals(1, dinings.size)
+        assertEquals(operating, dinings.first())
+    }
+
+    @Test
+    fun `메뉴가 비어 있는 식단은 목록에서 제외된다`() = runTest {
+        val operating = makeDining(listOf("비빔밥"))
+        val emptyMenu = makeDining(emptyList())
+        diningRepository.setFakeDinings(listOf(operating, emptyMenu))
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        val dinings = result.getOrThrow()
+        assertEquals(1, dinings.size)
+        assertEquals(operating, dinings.first())
+    }
+
+    @Test
+    fun `모든 식단이 미운영이면 빈 목록을 반환한다`() = runTest {
+        val notOperating1 = makeDining(listOf("미운영"))
+        val notOperating2 = makeDining(listOf("미운영"))
+        diningRepository.setFakeDinings(listOf(notOperating1, notOperating2))
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `저장소에 식단이 없으면 빈 목록을 반환한다`() = runTest {
+        diningRepository.setFakeDinings(emptyList())
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `저장소 호출 실패 시 실패 결과를 반환한다`() = runTest {
+        diningRepository.setShouldThrow(true)
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `미운영이 첫 번째 항목이 아닌 경우 제외되지 않는다`() = runTest {
+        // "미운영"이 첫 번째 항목이 아니면 필터링 대상이 아님
+        val dining = makeDining(listOf("김치찌개", "미운영"))
+        diningRepository.setFakeDinings(listOf(dining))
+
+        val result = GetNotOperationFilteredDiningUseCase(diningRepository)("2024-01-01")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, result.getOrThrow().size)
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1288

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
DiningRepository 관련 UseCase 단위 테스트 추가

- `FakeDiningRepository` 추가
- `GetDiningUseCaseTest` 추가 (4개 테스트)
- `GetNotOperationFilteredDiningUseCaseTest` 추가 (7개 테스트)

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for dining use cases: normal operations, filtering logic, empty-state and error handling, and edge cases to ensure reliability.
* **Test Utilities**
  * Added an in-memory test double to simulate dining data and optional failure scenarios for deterministic testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->