### PR TITLE
[Refactor] 채팅 버블 컴포넌트 리팩토링

### DIFF
--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/room/component/ChatBubble.kt
@@ -98,6 +98,32 @@ fun ChatBubble(
     message: ConvertedChatMessage,
     modifier: Modifier = Modifier,
     colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
+    chatPartnerProfileImage: @Composable () -> Unit = {},
+    onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
+) {
+    if (message.isSentByMe) {
+        ChatBubbleFromMe(
+            message = message,
+            onShowImageChange = onShowImageChange,
+            colors = colors,
+            modifier = modifier.then(chatBubbleDefaultModifier)
+        )
+    } else {
+        ChatBubbleFromOther(
+            message = message,
+            chatPartnerProfile = chatPartnerProfileImage,
+            onShowImageChange = onShowImageChange,
+            colors = colors,
+            modifier = modifier.then(chatBubbleDefaultModifier)
+        )
+    }
+}
+
+@Composable
+fun ChatBubble(
+    message: ConvertedChatMessage,
+    modifier: Modifier = Modifier,
+    colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
     chatPartnerProfileImage: Uri? = null,
     onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
 ) {
@@ -111,7 +137,29 @@ fun ChatBubble(
     } else {
         ChatBubbleFromOther(
             message = message,
-            chatPartnerProfileImage = chatPartnerProfileImage,
+            chatPartnerProfile = {
+                if (chatPartnerProfileImage == null || chatPartnerProfileImage == Uri.EMPTY) {
+                    Image(
+                        painter = painterResource(id = R.drawable.ic_chat_user_image),
+                        contentDescription = stringResource(id = R.string.chat_user_profile_image),
+                        modifier = Modifier
+                            .clip(KoinTheme.shapes.small)
+                            .border(width = 1.dp, color = colors.iconBorderColor, shape = KoinTheme.shapes.small)
+                            .background(colors.iconContainerColor)
+                            .padding(2.dp)
+                            .size(24.dp)
+                    )
+                } else {
+                    AsyncImage(
+                        model = ImageRequest.Builder(LocalContext.current)
+                            .data(chatPartnerProfileImage)
+                            .crossfade(true)
+                            .build(),
+                        contentDescription = stringResource(id = R.string.chat_user_profile_image),
+                        placeholder = painterResource(id = R.drawable.ic_chat_user_image)
+                    )
+                }
+            },
             onShowImageChange = onShowImageChange,
             colors = colors,
             modifier = modifier.then(chatBubbleDefaultModifier)
@@ -171,7 +219,7 @@ private fun ChatBubbleFromOther(
     message: ConvertedChatMessage,
     modifier: Modifier = Modifier,
     colors: ChatBubbleColors = ChatBubbleDefaults.colors(),
-    chatPartnerProfileImage: Uri? = null,
+    chatPartnerProfile: @Composable () -> Unit = {},
     onShowImageChange: (Boolean, Uri) -> Unit = { _, _ -> }
 ) {
     Column(
@@ -180,27 +228,7 @@ private fun ChatBubbleFromOther(
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            if (chatPartnerProfileImage == null || chatPartnerProfileImage == Uri.EMPTY) {
-                Image(
-                    painter = painterResource(id = R.drawable.ic_chat_user_image),
-                    contentDescription = stringResource(id = R.string.chat_user_profile_image),
-                    modifier = Modifier
-                        .clip(KoinTheme.shapes.small)
-                        .border(width = 1.dp, color = colors.iconBorderColor, shape = KoinTheme.shapes.small)
-                        .background(colors.iconContainerColor)
-                        .padding(2.dp)
-                        .size(24.dp)
-                )
-            } else {
-                AsyncImage(
-                    model = ImageRequest.Builder(LocalContext.current)
-                        .data(chatPartnerProfileImage)
-                        .crossfade(true)
-                        .build(),
-                    contentDescription = stringResource(id = R.string.chat_user_profile_image),
-                    placeholder = painterResource(id = R.drawable.ic_chat_user_image)
-                )
-            }
+            chatPartnerProfile()
             Spacer(modifier = Modifier.width(4.dp))
             Text(
                 text = message.userNickname,
@@ -338,7 +366,8 @@ fun ChatBubblePreview() {
                     timestamp = LocalDateTime.now(),
                     isImage = false,
                     isSentByMe = true
-                )
+                ),
+                chatPartnerProfileImage = {}
             )
 
             ChatBubble(
@@ -349,7 +378,8 @@ fun ChatBubblePreview() {
                     timestamp = LocalDateTime.now(),
                     isImage = false,
                     isSentByMe = false
-                )
+                ),
+                chatPartnerProfileImage = {}
             )
         }
     }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1283 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 기존 채팅 버블 컴포넌트를 리팩토링했습니다. 이제 Composable을 lambda로 넘기거나, 기존처럼 uri를 넘길 수 있습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 채팅 버블의 프로필 이미지 렌더링 방식을 개선하여 더욱 유연한 구조로 변경했습니다.
  * 기본 아바타와 사용자 프로필 이미지 표시 로직을 최적화했습니다.
  * 채팅 상대방 프로필 정보 표시 기능의 효율성과 확장성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->