### PR TITLE
[Chore] SonarQube coverage exclusions 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,7 +66,7 @@ kover {
 }
 
 val coverageExclusions = listOf(
-    "**/core/analtyics/*",
+    "**/core/analytics/*",
     "**/core/designsystem/*",
     "**/core/navigation/*",
     "**/core/network/*",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,23 +66,24 @@ kover {
 }
 
 val coverageExclusions = listOf(
-    "**/core/analytics/*",
-    "**/core/designsystem/*",
-    "**/core/navigation/*",
-    "**/core/network/*",
-    "**/core/notification/*",
-    "**/core/onboarding/*",
-    "**/core/webapp/*",
+    "**/core/analytics/**",
+    "**/core/designsystem/**",
+    "**/core/navigation/**",
+    "**/core/network/**",
+    "**/core/notification/**",
+    "**/core/onboarding/**",
+    "**/core/webapp/**",
     "**/firebase/*",
-    "**/di/*",
+    "**/di/**",
     "**/navigation/*",
-    "**/feature/**/model/*",
-    "**/feature/**/component/*",
+    "**/feature/**/model/**",
+    "**/feature/**/component/**",
     "**/ui/**/*Screen.kt",
     "**/ui/**/*State.kt",
     "**/ui/**/*SideEffect.kt",
     "**/*Activity.kt",
     "**/*RecyclerAdapter.kt",
+    "**/*RecyclerViewAdapter.kt",
     "**/*Fragment.kt"
 ).joinToString(", ")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,7 +73,7 @@ val coverageExclusions = listOf(
     "**/core/notification/**",
     "**/core/onboarding/**",
     "**/core/webapp/**",
-    "**/firebase/*",
+    "**/firebase/**",
     "**/di/**",
     "**/navigation/*",
     "**/feature/**/model/**",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,7 @@ kover {
     }
 }
 
-val coverageExclusions = listOf(
+val sonarCoverageExclusions = listOf(
     "**/core/analytics/**",
     "**/core/designsystem/**",
     "**/core/navigation/**",
@@ -94,7 +94,7 @@ sonar {
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/kover/report.xml")
         property("sonar.androidLint.reportPaths", "${projectDir.absolutePath}/koin/build/reports/lint-results*.xml")
         property("sonar.kotlin.detekt.reportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/detekt/detekt.xml")
-        property("sonar.coverage.exclusions", coverageExclusions)
+        property("sonar.coverage.exclusions", sonarCoverageExclusions)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,27 @@ kover {
     }
 }
 
+val coverageExclusions = listOf(
+    "**/core/analtyics/*",
+    "**/core/designsystem/*",
+    "**/core/navigation/*",
+    "**/core/network/*",
+    "**/core/notification/*",
+    "**/core/onboarding/*",
+    "**/core/webapp/*",
+    "**/firebase/*",
+    "**/di/*",
+    "**/navigation/*",
+    "**/feature/**/model/*",
+    "**/feature/**/component/*",
+    "**/ui/**/*Screen.kt",
+    "**/ui/**/*State.kt",
+    "**/ui/**/*SideEffect.kt",
+    "**/*Activity.kt",
+    "**/*RecyclerAdapter.kt",
+    "**/*Fragment.kt"
+).joinToString(", ")
+
 sonar {
     properties {
         property("sonar.projectKey", "BCSDLab_KOIN_ANDROID")
@@ -72,7 +93,7 @@ sonar {
         property("sonar.coverage.jacoco.xmlReportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/kover/report.xml")
         property("sonar.androidLint.reportPaths", "${projectDir.absolutePath}/koin/build/reports/lint-results*.xml")
         property("sonar.kotlin.detekt.reportPaths", "${layout.buildDirectory.get().asFile.absolutePath}/reports/detekt/detekt.xml")
-        property("sonar.coverage.inclusions", "**/data/**/*.kt,**/*ViewModel.kt")
+        property("sonar.coverage.exclusions", coverageExclusions)
     }
 }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1340

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
`coverage.inclusions` 는 coverage 결과 xml 수신의 필터링이고
`coverage.exclusions` 는 coverage 판정 파일의 제외 필터 입니다.
exclusions 를 사용하면 unittest 가 필요 없는 파일의 검사 자체를 건너뛰어 pass를 할 수 있습니다.
(inclusions 는 불가능)

- `sonar.coverage.inclusions` → `sonar.coverage.exclusions` 로 변경
- coverage 측정에서 제외할 파일 패턴을 `coverageExclusions` 변수로 분리하여 가독성 개선
- 제외 대상: core 모듈 하위 패키지, di, navigation, feature model/component, Screen, State, SideEffect, Activity, RecyclerViewAdepter, firebase, Fragment

### 논의 사항

생각나는대로 작성했습니다.  추가되러야할 부분은 적어주세요.

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 코드 커버리지 설정이 포함(inclusion) 방식에서 제외(exclusion) 방식으로 전환되었습니다.
  * 여러 반복적 파일/경로 패턴을 단일 집계된 제외 목록으로 통합했습니다.
  * 테스트 커버리지 분석 대상이 명확해지고 관리 및 유지보수가 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->