### PR TITLE
[Koin Project][Chore] DeptRepository UseCase 단위 테스트 추가

### DIFF
--- a/domain/src/test/java/in/koreatech/koin/domain/error/dept/FakeDeptErrorHandler.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/error/dept/FakeDeptErrorHandler.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.domain.error.dept
+
+import `in`.koreatech.koin.domain.model.error.ErrorHandler
+
+class FakeDeptErrorHandler : DeptErrorHandler {
+    override fun getDeptNameFromDeptCodeError(throwable: Throwable): ErrorHandler {
+        return ErrorHandler(throwable.message ?: "Unknown error")
+    }
+
+    override fun getDeptsError(throwable: Throwable): ErrorHandler {
+        return ErrorHandler(throwable.message ?: "Unknown error")
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDeptRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeDeptRepository.kt
@@ -1,0 +1,36 @@
+package `in`.koreatech.koin.domain.repository
+
+import `in`.koreatech.koin.domain.model.user.Dept
+
+class FakeDeptRepository : DeptRepository {
+    private var deptCodeToName: Map<String, String> = emptyMap()
+    private var fakeDepts: List<Dept> = emptyList()
+    private var shouldThrow: Boolean = false
+
+    fun setDeptNameForCode(code: String, name: String) {
+        deptCodeToName = deptCodeToName + (code to name)
+    }
+
+    fun setFakeDepts(depts: List<Dept>) {
+        fakeDepts = depts
+    }
+
+    fun setShouldThrow(shouldThrow: Boolean) {
+        this.shouldThrow = shouldThrow
+    }
+
+    override suspend fun getDeptNameFromDeptCode(deptCode: String): String {
+        if (shouldThrow) throw RuntimeException("Network error")
+        return deptCodeToName[deptCode] ?: throw NoSuchElementException("No dept for code: $deptCode")
+    }
+
+    override suspend fun getDepts(): List<Dept> {
+        if (shouldThrow) throw RuntimeException("Network error")
+        return fakeDepts
+    }
+
+    override suspend fun getDeptNames(): List<String> {
+        if (shouldThrow) throw RuntimeException("Network error")
+        return fakeDepts.map { it.name }
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCaseTest.kt
@@ -95,6 +95,14 @@ class GetDeptNameFromStudentIdUseCaseTest {
     }
 
     @Test
+    fun `존재하지 않는 학과 코드일 때 null과 ErrorHandler를 반환한다`() = runTest {
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)(validStudentId10)
+
+        assertNull(result.first)
+        assertNotNull(result.second)
+    }
+
+    @Test
     fun `저장소 호출 실패 시 null과 ErrorHandler를 반환한다`() = runTest {
         deptRepository.setShouldThrow(true)
 

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCaseTest.kt
@@ -1,0 +1,106 @@
+package `in`.koreatech.koin.domain.usecase.dept
+
+import `in`.koreatech.koin.domain.error.dept.FakeDeptErrorHandler
+import `in`.koreatech.koin.domain.repository.FakeDeptRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class GetDeptNameFromStudentIdUseCaseTest {
+
+    private lateinit var deptRepository: FakeDeptRepository
+    private lateinit var deptErrorHandler: FakeDeptErrorHandler
+
+    // Student ID of "2023136001": deptCode = substring(5..6) = "36"
+    private val validStudentId10 = "2023136001"
+    private val deptCode10 = "36"
+
+    // Student ID of "202313001" (9 digits): deptCode = "30"
+    private val validStudentId9 = "202313001"
+    private val deptCode9 = "30"
+
+    // Student ID of "20231001" (8 digits): deptCode = substring(5..6) = "00"
+    private val validStudentId8 = "20231001"
+    private val deptCode8 = "00"
+
+    @Before
+    fun setUp() {
+        deptRepository = FakeDeptRepository()
+        deptErrorHandler = FakeDeptErrorHandler()
+    }
+
+    @Test
+    fun `유효한 10자리 학번으로 학과명을 가져온다`() = runTest {
+        deptRepository.setDeptNameForCode(deptCode10, "컴퓨터공학부")
+
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)(validStudentId10)
+
+        assertEquals("컴퓨터공학부", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `유효한 9자리 학번으로 학과명을 가져온다`() = runTest {
+        deptRepository.setDeptNameForCode(deptCode9, "기계공학부")
+
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)(validStudentId9)
+
+        assertEquals("기계공학부", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `유효한 8자리 학번으로 학과명을 가져온다`() = runTest {
+        deptRepository.setDeptNameForCode(deptCode8, "전기전자통신공학부")
+
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)(validStudentId8)
+
+        assertEquals("전기전자통신공학부", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `학번 길이가 7자 이하이면 빈 문자열과 null 에러를 반환한다`() = runTest {
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)("2023130")
+
+        assertEquals("", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `학번 길이가 11자 이상이면 빈 문자열과 null 에러를 반환한다`() = runTest {
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)("20231360012")
+
+        assertEquals("", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `학번에 숫자가 아닌 문자가 포함되면 빈 문자열과 null 에러를 반환한다`() = runTest {
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)("2023abcdef")
+
+        assertEquals("", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `빈 문자열 학번이면 빈 문자열과 null 에러를 반환한다`() = runTest {
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)("")
+
+        assertEquals("", result.first)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `저장소 호출 실패 시 null과 ErrorHandler를 반환한다`() = runTest {
+        deptRepository.setShouldThrow(true)
+
+        val result = GetDeptNameFromStudentIdUseCase(deptRepository, deptErrorHandler)(validStudentId10)
+
+        assertNull(result.first)
+        assertNotNull(result.second)
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
@@ -42,14 +42,4 @@ class GetDeptNamesUseCaseTest {
         assertTrue(result.isEmpty())
     }
 
-    @Test
-    fun `학과 이름만 추출하여 반환한다`() = runTest {
-        deptRepository.setFakeDepts(fakeDepts)
-
-        val result = GetDeptNamesUseCase(deptRepository)()
-
-        assertTrue(result.contains("컴퓨터공학부"))
-        assertTrue(result.contains("기계공학부"))
-        assertTrue(result.contains("전기전자통신공학부"))
-    }
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
@@ -41,5 +41,4 @@ class GetDeptNamesUseCaseTest {
 
         assertTrue(result.isEmpty())
     }
-
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/dept/GetDeptNamesUseCaseTest.kt
@@ -1,0 +1,55 @@
+package `in`.koreatech.koin.domain.usecase.dept
+
+import `in`.koreatech.koin.domain.model.user.Dept
+import `in`.koreatech.koin.domain.repository.FakeDeptRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetDeptNamesUseCaseTest {
+
+    private lateinit var deptRepository: FakeDeptRepository
+
+    private val fakeDepts = listOf(
+        Dept(name = "컴퓨터공학부", curriculumUrl = "https://example.com/cs", codes = listOf("36")),
+        Dept(name = "기계공학부", curriculumUrl = "https://example.com/me", codes = listOf("30")),
+        Dept(name = "전기전자통신공학부", curriculumUrl = "https://example.com/ee", codes = listOf("10"))
+    )
+
+    @Before
+    fun setUp() {
+        deptRepository = FakeDeptRepository()
+    }
+
+    @Test
+    fun `학과 이름 목록을 반환한다`() = runTest {
+        deptRepository.setFakeDepts(fakeDepts)
+
+        val result = GetDeptNamesUseCase(deptRepository)()
+
+        assertEquals(fakeDepts.size, result.size)
+        assertEquals(fakeDepts.map { it.name }, result)
+    }
+
+    @Test
+    fun `학과가 없으면 빈 목록을 반환한다`() = runTest {
+        deptRepository.setFakeDepts(emptyList())
+
+        val result = GetDeptNamesUseCase(deptRepository)()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `학과 이름만 추출하여 반환한다`() = runTest {
+        deptRepository.setFakeDepts(fakeDepts)
+
+        val result = GetDeptNamesUseCase(deptRepository)()
+
+        assertTrue(result.contains("컴퓨터공학부"))
+        assertTrue(result.contains("기계공학부"))
+        assertTrue(result.contains("전기전자통신공학부"))
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1288

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
DeptRepository 관련 UseCase 단위 테스트 추가

- `FakeDeptRepository` 추가
- `FakeDeptErrorHandler` 추가
- `GetDeptNameFromStudentIdUseCaseTest` 추가 (8개 테스트)
- `GetDeptNamesUseCaseTest` 추가 (3개 테스트)

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test helpers that provide in-memory department data and deterministic error responses with configurable failure modes for repository behavior.
  * Added comprehensive unit tests for department-related logic covering valid student IDs, edge cases, empty results, non-existent departments, and repository failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->