### PR TITLE
[Feature] SonarQube coverage 분석 대상을 Kover 설정과 일치

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,7 @@ sonar {
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/kover/report.xml")
         property("sonar.androidLint.reportPaths", "${projectDir.absolutePath}/koin/build/reports/lint-results*.xml")
         property("sonar.kotlin.detekt.reportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/detekt/detekt.xml")
+        property("sonar.coverage.inclusions", "**/data/**/*.kt,**/domain/**/*.kt,**/*ViewModel.kt")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ sonar {
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/kover/report.xml")
         property("sonar.androidLint.reportPaths", "${projectDir.absolutePath}/koin/build/reports/lint-results*.xml")
         property("sonar.kotlin.detekt.reportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/detekt/detekt.xml")
-        property("sonar.coverage.inclusions", "**/data/**/*.kt,**/domain/**/*.kt,**/*ViewModel.kt")
+        property("sonar.coverage.inclusions", "**/data/**/*.kt,**/*ViewModel.kt")
     }
 }
 


### PR DESCRIPTION
## PR 개요
이슈 번호:

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `sonar.coverage.inclusions` 설정 추가로 SonarQube coverage 분석 대상을 Kover 설정과 일치시킴
  - `**/data/**/*.kt` — data 모듈 전체
  - `**/*ViewModel.kt` — 전체 모듈은 ViewModel 클래스만
- 기존에 Kover report에 없는 파일이 SonarQube에서 0.0%로 표시되던 문제 해결

### 논의 사항

domain 은 kover 에서 제외되어있으므로 똑같이 제외하겠습니다.
domain 에서 중점적으로 이용할 test 는 usecase 이며 usecase 는 대부분 단순 repository 호출 연계 이므로
data 만 있어도 충분하다는 판단을 했습니다.

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **작업(Chores)**
  * 코드 품질 분석 구성이 업데이트되었습니다. 테스트/커버리지 집계 대상이 일부 Kotlin 소스 범위에 맞게 조정되어, 관련 파일들이 코드커버리지 측정에 더 정확히 포함됩니다. 사용자 기능 변경은 없으며 동작·오류 처리에는 영향이 없습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->