### PR TITLE
[Feature] Kover 커버리지 설정 - feature 모듈 ViewModel만 검사, core 모듈 제외

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     compileOnly(libs.kotlin.gradle)
     compileOnly(libs.android.gradle.tool)
     compileOnly(libs.detekt.gradle.plugin)
+    compileOnly(libs.kover.gradle.plugin)
 }
 
 gradlePlugin {

--- a/build-logic/convention/src/main/java/AndroidFeatureConventionPlugin.kt
+++ b/build-logic/convention/src/main/java/AndroidFeatureConventionPlugin.kt
@@ -7,6 +7,7 @@ import `in`.koreatech.convention.configureDetekt
 import `in`.koreatech.convention.configureTest
 import `in`.koreatech.convention.libs
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -35,6 +36,16 @@ internal class AndroidFeatureConventionPlugin : Plugin<Project> {
 
             extensions.configure<DetektExtension> {
                 configureDetekt(this)
+            }
+
+            extensions.configure<KoverProjectExtension> {
+                reports {
+                    filters {
+                        includes {
+                            classes("*ViewModel")
+                        }
+                    }
+                }
             }
         }
     }

--- a/core/analytics/build.gradle.kts
+++ b/core/analytics/build.gradle.kts
@@ -28,3 +28,13 @@ dependencies {
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.androidx.test.espresso.core)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -22,3 +22,13 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug.test)
     androidTestImplementation(libs.androidx.compose.ui.test.manifest)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -18,3 +18,13 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.bundles.compose.m3)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -11,3 +11,13 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/notification/build.gradle.kts
+++ b/core/notification/build.gradle.kts
@@ -12,3 +12,13 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.timber)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/onboarding/build.gradle.kts
+++ b/core/onboarding/build.gradle.kts
@@ -23,3 +23,13 @@ dependencies {
     implementation(libs.balloon)
     implementation(libs.balloon.compose)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/core/webapp/build.gradle.kts
+++ b/core/webapp/build.gradle.kts
@@ -24,3 +24,13 @@ dependencies {
     debugImplementation(libs.bundles.compose.debug.test)
     androidTestImplementation(libs.androidx.compose.ui.test.manifest)
 }
+
+kover {
+    reports {
+        filters {
+            excludes {
+                classes("*")
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -130,6 +130,7 @@ colorpicker = { module = "com.github.duanhong169:colorpicker", version.ref = "co
 compose-numberPicker = { module = "com.chargemap.compose:numberpicker", version.ref = "composeNumberPicker" }
 desugar_jdk_libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
 detekt-gradle-plugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
+kover-gradle-plugin = { group = "org.jetbrains.kotlinx", name = "kover-gradle-plugin", version.ref = "kover" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
 firebase-analytics-ktx = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-appdistribution-gradle = { group = "com.google.firebase", name = "firebase-appdistribution-gradle", version.ref = "firebaseAppdistributionGradle" }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1301

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `AndroidFeatureConventionPlugin`에 Kover 필터 추가 — feature 모듈은 `*ViewModel` 클래스만 커버리지 검사 대상으로 설정
- core 모듈(`analytics`, `designsystem`, `navigation`, `network`, `notification`, `onboarding`, `webapp`) Kover 커버리지 검사에서 제외

### 논의 사항

core 의 경우 모두 android 의존 코드이기에 Unit test 로 불가능합니다. 그에 따라 core 의 모든 모듈은 개별적으로 제외됩니다.

현재 검사하는 부분은

featue:  ViewModel 파일만
data

의 부분만 kover 에 coverage 검사를 진행합니다.

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다