### PR TITLE
[Chore] detekt 상수 네이밍 규칙 수정

### DIFF
--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -363,7 +363,7 @@ naming:
     packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
-    constantPattern: '[A-Z][_A-Za-z0-9]*'
+    constantPattern: '[A-Z][A-Z0-9_]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -363,7 +363,7 @@ naming:
     packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
-    constantPattern: '[A-Z][A-Za-z0-9]*'
+    constantPattern: '[A-Z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:


### PR DESCRIPTION
## PR 개요
이슈 번호: #1339

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `TopLevelPropertyNaming`의 `constantPattern`을 `[A-Z][A-Za-z0-9]*` → `[A-Z][A-Z0-9_]*` 로 변경
- SCREAMING_SNAKE_CASE 형태의 상수명(e.g. `CALLVAN_REPORT_OTHER_REASON_MAX_LENGTH`)이 detekt 규칙을 통과하도록 수정

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **기타**
  * 상수 명명 규칙이 업데이트되었습니다. 새 패턴은 대문자로 시작하며 이후에 대문자, 숫자 및 밑줄(_)을 허용하므로 기존보다 더 다양한 명명 스타일과 형식을 지원하여 코드 스타일 호환성이 향상됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->