### PR TITLE
[Koin Project][Chore] StoreRepository UseCase 단위 테스트 추가

### DIFF
--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
@@ -66,34 +66,90 @@ class FakeStoreRepository : StoreRepository {
 
     var lastCapturedMinimumOrderAmount: Int? = Int.MIN_VALUE
 
-    fun setFakeShops(shops: List<Shop>) { fakeShops = shops }
-    fun setFakeStores(stores: List<Store>) { fakeStores = stores }
-    fun setFakeStoreEvents(events: List<StoreEvent>) { fakeStoreEvents = events }
-    fun setFakeStoreCategories(categories: List<StoreCategories>) { fakeStoreCategories = categories }
-    fun setFakeStoreWithMenu(storeWithMenu: StoreWithMenu) { fakeStoreWithMenu = storeWithMenu }
-    fun setFakeStoreWithMenuV2(storeWithMenuV2: StoreWithMenuV2) { fakeStoreWithMenuV2 = storeWithMenuV2 }
-    fun setFakeStoreMenuCategories(categories: List<StoreMenuCategory>) { fakeStoreMenuCategories = categories }
-    fun setFakeStoreMenu(storeMenu: StoreMenu) { fakeStoreMenu = storeMenu }
-    fun setFakeShopEvents(shopEvents: ShopEvents) { fakeShopEvents = shopEvents }
-    fun setFakeStoreReview(storeReview: StoreReview) { fakeStoreReview = storeReview }
-    fun setFakeReviewDetail(reviewDetail: ReviewDetail) { fakeReviewDetail = reviewDetail }
-    fun setFakeStoreBenefit(storeBenefit: StoreBenefit) { fakeStoreBenefit = storeBenefit }
-    fun setFakeBenefitCategoryList(list: BenefitCategoryList) { fakeBenefitCategoryList = list }
-    fun setFakeShopSearchRelatedList(list: ShopSearchRelatedList) { fakeShopSearchRelatedList = list }
-    fun setFakeOrderableShopSearchRelated(related: OrderableShopSearchRelated) { fakeOrderableShopSearchRelated = related }
-    fun setFakeShopSummary(summary: ShopSummary) { fakeShopSummary = summary }
-    fun setFakeShopDetail(detail: ShopDetail) { fakeShopDetail = detail }
-    fun setFakeShopDeliveryAvailable(delivery: ShopDeliveryAvailable) { fakeShopDeliveryAvailable = delivery }
-    fun setFakeShopMenusList(menus: List<ShopMenus>) { fakeShopMenusList = menus }
-    fun setFakeShopMenu(menu: ShopMenu) { fakeShopMenu = menu }
-    fun setFakeShopMenusGroups(groups: List<ShopMenusGroup>) { fakeShopMenusGroups = groups }
-    fun setFakeOrderHistoryRelated(history: OrderHistoryRelated) { fakeOrderHistoryRelated = history }
-    fun setFakeCart(cart: Cart) { fakeCart = cart }
-    fun setFakeCartSummary(summary: CartSummary) { fakeCartSummary = summary }
-    fun setFakeCartPaymentSummary(summary: CartPaymentSummary) { fakeCartPaymentSummary = summary }
-    fun setFakeCartItemEdit(edit: CartItemEdit) { fakeCartItemEdit = edit }
-    fun setFakeCartItemsCount(count: CartItemsCount) { fakeCartItemsCount = count }
-    fun setFakeOrdersInProgress(orders: List<OrderInProgress>) { fakeOrdersInProgress = orders }
+    fun setFakeShops(shops: List<Shop>) {
+        fakeShops = shops
+    }
+    fun setFakeStores(stores: List<Store>) {
+        fakeStores = stores
+    }
+    fun setFakeStoreEvents(events: List<StoreEvent>) {
+        fakeStoreEvents = events
+    }
+    fun setFakeStoreCategories(categories: List<StoreCategories>) {
+        fakeStoreCategories = categories
+    }
+    fun setFakeStoreWithMenu(storeWithMenu: StoreWithMenu) {
+        fakeStoreWithMenu = storeWithMenu
+    }
+    fun setFakeStoreWithMenuV2(storeWithMenuV2: StoreWithMenuV2) {
+        fakeStoreWithMenuV2 = storeWithMenuV2
+    }
+    fun setFakeStoreMenuCategories(categories: List<StoreMenuCategory>) {
+        fakeStoreMenuCategories = categories
+    }
+    fun setFakeStoreMenu(storeMenu: StoreMenu) {
+        fakeStoreMenu = storeMenu
+    }
+    fun setFakeShopEvents(shopEvents: ShopEvents) {
+        fakeShopEvents = shopEvents
+    }
+    fun setFakeStoreReview(storeReview: StoreReview) {
+        fakeStoreReview = storeReview
+    }
+    fun setFakeReviewDetail(reviewDetail: ReviewDetail) {
+        fakeReviewDetail = reviewDetail
+    }
+    fun setFakeStoreBenefit(storeBenefit: StoreBenefit) {
+        fakeStoreBenefit = storeBenefit
+    }
+    fun setFakeBenefitCategoryList(list: BenefitCategoryList) {
+        fakeBenefitCategoryList = list
+    }
+    fun setFakeShopSearchRelatedList(list: ShopSearchRelatedList) {
+        fakeShopSearchRelatedList = list
+    }
+    fun setFakeOrderableShopSearchRelated(related: OrderableShopSearchRelated) {
+        fakeOrderableShopSearchRelated = related
+    }
+    fun setFakeShopSummary(summary: ShopSummary) {
+        fakeShopSummary = summary
+    }
+    fun setFakeShopDetail(detail: ShopDetail) {
+        fakeShopDetail = detail
+    }
+    fun setFakeShopDeliveryAvailable(delivery: ShopDeliveryAvailable) {
+        fakeShopDeliveryAvailable = delivery
+    }
+    fun setFakeShopMenusList(menus: List<ShopMenus>) {
+        fakeShopMenusList = menus
+    }
+    fun setFakeShopMenu(menu: ShopMenu) {
+        fakeShopMenu = menu
+    }
+    fun setFakeShopMenusGroups(groups: List<ShopMenusGroup>) {
+        fakeShopMenusGroups = groups
+    }
+    fun setFakeOrderHistoryRelated(history: OrderHistoryRelated) {
+        fakeOrderHistoryRelated = history
+    }
+    fun setFakeCart(cart: Cart) {
+        fakeCart = cart
+    }
+    fun setFakeCartSummary(summary: CartSummary) {
+        fakeCartSummary = summary
+    }
+    fun setFakeCartPaymentSummary(summary: CartPaymentSummary) {
+        fakeCartPaymentSummary = summary
+    }
+    fun setFakeCartItemEdit(edit: CartItemEdit) {
+        fakeCartItemEdit = edit
+    }
+    fun setFakeCartItemsCount(count: CartItemsCount) {
+        fakeCartItemsCount = count
+    }
+    fun setFakeOrdersInProgress(orders: List<OrderInProgress>) {
+        fakeOrdersInProgress = orders
+    }
 
     override suspend fun getStores(storeSorter: StoreSorter?, isOperating: Boolean?, isDelivery: Boolean?, query: String?): List<Store> =
         fakeStores

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
@@ -64,7 +64,9 @@ class FakeStoreRepository : StoreRepository {
     private var fakeCartItemsCount: CartItemsCount? = null
     private var fakeOrdersInProgress: List<OrderInProgress> = emptyList()
 
-    var lastCapturedMinimumOrderAmount: Int? = Int.MIN_VALUE
+    var lastCapturedMinimumOrderAmount: Int? = null
+    var lastCapturedSorter: String? = null
+    private var shouldFail = false
 
     fun setFakeShops(shops: List<Shop>) {
         fakeShops = shops
@@ -150,6 +152,9 @@ class FakeStoreRepository : StoreRepository {
     fun setFakeOrdersInProgress(orders: List<OrderInProgress>) {
         fakeOrdersInProgress = orders
     }
+    fun setShouldFail(value: Boolean) {
+        shouldFail = value
+    }
 
     override suspend fun getStores(storeSorter: StoreSorter?, isOperating: Boolean?, isDelivery: Boolean?, query: String?): List<Store> =
         fakeStores
@@ -206,6 +211,8 @@ class FakeStoreRepository : StoreRepository {
 
     override suspend fun getOrderableShops(sorter: String?, filter: List<String>, categoryFilter: Int?, minimumOrderAmount: Int?): Result<List<Shop>> {
         lastCapturedMinimumOrderAmount = minimumOrderAmount
+        lastCapturedSorter = sorter
+        if (shouldFail) return Result.failure(RuntimeException("Network error"))
         return Result.success(fakeShops)
     }
 

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeStoreRepository.kt
@@ -36,168 +36,189 @@ import `in`.koreatech.koin.domain.model.store.StoreWithMenuV2
 
 class FakeStoreRepository : StoreRepository {
     private var fakeShops: List<Shop> = emptyList()
+    private var fakeStores: List<Store> = emptyList()
+    private var fakeStoreEvents: List<StoreEvent> = emptyList()
+    private var fakeStoreCategories: List<StoreCategories> = emptyList()
+    private var fakeStoreWithMenu: StoreWithMenu? = null
+    private var fakeStoreWithMenuV2: StoreWithMenuV2? = null
+    private var fakeStoreMenuCategories: List<StoreMenuCategory> = emptyList()
+    private var fakeStoreMenu: StoreMenu? = null
+    private var fakeShopEvents: ShopEvents? = null
+    private var fakeStoreReview: StoreReview? = null
+    private var fakeReviewDetail: ReviewDetail? = null
+    private var fakeStoreBenefit: StoreBenefit? = null
+    private var fakeBenefitCategoryList: BenefitCategoryList? = null
+    private var fakeShopSearchRelatedList: ShopSearchRelatedList? = null
+    private var fakeOrderableShopSearchRelated: OrderableShopSearchRelated? = null
+    private var fakeShopSummary: ShopSummary? = null
+    private var fakeShopDetail: ShopDetail? = null
+    private var fakeShopDeliveryAvailable: ShopDeliveryAvailable? = null
+    private var fakeShopMenusList: List<ShopMenus> = emptyList()
+    private var fakeShopMenu: ShopMenu? = null
+    private var fakeShopMenusGroups: List<ShopMenusGroup> = emptyList()
+    private var fakeOrderHistoryRelated: OrderHistoryRelated? = null
+    private var fakeCart: Cart? = null
+    private var fakeCartSummary: CartSummary? = null
+    private var fakeCartPaymentSummary: CartPaymentSummary? = null
+    private var fakeCartItemEdit: CartItemEdit? = null
+    private var fakeCartItemsCount: CartItemsCount? = null
+    private var fakeOrdersInProgress: List<OrderInProgress> = emptyList()
 
-    fun setFakeShops(shops: List<Shop>) {
-        fakeShops = shops
+    var lastCapturedMinimumOrderAmount: Int? = Int.MIN_VALUE
+
+    fun setFakeShops(shops: List<Shop>) { fakeShops = shops }
+    fun setFakeStores(stores: List<Store>) { fakeStores = stores }
+    fun setFakeStoreEvents(events: List<StoreEvent>) { fakeStoreEvents = events }
+    fun setFakeStoreCategories(categories: List<StoreCategories>) { fakeStoreCategories = categories }
+    fun setFakeStoreWithMenu(storeWithMenu: StoreWithMenu) { fakeStoreWithMenu = storeWithMenu }
+    fun setFakeStoreWithMenuV2(storeWithMenuV2: StoreWithMenuV2) { fakeStoreWithMenuV2 = storeWithMenuV2 }
+    fun setFakeStoreMenuCategories(categories: List<StoreMenuCategory>) { fakeStoreMenuCategories = categories }
+    fun setFakeStoreMenu(storeMenu: StoreMenu) { fakeStoreMenu = storeMenu }
+    fun setFakeShopEvents(shopEvents: ShopEvents) { fakeShopEvents = shopEvents }
+    fun setFakeStoreReview(storeReview: StoreReview) { fakeStoreReview = storeReview }
+    fun setFakeReviewDetail(reviewDetail: ReviewDetail) { fakeReviewDetail = reviewDetail }
+    fun setFakeStoreBenefit(storeBenefit: StoreBenefit) { fakeStoreBenefit = storeBenefit }
+    fun setFakeBenefitCategoryList(list: BenefitCategoryList) { fakeBenefitCategoryList = list }
+    fun setFakeShopSearchRelatedList(list: ShopSearchRelatedList) { fakeShopSearchRelatedList = list }
+    fun setFakeOrderableShopSearchRelated(related: OrderableShopSearchRelated) { fakeOrderableShopSearchRelated = related }
+    fun setFakeShopSummary(summary: ShopSummary) { fakeShopSummary = summary }
+    fun setFakeShopDetail(detail: ShopDetail) { fakeShopDetail = detail }
+    fun setFakeShopDeliveryAvailable(delivery: ShopDeliveryAvailable) { fakeShopDeliveryAvailable = delivery }
+    fun setFakeShopMenusList(menus: List<ShopMenus>) { fakeShopMenusList = menus }
+    fun setFakeShopMenu(menu: ShopMenu) { fakeShopMenu = menu }
+    fun setFakeShopMenusGroups(groups: List<ShopMenusGroup>) { fakeShopMenusGroups = groups }
+    fun setFakeOrderHistoryRelated(history: OrderHistoryRelated) { fakeOrderHistoryRelated = history }
+    fun setFakeCart(cart: Cart) { fakeCart = cart }
+    fun setFakeCartSummary(summary: CartSummary) { fakeCartSummary = summary }
+    fun setFakeCartPaymentSummary(summary: CartPaymentSummary) { fakeCartPaymentSummary = summary }
+    fun setFakeCartItemEdit(edit: CartItemEdit) { fakeCartItemEdit = edit }
+    fun setFakeCartItemsCount(count: CartItemsCount) { fakeCartItemsCount = count }
+    fun setFakeOrdersInProgress(orders: List<OrderInProgress>) { fakeOrdersInProgress = orders }
+
+    override suspend fun getStores(storeSorter: StoreSorter?, isOperating: Boolean?, isDelivery: Boolean?, query: String?): List<Store> =
+        fakeStores
+
+    override suspend fun getStoreEvents(): List<StoreEvent> = fakeStoreEvents
+
+    override suspend fun getStoreCategories(): List<StoreCategories> = fakeStoreCategories
+
+    override suspend fun getStoreWithMenu(storeId: Int): StoreWithMenu =
+        fakeStoreWithMenu ?: throw IllegalStateException("No StoreWithMenu set")
+
+    override suspend fun getStoreWithMenuV2(storeId: Int): StoreWithMenuV2 =
+        fakeStoreWithMenuV2 ?: throw IllegalStateException("No StoreWithMenuV2 set")
+
+    override suspend fun getStoreMenuCategory(storeId: Int): List<StoreMenuCategory> =
+        fakeStoreMenuCategories
+
+    override suspend fun getShopMenus(storeId: Int): StoreMenu =
+        fakeStoreMenu ?: throw IllegalStateException("No StoreMenu set")
+
+    override suspend fun getShopEvents(storeId: Int): ShopEvents =
+        fakeShopEvents ?: throw IllegalStateException("No ShopEvents set")
+
+    override suspend fun getStoreReviews(storeId: Int): StoreReview =
+        fakeStoreReview ?: throw IllegalStateException("No StoreReview set")
+
+    override suspend fun invalidateStores() {}
+
+    override suspend fun writeReview(shopId: Int, content: Review) {}
+
+    override suspend fun deleteReview(reviewId: Int, shopId: Int): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun modifyReview(reviewId: Int, shopId: Int, content: Review) {}
+
+    override suspend fun searchReview(reviewId: Int, shopId: Int): ReviewDetail =
+        fakeReviewDetail ?: throw IllegalStateException("No ReviewDetail set")
+
+    override suspend fun reportReview(storeId: Int?, reviewId: Int?, reportList: List<StoreReport>?): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun getStoreBenefitShopList(uid: Int): StoreBenefit =
+        fakeStoreBenefit ?: throw IllegalStateException("No StoreBenefit set")
+
+    override suspend fun getStoreBenefitCategories(): BenefitCategoryList =
+        fakeBenefitCategoryList ?: throw IllegalStateException("No BenefitCategoryList set")
+
+    override suspend fun getShopSearchRelatedList(query: String): ShopSearchRelatedList =
+        fakeShopSearchRelatedList ?: throw IllegalStateException("No ShopSearchRelatedList set")
+
+    override suspend fun getShopSearchRelatedListV2(keyword: String): Result<OrderableShopSearchRelated> =
+        fakeOrderableShopSearchRelated?.let { Result.success(it) }
+            ?: throw IllegalStateException("No OrderableShopSearchRelated set")
+
+    override suspend fun getOrderableShops(sorter: String?, filter: List<String>, categoryFilter: Int?, minimumOrderAmount: Int?): Result<List<Shop>> {
+        lastCapturedMinimumOrderAmount = minimumOrderAmount
+        return Result.success(fakeShops)
     }
-
-    override suspend fun getStores(storeSorter: StoreSorter?, isOperating: Boolean?, isDelivery: Boolean?, query: String?): List<Store> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreEvents(): List<StoreEvent> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreCategories(): List<StoreCategories> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreWithMenu(storeId: Int): StoreWithMenu {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreWithMenuV2(storeId: Int): StoreWithMenuV2 {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreMenuCategory(storeId: Int): List<StoreMenuCategory> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getShopMenus(storeId: Int): StoreMenu {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getShopEvents(storeId: Int): ShopEvents {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreReviews(storeId: Int): StoreReview {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun invalidateStores() {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun writeReview(shopId: Int, content: Review) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun deleteReview(reviewId: Int, shopId: Int): Result<Unit> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun modifyReview(reviewId: Int, shopId: Int, content: Review) {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun searchReview(reviewId: Int, shopId: Int): ReviewDetail {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun reportReview(storeId: Int?, reviewId: Int?, reportList: List<StoreReport>?): Result<Unit> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreBenefitShopList(uid: Int): StoreBenefit {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getStoreBenefitCategories(): BenefitCategoryList {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getShopSearchRelatedList(query: String): ShopSearchRelatedList {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getShopSearchRelatedListV2(keyword: String): Result<OrderableShopSearchRelated> {
-        TODO("Not yet implemented")
-    }
-
-    override suspend fun getOrderableShops(sorter: String?, filter: List<String>, categoryFilter: Int?, minimumOrderAmount: Int?): Result<List<Shop>> = Result.success(fakeShops)
 
     override suspend fun getNearbyShops(): Result<List<Shop>> = Result.success(fakeShops)
 
-    override suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopSummary(shopId: Int): Result<ShopSummary> =
+        fakeShopSummary?.let { Result.success(it) }
+            ?: throw IllegalStateException("No ShopSummary set")
 
-    override suspend fun getOrderableShopDetail(shopId: Int): Result<ShopDetail> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopDetail(shopId: Int): Result<ShopDetail> =
+        fakeShopDetail?.let { Result.success(it) }
+            ?: throw IllegalStateException("No ShopDetail set")
 
-    override suspend fun getOrderableShopDelivery(shopId: Int): Result<ShopDeliveryAvailable> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopDelivery(shopId: Int): Result<ShopDeliveryAvailable> =
+        fakeShopDeliveryAvailable?.let { Result.success(it) }
+            ?: throw IllegalStateException("No ShopDeliveryAvailable set")
 
-    override suspend fun getOrderableShopMenus(shopId: Int): Result<List<ShopMenus>> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopMenus(shopId: Int): Result<List<ShopMenus>> =
+        Result.success(fakeShopMenusList)
 
-    override suspend fun getOrderableShopMenu(shopId: Int, menuId: Int): Result<ShopMenu> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopMenu(shopId: Int, menuId: Int): Result<ShopMenu> =
+        fakeShopMenu?.let { Result.success(it) }
+            ?: throw IllegalStateException("No ShopMenu set")
 
-    override suspend fun getOrderableShopMenuGroups(shopId: Int): Result<List<ShopMenusGroup>> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopMenuGroups(shopId: Int): Result<List<ShopMenusGroup>> =
+        Result.success(fakeShopMenusGroups)
 
-    override suspend fun getOrderableShopSearchRelated(query: String): Result<OrderableShopSearchRelated> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderableShopSearchRelated(query: String): Result<OrderableShopSearchRelated> =
+        fakeOrderableShopSearchRelated?.let { Result.success(it) }
+            ?: throw IllegalStateException("No OrderableShopSearchRelated set")
 
-    override suspend fun getOrderHistories(page: Int?, limit: Int?, period: String?, status: String?, type: String?, query: String?): Result<OrderHistoryRelated> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderHistories(page: Int?, limit: Int?, period: String?, status: String?, type: String?, query: String?): Result<OrderHistoryRelated> =
+        fakeOrderHistoryRelated?.let { Result.success(it) }
+            ?: throw IllegalStateException("No OrderHistoryRelated set")
 
-    override suspend fun updateCartItem(cartMenuItemId: Int, cartItem: CartItem): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun updateCartItem(cartMenuItemId: Int, cartItem: CartItem): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun updateCartItemQuantity(cartMenuItemId: Int, quantity: Int): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun updateCartItemQuantity(cartMenuItemId: Int, quantity: Int): Result<Unit> =
+        Result.success(Unit)
 
-    override suspend fun addCartItem(cartAdd: CartAdd): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun addCartItem(cartAdd: CartAdd): Result<Unit> = Result.success(Unit)
 
-    override suspend fun getCartItems(type: String): Result<Cart> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCartItems(type: String): Result<Cart> =
+        fakeCart?.let { Result.success(it) }
+            ?: throw IllegalStateException("No Cart set")
 
-    override suspend fun validateCartItems(orderType: String): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun validateCartItems(orderType: String): Result<Unit> = Result.success(Unit)
 
-    override suspend fun getCartSummary(orderableShopId: Int): Result<CartSummary> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCartSummary(orderableShopId: Int): Result<CartSummary> =
+        fakeCartSummary?.let { Result.success(it) }
+            ?: throw IllegalStateException("No CartSummary set")
 
-    override suspend fun getCartPaymentSummary(type: String): Result<CartPaymentSummary> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCartPaymentSummary(type: String): Result<CartPaymentSummary> =
+        fakeCartPaymentSummary?.let { Result.success(it) }
+            ?: throw IllegalStateException("No CartPaymentSummary set")
 
-    override suspend fun getCartItemEdit(cartMenuItemId: Int): Result<CartItemEdit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCartItemEdit(cartMenuItemId: Int): Result<CartItemEdit> =
+        fakeCartItemEdit?.let { Result.success(it) }
+            ?: throw IllegalStateException("No CartItemEdit set")
 
-    override suspend fun resetCart(): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun resetCart(): Result<Unit> = Result.success(Unit)
 
-    override suspend fun deleteCartItem(cartMenuItemId: Int): Result<Unit> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun deleteCartItem(cartMenuItemId: Int): Result<Unit> = Result.success(Unit)
 
-    override suspend fun getCartItemsCount(): Result<CartItemsCount> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getCartItemsCount(): Result<CartItemsCount> =
+        fakeCartItemsCount?.let { Result.success(it) }
+            ?: throw IllegalStateException("No CartItemsCount set")
 
-    override suspend fun getOrderInProgress(): Result<List<OrderInProgress>> {
-        TODO("Not yet implemented")
-    }
+    override suspend fun getOrderInProgress(): Result<List<OrderInProgress>> =
+        Result.success(fakeOrdersInProgress)
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
@@ -5,6 +5,7 @@ import `in`.koreatech.koin.domain.model.store.Shop
 import `in`.koreatech.koin.domain.repository.FakeStoreRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -105,13 +106,14 @@ class GetOrderableShopsUseCaseTest {
     @Test
     fun `정렬 옵션 없이 가져오면 기본값(NONE)으로 저장소에 전달된다`() = runTest {
         val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
-        val result = getOrderableShopsUseCase()
 
-        assertTrue(result.isSuccess)
+        getOrderableShopsUseCase()
+
+        assertEquals("NONE", storeRepository.lastCapturedSorter)
     }
 
     @Test
-    fun `저장소 호출 실패 시 실패 결과를 반환한다`() = runTest {
+    fun `저장소가 비어있을 때 빈 리스트를 반환한다`() = runTest {
         storeRepository.setFakeShops(emptyList())
         val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
 
@@ -119,5 +121,15 @@ class GetOrderableShopsUseCaseTest {
 
         assertTrue(result.isSuccess)
         assertTrue(result.getOrThrow().isEmpty())
+    }
+
+    @Test
+    fun `저장소 호출 실패 시 실패 결과를 반환한다`() = runTest {
+        storeRepository.setShouldFail(true)
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+
+        val result = getOrderableShopsUseCase()
+
+        assertFalse(result.isSuccess)
     }
 }

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.domain.usecase.store
 
 import `in`.koreatech.koin.domain.model.store.OpenStatus
 import `in`.koreatech.koin.domain.model.store.Shop
-import `in`.koreatech.koin.domain.model.store.StoreSorter
 import `in`.koreatech.koin.domain.repository.FakeStoreRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/store/GetOrderableShopsUseCaseTest.kt
@@ -1,0 +1,124 @@
+package `in`.koreatech.koin.domain.usecase.store
+
+import `in`.koreatech.koin.domain.model.store.OpenStatus
+import `in`.koreatech.koin.domain.model.store.Shop
+import `in`.koreatech.koin.domain.model.store.StoreSorter
+import `in`.koreatech.koin.domain.repository.FakeStoreRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class GetOrderableShopsUseCaseTest {
+
+    private lateinit var storeRepository: FakeStoreRepository
+
+    private val fakeShops = listOf(
+        Shop(
+            shopId = 1,
+            orderableShopId = 1,
+            name = "pizza",
+            isDeliveryAvailable = true,
+            isTakeoutAvailable = true,
+            serviceEvent = false,
+            minimumOrderAmount = 10000,
+            ratingAverage = 4.5,
+            reviewCount = 10,
+            minimumDeliveryTip = 0,
+            maximumDeliveryTip = 0,
+            isOpen = true,
+            categoryIds = listOf(1, 2),
+            images = emptyList(),
+            openStatus = OpenStatus.OPERATING
+        ),
+        Shop(
+            shopId = 2,
+            orderableShopId = 2,
+            name = "chicken",
+            isDeliveryAvailable = true,
+            isTakeoutAvailable = false,
+            serviceEvent = false,
+            minimumOrderAmount = 15000,
+            ratingAverage = 3.0,
+            reviewCount = 5,
+            minimumDeliveryTip = 1000,
+            maximumDeliveryTip = 3000,
+            isOpen = false,
+            categoryIds = listOf(1, 3),
+            images = emptyList(),
+            openStatus = OpenStatus.CLOSED
+        ),
+        Shop(
+            shopId = 3,
+            orderableShopId = 3,
+            name = "burger",
+            isDeliveryAvailable = false,
+            isTakeoutAvailable = true,
+            serviceEvent = false,
+            minimumOrderAmount = 5000,
+            ratingAverage = 4.0,
+            reviewCount = 20,
+            minimumDeliveryTip = 0,
+            maximumDeliveryTip = 0,
+            isOpen = true,
+            categoryIds = listOf(1, 4),
+            images = emptyList(),
+            openStatus = OpenStatus.OPERATING
+        )
+    )
+
+    @Before
+    fun setUp() {
+        storeRepository = FakeStoreRepository()
+        storeRepository.setFakeShops(fakeShops)
+    }
+
+    @Test
+    fun `주문 가능한 상점 목록을 가져온다`() = runTest {
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+        val result = getOrderableShopsUseCase()
+
+        assertTrue(result.isSuccess)
+        assertEquals(fakeShops.size, result.getOrThrow().size)
+    }
+
+    @Test
+    fun `minimumOrderAmount가 Int MAX_VALUE이면 저장소에 null로 전달된다`() = runTest {
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+
+        getOrderableShopsUseCase(minimumOrderAmount = Int.MAX_VALUE)
+
+        assertNull(storeRepository.lastCapturedMinimumOrderAmount)
+    }
+
+    @Test
+    fun `minimumOrderAmount가 유효한 값이면 해당 값을 그대로 저장소에 전달한다`() = runTest {
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+        val minimumOrderAmount = 10000
+
+        getOrderableShopsUseCase(minimumOrderAmount = minimumOrderAmount)
+
+        assertEquals(minimumOrderAmount, storeRepository.lastCapturedMinimumOrderAmount)
+    }
+
+    @Test
+    fun `정렬 옵션 없이 가져오면 기본값(NONE)으로 저장소에 전달된다`() = runTest {
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+        val result = getOrderableShopsUseCase()
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `저장소 호출 실패 시 실패 결과를 반환한다`() = runTest {
+        storeRepository.setFakeShops(emptyList())
+        val getOrderableShopsUseCase = GetOrderableShopsUseCase(storeRepository)
+
+        val result = getOrderableShopsUseCase()
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow().isEmpty())
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1288

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
StoreRepository 관련 UseCase 단위 테스트 추가

- `FakeStoreRepository` TODO 전체 구현
- `GetOrderableShopsUseCaseTest` 추가 (5개 테스트)

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for orderable shop retrieval, covering success, empty results, minimum-order forwarding, and sorting behavior.

* **Chores**
  * Introduced a configurable, data-driven fake repository for tests with public setters and captured state to make test scenarios deterministic and easier to seed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->