### PR TITLE
[Koin Project][Chore] UserRepository UseCase 단위 테스트 추가

### DIFF
--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeTokenRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeTokenRepository.kt
@@ -3,6 +3,8 @@ package `in`.koreatech.koin.domain.repository
 class FakeTokenRepository : TokenRepository {
     private var accessToken: String? = null
     private var refreshToken: String? = null
+    private var accessHistoryId: String? = null
+    private var ownerAccessToken: String? = null
 
     override suspend fun saveAccessToken(token: String) {
         accessToken = token
@@ -13,46 +15,35 @@ class FakeTokenRepository : TokenRepository {
     }
 
     override suspend fun saveAccessHistoryId(token: String) {
-        TODO("Not yet implemented")
+        accessHistoryId = token
     }
 
-    override suspend fun getAccessToken(): String? {
-        return accessToken
-    }
+    override suspend fun getAccessToken(): String? = accessToken
 
-    override suspend fun getRefreshToken(): String? {
-        return refreshToken
-    }
+    override suspend fun getRefreshToken(): String? = refreshToken
 
-    override suspend fun getAccessHistoryId(): String? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getAccessHistoryId(): String? = accessHistoryId
 
-    override fun getAccessTokenBlocking(): String? {
-        TODO("Not yet implemented")
-    }
+    override fun getAccessTokenBlocking(): String? = accessToken
 
     override suspend fun removeToken() {
-        TODO("Not yet implemented")
+        accessToken = null
+        refreshToken = null
     }
 
     override suspend fun saveOwnerAccessToken(token: String) {
-        TODO("Not yet implemented")
+        ownerAccessToken = token
     }
 
-    override suspend fun getOwnerAccessToken(): String? {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOwnerAccessToken(): String? = ownerAccessToken
 
-    override fun getAccessOwnerTokenBlocking(): String? {
-        TODO("Not yet implemented")
-    }
+    override fun getAccessOwnerTokenBlocking(): String? = ownerAccessToken
 
     override suspend fun removeOwnerAccessToken() {
-        TODO("Not yet implemented")
+        ownerAccessToken = null
     }
 
     override suspend fun removeRefreshToken() {
-        TODO("Not yet implemented")
+        refreshToken = null
     }
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeUserRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeUserRepository.kt
@@ -6,11 +6,42 @@ import `in`.koreatech.koin.domain.model.user.CodeCount
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.model.user.UserType
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 
 class FakeUserRepository : UserRepository {
     private var authToken: AuthToken? = null
     private var user: User? = null
     var userType: UserType = UserType.ANONYMOUS
+    private var nicknameDuplicated: Boolean = false
+    private var emailDuplicated: Boolean = false
+    private var ownerTokenValid: Boolean = false
+    private var fakeABTest: ABTest? = null
+    private var fakeCodeCount: CodeCount? = null
+    private var fakeLoginId: String = ""
+
+    fun setNicknameDuplicated(isDuplicated: Boolean) {
+        nicknameDuplicated = isDuplicated
+    }
+
+    fun setEmailDuplicated(isDuplicated: Boolean) {
+        emailDuplicated = isDuplicated
+    }
+
+    fun setOwnerTokenValid(isValid: Boolean) {
+        ownerTokenValid = isValid
+    }
+
+    fun setFakeABTest(abTest: ABTest) {
+        fakeABTest = abTest
+    }
+
+    fun setFakeCodeCount(codeCount: CodeCount) {
+        fakeCodeCount = codeCount
+    }
+
+    fun setFakeLoginId(loginId: String) {
+        fakeLoginId = loginId
+    }
 
     fun getUpdatedUser(): User? = user
 
@@ -18,15 +49,13 @@ class FakeUserRepository : UserRepository {
         authToken = token
     }
 
-    override suspend fun getToken(email: String, password: String): AuthToken = authToken ?: throw IllegalStateException("No access token set")
+    override suspend fun getToken(email: String, password: String): AuthToken =
+        authToken ?: throw IllegalStateException("No access token set")
 
-    override suspend fun getOwnerToken(phoneNumber: String, hashedPassword: String): AuthToken {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOwnerToken(phoneNumber: String, hashedPassword: String): AuthToken =
+        authToken ?: throw IllegalStateException("No auth token set")
 
-    override fun ownerTokenIsValid(): Boolean {
-        TODO("Not yet implemented")
-    }
+    override fun ownerTokenIsValid(): Boolean = ownerTokenValid
 
     override suspend fun fetchStudentUserInfo() {
         userType = UserType.STUDENT
@@ -36,108 +65,83 @@ class FakeUserRepository : UserRepository {
         userType = UserType.GENERAL
     }
 
-    override suspend fun getUserInfo(): User {
-        TODO("Not yet implemented")
+    override suspend fun getUserInfo(): User =
+        user ?: throw IllegalStateException("No user set")
+
+    override fun getUserInfoFlow(): Flow<User> = flow {
+        emit(user ?: throw IllegalStateException("No user set"))
     }
 
-    override fun getUserInfoFlow(): Flow<User> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun requestPasswordResetEmail(email: String) {}
 
-    override suspend fun requestPasswordResetEmail(email: String) {
-        TODO("Not yet implemented")
-    }
+    override suspend fun deleteUser() {}
 
-    override suspend fun deleteUser() {
-        TODO("Not yet implemented")
-    }
+    override suspend fun isUsernameDuplicated(nickname: String): Boolean = nicknameDuplicated
 
-    override suspend fun isUsernameDuplicated(nickname: String): Boolean {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun isUserEmailDuplicated(email: String): Boolean {
-        TODO("Not yet implemented")
-    }
+    override suspend fun isUserEmailDuplicated(email: String): Boolean = emailDuplicated
 
     override suspend fun updateUser(user: User): Result<Unit> = when (user) {
         is User.Student -> {
             this.user = user
             Result.success(Unit)
         }
-        is User.General -> TODO()
-        User.Anonymous -> TODO()
+        is User.General -> {
+            this.user = user
+            Result.success(Unit)
+        }
+        User.Anonymous -> Result.success(Unit)
     }
 
-    override suspend fun deleteDeviceToken() {
-        TODO("Not yet implemented")
-    }
+    override suspend fun deleteDeviceToken() {}
 
-    override suspend fun verifyPassword(hashedPassword: String) {
-        TODO("Not yet implemented")
-    }
+    override suspend fun verifyPassword(hashedPassword: String) {}
 
-    override suspend fun updateUserPassword(hashedPassword: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun updateUserPassword(hashedPassword: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun updateABTestToken() {
-        TODO("Not yet implemented")
-    }
+    override suspend fun updateABTestToken() {}
 
-    override suspend fun postABTestAssign(title: String): ABTest {
-        TODO("Not yet implemented")
-    }
+    override suspend fun postABTestAssign(title: String): ABTest =
+        fakeABTest ?: throw IllegalStateException("No ABTest set")
 
-    override suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCachedABTest(title: String): ABTest =
+        fakeABTest ?: throw IllegalStateException("No ABTest set")
 
-    override suspend fun requestEmailVerification(email: String): Result<CodeCount> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun requestSmsVerification(phoneNumber: String): Result<CodeCount> =
+        fakeCodeCount?.let { Result.success(it) }
+            ?: Result.success(CodeCount(phoneNumber, 3, 3, 0))
 
-    override suspend fun verifyCertificationCode(phoneNumber: String, verificationCode: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun requestEmailVerification(email: String): Result<CodeCount> =
+        fakeCodeCount?.let { Result.success(it) }
+            ?: Result.success(CodeCount(email, 3, 3, 0))
 
-    override suspend fun verifyEmailCode(email: String, verificationCode: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun verifyCertificationCode(phoneNumber: String, verificationCode: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun checkIdExists(loginId: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun verifyEmailCode(email: String, verificationCode: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun checkIdMatchEmail(loginId: String, email: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun checkIdExists(loginId: String): Result<Unit> = Result.success(Unit)
 
-    override suspend fun checkIdMatchPhone(loginId: String, phone: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun checkIdMatchEmail(loginId: String, email: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun resetPasswordByEmail(loginId: String, email: String, newPassword: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun checkIdMatchPhone(loginId: String, phone: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun resetPasswordBySms(loginId: String, phone: String, newPassword: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun resetPasswordByEmail(loginId: String, email: String, newPassword: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun checkEmailExists(email: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun resetPasswordBySms(loginId: String, phone: String, newPassword: String): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun checkPhoneExists(phone: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun checkEmailExists(email: String): Result<Unit> = Result.success(Unit)
 
-    override suspend fun findLoginIdByEmail(email: String, verificationCode: String): Result<String> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun checkPhoneExists(phone: String): Result<Unit> = Result.success(Unit)
 
-    override suspend fun findLoginIdBySms(phone: String, verificationCode: String): Result<String> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun findLoginIdByEmail(email: String, verificationCode: String): Result<String> =
+        Result.success(fakeLoginId)
+
+    override suspend fun findLoginIdBySms(phone: String, verificationCode: String): Result<String> =
+        Result.success(fakeLoginId)
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/signup/SignupCheckingUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/signup/SignupCheckingUseCaseTest.kt
@@ -1,0 +1,158 @@
+package `in`.koreatech.koin.domain.usecase.signup
+
+import `in`.koreatech.koin.domain.state.signup.SignupContinuationState
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SignupCheckingUseCaseTest {
+
+    private val signupCheckingUseCase = SignupCheckingUseCase()
+
+    // koreatech.ac.kr 학교 이메일, 영문+숫자+특수문자 포함 유효한 비밀번호
+    private val validEmail = "student@koreatech.ac.kr"
+    private val validPassword = "Pass1!valid"
+
+    @Test
+    fun `이메일 형식이 올바르지 않으면 EmailInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = "invalid-email",
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.EmailInvalid, result)
+    }
+
+    @Test
+    fun `koreatech 학교 이메일이 아니면 EmailInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = "student@gmail.com",
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.EmailInvalid, result)
+    }
+
+    @Test
+    fun `이메일에 공백이 포함되면 EmailInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = "student @koreatech.ac.kr",
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.EmailInvalid, result)
+    }
+
+    @Test
+    fun `비밀번호 형식이 올바르지 않으면 PasswordInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = "password",
+            passwordConfirm = "password",
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PasswordInvalid, result)
+    }
+
+    @Test
+    fun `비밀번호가 6자 미만이면 PasswordInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = "P1!ab",
+            passwordConfirm = "P1!ab",
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PasswordInvalid, result)
+    }
+
+    @Test
+    fun `비밀번호에 공백이 포함되면 PasswordInvalid를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = "Pass 1!valid",
+            passwordConfirm = "Pass 1!valid",
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PasswordInvalid, result)
+    }
+
+    @Test
+    fun `비밀번호 확인이 일치하지 않으면 PasswordNotMatching을 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = validPassword,
+            passwordConfirm = "${validPassword}different",
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PasswordNotMatching, result)
+    }
+
+    @Test
+    fun `개인정보 약관에 동의하지 않으면 PrivacyTermsNotAgreed를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = false,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PrivacyTermsNotAgreed, result)
+    }
+
+    @Test
+    fun `코인 서비스 약관에 동의하지 않으면 KoinTermsNotAgreed를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = false
+        )
+        assertEquals(SignupContinuationState.KoinTermsNotAgreed, result)
+    }
+
+    @Test
+    fun `모든 조건이 유효하면 SignupCheckComplete를 반환한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = validPassword,
+            passwordConfirm = validPassword,
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.SignupCheckComplete, result)
+    }
+
+    @Test
+    fun `이메일 검사가 비밀번호 검사보다 우선한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = "invalid-email",
+            password = "password",
+            passwordConfirm = "password",
+            isAgreedPrivacyTerms = false,
+            isAgreedKoinTerms = false
+        )
+        assertEquals(SignupContinuationState.EmailInvalid, result)
+    }
+
+    @Test
+    fun `비밀번호 검사가 비밀번호 일치 검사보다 우선한다`() {
+        val result = signupCheckingUseCase(
+            portalAccount = validEmail,
+            password = "password",
+            passwordConfirm = "different",
+            isAgreedPrivacyTerms = true,
+            isAgreedKoinTerms = true
+        )
+        assertEquals(SignupContinuationState.PasswordInvalid, result)
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/user/CheckNicknameValidationUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/user/CheckNicknameValidationUseCaseTest.kt
@@ -1,0 +1,97 @@
+package `in`.koreatech.koin.domain.usecase.user
+
+import `in`.koreatech.koin.domain.error.user.FakeUserErrorHandler
+import `in`.koreatech.koin.domain.repository.FakeUserRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class CheckNicknameValidationUseCaseTest {
+
+    private lateinit var userRepository: FakeUserRepository
+    private lateinit var userErrorHandler: FakeUserErrorHandler
+
+    @Before
+    fun setUp() {
+        userRepository = FakeUserRepository()
+        userErrorHandler = FakeUserErrorHandler()
+    }
+
+    @Test
+    fun `사용 가능한 닉네임이면 false와 null 에러를 반환한다`() = runTest {
+        userRepository.setNicknameDuplicated(false)
+
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("코인유저")
+
+        assertFalse(result.first!!)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `이미 사용 중인 닉네임이면 true와 null 에러를 반환한다`() = runTest {
+        userRepository.setNicknameDuplicated(true)
+
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("코인유저")
+
+        assertTrue(result.first!!)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `영어 닉네임은 유효하다`() = runTest {
+        userRepository.setNicknameDuplicated(false)
+
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("KoinUser")
+
+        assertFalse(result.first!!)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `숫자 닉네임은 유효하다`() = runTest {
+        userRepository.setNicknameDuplicated(false)
+
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("123456")
+
+        assertFalse(result.first!!)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `영어와 숫자 혼합 닉네임은 유효하다`() = runTest {
+        userRepository.setNicknameDuplicated(false)
+
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("Koin2024")
+
+        assertFalse(result.first!!)
+        assertNull(result.second)
+    }
+
+    @Test
+    fun `닉네임에 공백이 포함되면 null과 ErrorHandler를 반환한다`() = runTest {
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("코인 유저")
+
+        assertNull(result.first)
+        assertNotNull(result.second)
+    }
+
+    @Test
+    fun `닉네임에 특수문자가 포함되면 null과 ErrorHandler를 반환한다`() = runTest {
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("코인@유저")
+
+        assertNull(result.first)
+        assertNotNull(result.second)
+    }
+
+    @Test
+    fun `빈 문자열 닉네임이면 null과 ErrorHandler를 반환한다`() = runTest {
+        val result = CheckNicknameValidationUseCase(userRepository, userErrorHandler)("")
+
+        assertNull(result.first)
+        assertNotNull(result.second)
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/user/UpdateStudentUserInfoUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/user/UpdateStudentUserInfoUseCaseTest.kt
@@ -1,0 +1,147 @@
+package `in`.koreatech.koin.domain.usecase.user
+
+import `in`.koreatech.koin.domain.model.user.Gender
+import `in`.koreatech.koin.domain.model.user.User
+import `in`.koreatech.koin.domain.repository.FakeUserRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class UpdateStudentUserInfoUseCaseTest {
+
+    private lateinit var userRepository: FakeUserRepository
+
+    private val baseStudent = User.Student(
+        id = 1,
+        loginId = "student01",
+        email = "student@koreatech.ac.kr",
+        anonymousNickname = "익명",
+        gender = Gender.Man,
+        major = "컴퓨터공학부",
+        name = "홍길동",
+        nickname = "코인유저",
+        phoneNumber = "010-1234-5678",
+        studentNumber = "2023136001",
+        userType = "STUDENT"
+    )
+
+    @Before
+    fun setUp() {
+        userRepository = FakeUserRepository()
+    }
+
+    @Test
+    fun `정상적인 필드로 학생 정보를 업데이트한다`() = runTest {
+        val result = UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = "new@koreatech.ac.kr",
+            name = "이순신",
+            nickname = "새닉네임",
+            gender = Gender.Man,
+            phoneNumber = "010-9999-8888",
+            studentNumber = "2023130001",
+            major = "기계공학부"
+        )
+
+        assertTrue(result.isSuccess)
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertEquals("new@koreatech.ac.kr", updated.email)
+        assertEquals("이순신", updated.name)
+        assertEquals("새닉네임", updated.nickname)
+        assertEquals("010-9999-8888", updated.phoneNumber)
+        assertEquals("2023130001", updated.studentNumber)
+        assertEquals("기계공학부", updated.major)
+    }
+
+    @Test
+    fun `이메일이 빈 문자열이면 null로 저장된다`() = runTest {
+        UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = "",
+            name = "홍길동",
+            nickname = "코인유저",
+            gender = Gender.Man,
+            phoneNumber = "010-1234-5678",
+            studentNumber = "2023136001",
+            major = "컴퓨터공학부"
+        )
+
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertNull(updated.email)
+    }
+
+    @Test
+    fun `닉네임이 빈 문자열이면 null로 저장된다`() = runTest {
+        UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = "student@koreatech.ac.kr",
+            name = "홍길동",
+            nickname = "",
+            gender = Gender.Man,
+            phoneNumber = "010-1234-5678",
+            studentNumber = "2023136001",
+            major = "컴퓨터공학부"
+        )
+
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertNull(updated.nickname)
+    }
+
+    @Test
+    fun `이메일과 닉네임 모두 빈 문자열이면 둘 다 null로 저장된다`() = runTest {
+        UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = "",
+            name = "홍길동",
+            nickname = "",
+            gender = Gender.Man,
+            phoneNumber = "010-1234-5678",
+            studentNumber = "2023136001",
+            major = "컴퓨터공학부"
+        )
+
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertNull(updated.email)
+        assertNull(updated.nickname)
+    }
+
+    @Test
+    fun `성별을 여성으로 업데이트할 수 있다`() = runTest {
+        UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = "student@koreatech.ac.kr",
+            name = "홍길동",
+            nickname = "코인유저",
+            gender = Gender.Woman,
+            phoneNumber = "010-1234-5678",
+            studentNumber = "2023136001",
+            major = "컴퓨터공학부"
+        )
+
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertEquals(Gender.Woman, updated.gender)
+    }
+
+    @Test
+    fun `변경하지 않은 필드는 기존 값을 유지한다`() = runTest {
+        UpdateStudentUserInfoUseCase(userRepository)(
+            beforeUser = baseStudent,
+            email = baseStudent.email ?: "",
+            name = baseStudent.name ?: "",
+            nickname = baseStudent.nickname ?: "",
+            gender = baseStudent.gender,
+            phoneNumber = baseStudent.phoneNumber ?: "",
+            studentNumber = baseStudent.studentNumber ?: "",
+            major = baseStudent.major ?: ""
+        )
+
+        val updated = userRepository.getUpdatedUser() as User.Student
+        assertEquals(baseStudent.loginId, updated.loginId)
+        assertEquals(baseStudent.anonymousNickname, updated.anonymousNickname)
+        assertEquals(baseStudent.userType, updated.userType)
+        assertEquals(baseStudent.id, updated.id)
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1288

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
UserRepository 관련 UseCase 단위 테스트 추가

- `FakeUserRepository` TODO 전체 구현
- `FakeTokenRepository` TODO 전체 구현
- `CheckNicknameValidationUseCaseTest` 추가 (8개 테스트)
- `UpdateStudentUserInfoUseCaseTest` 추가 (6개 테스트)
- `SignupCheckingUseCaseTest` 추가 (12개 테스트)

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure with expanded mock repositories and new test suites for signup validation, nickname validation, and student user information updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->