### PR TITLE
[Chore] @Preview 함수에 private 접근 제한자 추가

### DIFF
--- a/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/dialog/MessageDialog.kt
+++ b/core/designsystem/src/main/java/in/koreatech/koin/core/designsystem/component/dialog/MessageDialog.kt
@@ -79,7 +79,7 @@ fun MessageDialog(
 
 @Preview
 @Composable
-fun PreviewMassageDialog() {
+private fun PreviewMassageDialog() {
     MessageDialog(
         title = "요일을 선택해 주세요."
     )

--- a/feature/article/src/main/java/in/koreatech/koin/feature/article/component/LoadingDialog.kt
+++ b/feature/article/src/main/java/in/koreatech/koin/feature/article/component/LoadingDialog.kt
@@ -43,6 +43,6 @@ fun LoadingDialog() {
 
 @Preview
 @Composable
-fun LoadingDialogPreview() {
+private fun LoadingDialogPreview() {
     LoadingDialog()
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerA.kt
@@ -117,6 +117,6 @@ fun BannerA(
 
 @Preview
 @Composable
-fun BannerPreview() {
+private fun BannerPreview() {
     BannerA(persistentListOf(), 0)
 }

--- a/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
+++ b/feature/banner/src/main/java/in/koreatech/koin/feature/banner/component/BannerB.kt
@@ -115,7 +115,7 @@ fun BannerB(
 
 @Preview
 @Composable
-fun BannerBPreview() {
+private fun BannerBPreview() {
     KoinTheme {
         BannerB(
             bannerList = persistentListOf(),

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailRouteCard.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailRouteCard.kt
@@ -47,7 +47,7 @@ fun CallvanDetailRouteCard(
 
 @Preview(showBackground = true)
 @Composable
-fun CallvanDetailRouteCardPreview() {
+private fun CallvanDetailRouteCardPreview() {
     CallvanDetailRouteCard(
         departure = "테니스장",
         destination = "천안 시외터미널",

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/component/ChatListItem.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/component/ChatListItem.kt
@@ -157,7 +157,7 @@ fun ChatListItem(
 
 @Preview(showBackground = true)
 @Composable
-fun ChatListItemPreview() {
+private fun ChatListItemPreview() {
     ChatListItem(
         title = "Title",
         recentMessage = " Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque vitae risus condimentum leo facilisis luctus. Vestibulum viverra justo eu leo dictum, sit amet fermentum nisi facilisis. Mauris sagittis dignissim massa, ac varius enim faucibus id. Etiam tempus dolor et diam tempus consectetur. Nulla facilisi. Pellentesque ex nisi, varius eu pellentesque in, scelerisque sed nisl. Morbi tincidunt vestibulum sapien, at mattis erat tempus in. Sed consequat non ligula eget eleifend. Nulla tempor eleifend ligula sed dapibus. Nunc fringilla cursus felis. Curabitur egestas arcu non sodales mollis. ",

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -327,7 +327,7 @@ private fun ChatBubbleImage(
 
 @Preview
 @Composable
-fun ChatBubblePreview() {
+private fun ChatBubblePreview() {
     KoinSurface {
         Column {
             ChatBubble(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatDateTitle.kt
@@ -71,6 +71,6 @@ fun ChatDateTitle(
 
 @Preview
 @Composable
-fun ChatDateTitlePreview() {
+private fun ChatDateTitlePreview() {
     ChatDateTitle(date = LocalDate.now())
 }

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatInput.kt
@@ -188,7 +188,7 @@ fun ChatTextField(
 
 @Preview
 @Composable
-fun ChatInputPreview() {
+private fun ChatInputPreview() {
     KoinSurface {
         ChatInput(
             modifier = Modifier,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/DetailDialog.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/DetailDialog.kt
@@ -102,7 +102,7 @@ fun DetailDialog(
 
 @Preview
 @Composable
-fun DetailDialogPreview() {
+private fun DetailDialogPreview() {
     DetailDialog(
         title = "동아리 생성 안내사항"
     )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubCategoryItem.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubCategoryItem.kt
@@ -70,7 +70,7 @@ fun KoinClubCategoryItem(
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewKoinClubCategoryItem() {
+private fun PreviewKoinClubCategoryItem() {
     KoinClubCategoryItem(
         categoryName = "운동",
         icon = painterResource(id = R.drawable.ic_club_category_sports),

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubListItem.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubListItem.kt
@@ -111,7 +111,7 @@ fun KoinClubListItem(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinClubListItemPreview() {
+private fun KoinClubListItemPreview() {
     KoinTheme {
         Box {
             KoinClubListItem(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubMessageDialog.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubMessageDialog.kt
@@ -71,7 +71,7 @@ fun KoinClubMessageDialog(
 
 @Preview
 @Composable
-fun KoinClubMessageDialogPreview() {
+private fun KoinClubMessageDialogPreview() {
     KoinTheme {
         KoinClubMessageDialog(
             title = "제목",

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubRecruitmentLabel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubRecruitmentLabel.kt
@@ -52,7 +52,7 @@ fun KoinClubRecruitmentLabel(
 
 @Preview
 @Composable
-fun KoinClubRecruitmentLabelPreview() {
+private fun KoinClubRecruitmentLabelPreview() {
     KoinTheme {
         KoinClubRecruitmentLabel(
             labelType = KoinClubRecruitmentLabelType.RECRUITING

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSwitch.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/component/KoinClubSwitch.kt
@@ -67,7 +67,7 @@ fun KoinClubSwitch(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinClubSwitchPreview() {
+private fun KoinClubSwitchPreview() {
     KoinClubSwitch(
         checked = true
     )

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/MainClubWidget.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/MainClubWidget.kt
@@ -159,7 +159,7 @@ fun MainClubWidgetB(
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewMainClubWidgetA() {
+private fun PreviewMainClubWidgetA() {
     KoinTheme {
         MainClubWidgetA()
     }
@@ -167,7 +167,7 @@ fun PreviewMainClubWidgetA() {
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewMainClubWidgetB() {
+private fun PreviewMainClubWidgetB() {
     KoinTheme {
         MainClubWidgetB(
             hotClubId = 0,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateScreen.kt
@@ -644,7 +644,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun ClubCreateScreenPreview() {
+private fun ClubCreateScreenPreview() {
     ClubCreateScreenImpl(
         isLoading = false,
         clubName = "Club Name",

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/eventbox/DetailEventBox.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/eventbox/DetailEventBox.kt
@@ -154,7 +154,7 @@ fun DetailEventBox(
 
 @Preview(showBackground = true)
 @Composable
-fun DetailEventBoxPreview() {
+private fun DetailEventBoxPreview() {
     DetailEventBox(
         eventName = "2025년 제22회 깔끔한 행사 명 선발 대회",
         stateText = "곧 행사 진행",
@@ -166,7 +166,7 @@ fun DetailEventBoxPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun DetailEventBoxDisablePreview() {
+private fun DetailEventBoxDisablePreview() {
     DetailEventBox(
         eventName = "2025년 제22회 깔끔한 행사 명 선발 대회",
         stateText = "마감된 행사",

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/component/textfield/DetailQnaTextField.kt
@@ -129,7 +129,7 @@ fun DetailQnaTextField(
 
 @Preview
 @Composable
-fun DetailQnaTextFieldTextPreview() {
+private fun DetailQnaTextFieldTextPreview() {
     DetailQnaTextField(
         value = "답변"
     )
@@ -137,7 +137,7 @@ fun DetailQnaTextFieldTextPreview() {
 
 @Preview
 @Composable
-fun DetailQnaTextFieldHintPreview() {
+private fun DetailQnaTextFieldHintPreview() {
     DetailQnaTextField(
         value = ""
     )
@@ -145,7 +145,7 @@ fun DetailQnaTextFieldHintPreview() {
 
 @Preview
 @Composable
-fun DetailQnaTextFieldNoIconPreview() {
+private fun DetailQnaTextFieldNoIconPreview() {
     DetailQnaTextField(
         value = "",
         isSendIconVisible = false
@@ -154,7 +154,7 @@ fun DetailQnaTextFieldNoIconPreview() {
 
 @Preview
 @Composable
-fun DetailQnaTextFieldErrorPreview() {
+private fun DetailQnaTextFieldErrorPreview() {
     DetailQnaTextField(
         value = "",
         isSendIconVisible = false,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/events/ClubDetailEventInfo.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/events/ClubDetailEventInfo.kt
@@ -269,7 +269,7 @@ fun ClubDetailEventInfo(
 
 @Preview(showBackground = true)
 @Composable
-fun ClubDetailEventInfoManagerPreview() {
+private fun ClubDetailEventInfoManagerPreview() {
     ClubDetailEventInfo(
         ParcelizeClubEvent(
             id = 1,

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/events/ClubDetailEvents.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/events/ClubDetailEvents.kt
@@ -134,7 +134,7 @@ fun ClubDetailEvents(
 
 @Preview(showBackground = true)
 @Composable
-fun ClubDetailEventsPreview() {
+private fun ClubDetailEventsPreview() {
     ClubDetailEvents(
         isDropdownExpanded = false,
         clubEvents = immutableListOf(
@@ -157,7 +157,7 @@ fun ClubDetailEventsPreview() {
 
 @Preview(showBackground = true)
 @Composable
-fun ClubDetailEventsManagerPreview() {
+private fun ClubDetailEventsManagerPreview() {
     ClubDetailEvents(
         isDropdownExpanded = false,
         clubEvents = immutableListOf(

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/intro/ClubDetailIntro.kt
@@ -72,7 +72,7 @@ fun ClubDetailIntro(
 
 @Preview
 @Composable
-fun ClubDetailIntroPreview() {
+private fun ClubDetailIntroPreview() {
     ClubDetailIntro(
         introduction = "introduction",
         modifier = Modifier

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListScreen.kt
@@ -507,7 +507,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun ClubListScreenPreview() {
+private fun ClubListScreenPreview() {
     ClubListScreenImpl(
         isLoading = false,
         clubList = emptyList(),

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
@@ -551,7 +551,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun ClubModifyScreenPreview() {
+private fun ClubModifyScreenPreview() {
     ClubModifyScreenImpl(
         isLoading = false,
         clubName = "Club Name",

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/abTeset/DiningAbTestFloatingButton.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/component/abTeset/DiningAbTestFloatingButton.kt
@@ -66,7 +66,7 @@ fun DiningAbTestFloatingButton(
 
 @Preview
 @Composable
-fun DiningAbTestFloatingButtonPreview() {
+private fun DiningAbTestFloatingButtonPreview() {
     DiningAbTestFloatingButton(
         contentText = "오늘 학식 메뉴가 별로라면?",
         buttonText = "주변상점 보기",

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LoadingDialog.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LoadingDialog.kt
@@ -43,6 +43,6 @@ fun LoadingDialog() {
 
 @Preview
 @Composable
-fun LoadingDialogPreview() {
+private fun LoadingDialogPreview() {
     LoadingDialog()
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/component/LostAndFoundReportContent.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/component/LostAndFoundReportContent.kt
@@ -62,7 +62,7 @@ fun LostAndFoundReportContent(
 
 @Preview
 @Composable
-fun LostAndFoundReportContentPreview() {
+private fun LostAndFoundReportContentPreview() {
     KoinSurface {
         LostAndFoundReportContent(
             itemList = lostAndFoundReportReasonList,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/component/LostAndFoundReportReasons.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/component/LostAndFoundReportReasons.kt
@@ -215,7 +215,7 @@ fun ReportTextField(
 
 @Preview
 @Composable
-fun PreviewLostAndFoundReportReasons() {
+private fun PreviewLostAndFoundReportReasons() {
     KoinSurface {
         LostAndFoundReportReasons(
             itemList = lostAndFoundReportReasonList,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/cart/component/DeleteMenuDialog.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/cart/component/DeleteMenuDialog.kt
@@ -97,7 +97,7 @@ fun DeleteCartDialog(
 
 @Composable
 @Preview
-fun DeleteCartDialogPreview() {
+private fun DeleteCartDialogPreview() {
     DeleteCartDialog(
         onConfirm = {},
         onDismiss = {},

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/CustomRadioButton.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/CustomRadioButton.kt
@@ -47,7 +47,7 @@ fun CustomRadioButton(
 
 @Preview
 @Composable
-fun CustomRadioButtonPreview() {
+private fun CustomRadioButtonPreview() {
     Column(
         verticalArrangement = Arrangement.spacedBy(10.dp)
     ) {

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/CustomStepSlider.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/CustomStepSlider.kt
@@ -115,7 +115,7 @@ fun CustomStepSlider(
 
 @Preview(showBackground = true)
 @Composable
-fun CustomStepSliderPreview() {
+private fun CustomStepSliderPreview() {
     Column(
         modifier = Modifier
             .fillMaxWidth()

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinCartOptionItem.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinCartOptionItem.kt
@@ -127,7 +127,7 @@ fun KoinCartOptionItem(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinCartOptionItemPreview() {
+private fun KoinCartOptionItemPreview() {
     RebrandKoinTheme {
         KoinCartOptionItem(
             options = listOf(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinCartPriceItem.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinCartPriceItem.kt
@@ -124,7 +124,7 @@ fun KoinCartPriceItem(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinCartPriceItemPreview() {
+private fun KoinCartPriceItemPreview() {
     KoinCartPriceItem(
         prices = listOf(
             LocalShopPrice(

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreDialog.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/KoinStoreDialog.kt
@@ -152,7 +152,7 @@ fun KoinStoreDialog(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinStoreDialogPreview() {
+private fun KoinStoreDialogPreview() {
     KoinStoreDialog(
         onDismissRequest = {},
         message = "This is a preview of the Koin Store Dialog."

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/QuantityOptionButton.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/QuantityOptionButton.kt
@@ -94,7 +94,7 @@ fun QuantityOptionButton(
 
 @Composable
 @Preview
-fun QuantityOptionButtonPreview() {
+private fun QuantityOptionButtonPreview() {
     KoinTheme {
         QuantityOptionButton(
             quantity = 2,

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/component/QuantitySelectorSection.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/component/QuantitySelectorSection.kt
@@ -74,7 +74,7 @@ fun QuantitySelectorSection(
 
 @Preview
 @Composable
-fun QuantitySelectorSectionPreview() {
+private fun QuantitySelectorSectionPreview() {
     QuantitySelectorSection(
         value = 1
     )

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/detail/component/StoreDetailInfo.kt
@@ -163,7 +163,7 @@ fun CallCard(
 
 @Preview(showBackground = true)
 @Composable
-fun StoreDetailInfoPreview() {
+private fun StoreDetailInfoPreview() {
     StoreDetailInfo(
         storeInfo = ShopInfoModel.empty(),
         storeReview = StoreReview.empty(),

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewreport/component/ReviewReportReasons.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/reviewreport/component/ReviewReportReasons.kt
@@ -221,7 +221,7 @@ fun ReportTextField(
 
 @Preview
 @Composable
-fun PreviewLostAndFoundReportReasons() {
+private fun PreviewLostAndFoundReportReasons() {
     KoinSurface {
         ReviewReportReasons(
             itemList = reviewReportReasonList,

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/TimetableCustomAddBox.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/TimetableCustomAddBox.kt
@@ -61,6 +61,6 @@ fun TimetableCustomAddBox(
 
 @Preview
 @Composable
-fun TimetableCustomAddBoxPreview() {
+private fun TimetableCustomAddBoxPreview() {
     TimetableCustomAddBox()
 }

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/section/TimetableBottomSheetBasic.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/section/TimetableBottomSheetBasic.kt
@@ -76,7 +76,7 @@ fun TimetableBottomSheetBasic(
 
 @Preview(showBackground = true)
 @Composable
-fun TimetableBottomSheetBasicPreview() {
+private fun TimetableBottomSheetBasicPreview() {
     TimetableBottomSheetBasic(
         searchText = "",
         lectures = listOf(dummyLecture, dummyLecture.copy(id = 2, name = "컴퓨터 개발")),

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/section/TimetableBottomSheetCustom.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/section/TimetableBottomSheetCustom.kt
@@ -93,7 +93,7 @@ fun TimetableBottomSheetCustom(
 
 @Preview(showBackground = true)
 @Composable
-fun TimetableBottomSheetCustomPreview() {
+private fun TimetableBottomSheetCustomPreview() {
     TimetableBottomSheetCustom(
         customContents = CustomContentState(),
         sheetLazyListState = rememberLazyListState()

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserBasicItem.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserBasicItem.kt
@@ -72,7 +72,7 @@ fun KoinUserBasicItem(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinUserBasicItemPreview() {
+private fun KoinUserBasicItemPreview() {
     KoinTheme {
         KoinUserBasicItem(
             title = "Name",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserWithButtonItem.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserWithButtonItem.kt
@@ -96,7 +96,7 @@ fun KoinUserWithButtonItem(
 
 @Preview(showBackground = true)
 @Composable
-fun KoinUserWithButtonItemPreview() {
+private fun KoinUserWithButtonItemPreview() {
     KoinTheme {
         KoinUserWithButtonItem(
             title = "Name",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findid/complete/FindIdComplete.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findid/complete/FindIdComplete.kt
@@ -108,7 +108,7 @@ fun FindIdCompleteImpl(
 
 @Preview(showBackground = true)
 @Composable
-fun FindIdCompletePreview() {
+private fun FindIdCompletePreview() {
     FindIdCompleteImpl(
         loginId = "test"
     )

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findid/verification/FindIdVerification.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findid/verification/FindIdVerification.kt
@@ -393,7 +393,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun FindPasswordByVerificationMethodPreview() {
+private fun FindPasswordByVerificationMethodPreview() {
     FindIdVerificationImpl(
         isSms = true,
         verificationMethod = "test@test.com",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/changepassword/ChangePasswordScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/changepassword/ChangePasswordScreen.kt
@@ -177,7 +177,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun ChangePasswordScreenPreview() {
+private fun ChangePasswordScreenPreview() {
     ChangePasswordScreenImpl(
         password = "password123",
         isPasswordValid = true,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/complete/FindPasswordComplete.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/complete/FindPasswordComplete.kt
@@ -91,6 +91,6 @@ fun FindPasswordCompleteScreen() {
 
 @Preview(showBackground = true)
 @Composable
-fun FindPasswordCompleteScreenPreview() {
+private fun FindPasswordCompleteScreenPreview() {
     FindPasswordCompleteScreen()
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerification.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/findpassword/verification/FindPasswordVerification.kt
@@ -445,7 +445,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun FindPasswordBySmsPreview() {
+private fun FindPasswordBySmsPreview() {
     FindPasswordVerificationImpl(
         loginId = "testUser",
         loginIdValid = true,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/inforequire/InfoRequiredFullScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/inforequire/InfoRequiredFullScreen.kt
@@ -117,7 +117,7 @@ fun InfoRequiredFullScreen(
 
 @Preview(showBackground = true, showSystemUi = true)
 @Composable
-fun MainScreenPreview() {
+private fun MainScreenPreview() {
     MaterialTheme {
         InfoRequiredFullScreen(
             buttonText = "정보 입력하러 가기",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/inforequire/InfoRequiredModalScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/inforequire/InfoRequiredModalScreen.kt
@@ -55,7 +55,7 @@ fun InfoRequiredModalScreen(
 
 @Preview(showBackground = true)
 @Composable
-fun ChoiceDialogPreview() {
+private fun ChoiceDialogPreview() {
     KoinTheme {
         InfoRequiredModalScreen(
             title = "아직 입력되지 않은 정보가 있어요",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/complete/SignUpCompleteScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/complete/SignUpCompleteScreen.kt
@@ -98,6 +98,6 @@ fun SignUpCompleteScreen(
 
 @Preview
 @Composable
-fun SignUpCompleteScreenPreview() {
+private fun SignUpCompleteScreenPreview() {
     SignUpCompleteScreen()
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/term/SignUpTermScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/term/SignUpTermScreen.kt
@@ -184,7 +184,7 @@ fun handleSideEffect(sideEffect: SignUpTermSideEffect, context: Context) {
 
 @Preview(showBackground = true)
 @Composable
-fun SignUpTermScreenPreview() {
+private fun SignUpTermScreenPreview() {
     SignUpTermScreenImpl(
         privacyTerm = "개인정보 처리방침",
         koinTerm = "코인 이용약관",

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/general/SignUpGeneralUserInfo.kt
@@ -426,7 +426,7 @@ private fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun SignUpGeneralUserInfoPreview() {
+private fun SignUpGeneralUserInfoPreview() {
     KoinTheme {
         SignUpGeneralUserInfoImpl(
             step = SignUpGeneralStep.NICKNAME_AND_EMAIL,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/userinfo/student/SignUpStudentUserInfo.kt
@@ -515,7 +515,7 @@ private fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun SignUpStudentUserInfoPreview() {
+private fun SignUpStudentUserInfoPreview() {
     KoinTheme {
         SignUpStudentUserInfoImpl(
             step = SignUpStudentStep.NICKNAME_AND_EMAIL,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/usertype/SignUpUserType.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/usertype/SignUpUserType.kt
@@ -101,6 +101,6 @@ fun SignUpUserType(
 
 @Preview(showBackground = true)
 @Composable
-fun SignUpUserTypePreview() {
+private fun SignUpUserTypePreview() {
     SignUpUserType()
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerification.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signup/verification/SignUpVerification.kt
@@ -527,7 +527,7 @@ private fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun SignUpVerificationPreview() {
+private fun SignUpVerificationPreview() {
     SignUpVerificationImpl(
         name = "홍길동",
         isNameValid = true,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditScreen.kt
@@ -752,7 +752,7 @@ fun handleSideEffect(
 
 @Preview(showBackground = true)
 @Composable
-fun UserInfoEditScreenImplPreview() {
+private fun UserInfoEditScreenImplPreview() {
     KoinTheme {
         Column {
             UserInfoHeader(stringResource(R.string.user_info_general_user_info_header))

--- a/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/main/widget/DiningWidget.kt
@@ -317,7 +317,7 @@ fun DiningEmptyContent() {
 
 @Preview(showBackground = true)
 @Composable
-fun PreviewDiningWidget() {
+private fun PreviewDiningWidget() {
     KoinTheme {
         DiningWidget(
             selectedPosition = 0,


### PR DESCRIPTION
## PR 개요
이슈 번호: #1331

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
business 모듈을 제외한 전체 프로젝트에서 `@Preview` 어노테이션이 붙은 함수 중 `private`이 아닌 함수에 `private` 접근 제한자를 추가했습니다.

대상 모듈:
- core/designsystem
- feature/article
- feature/banner
- feature/callvan
- feature/chat
- feature/club
- feature/dining
- feature/lostandfound
- feature/store
- feature/timetable
- feature/user
- koin

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다