### PR TITLE
[Feature] 신고된 사용자 표시 기능 추가 및 신규 알림 검사 LaunchedEffect 이동

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -181,6 +181,14 @@ object AnalyticsConstant {
             const val DINING_AB_TEST_DESIGN_A = "design_A"
             const val DINING_AB_TEST_DESIGN_B = "design_B"
         }
+
+        object Callvan {
+            const val MAIN_CALLVAN_VIEW = "main_callvan_view"
+            const val MAIN_CALLVAN_WRITE = "main_callvan_write"
+            const val CALLVAN_HAMBURGER = "hamburger"
+            const val CALLVAN_CHAT_SEND = "callvan_chat_send"
+            const val CALLVAN_CHAT_ENRTY = "callvan_chat_entry"
+        }
     }
 
     const val PREVIOUS_PAGE = "previous_page"

--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -187,7 +187,7 @@ object AnalyticsConstant {
             const val MAIN_CALLVAN_WRITE = "main_callvan_write"
             const val CALLVAN_HAMBURGER = "hamburger"
             const val CALLVAN_CHAT_SEND = "callvan_chat_send"
-            const val CALLVAN_CHAT_ENRTY = "callvan_chat_entry"
+            const val CALLVAN_CHAT_ENTRY = "callvan_chat_entry"
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/mapper/CallvanMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/CallvanMapper.kt
@@ -81,7 +81,8 @@ fun CallvanPostDetailResponse.toCallvanPostDetail() = CallvanPostDetail(
 fun CallvanPostDetailResponse.CallvanParticipantResponse.toCallvanParticipant() = CallvanPostDetail.CallvanParticipant(
     userId = userId,
     nickname = nickname,
-    isMe = isMe
+    isMe = isMe,
+    isReported = isReported
 )
 
 fun CallvanNotificationResponse.toCallvanNotification() = CallvanNotification(

--- a/data/src/main/java/in/koreatech/koin/data/response/callvan/CallvanPostDetailResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/callvan/CallvanPostDetailResponse.kt
@@ -30,6 +30,8 @@ data class CallvanPostDetailResponse(
         @SerializedName("nickname")
         val nickname: String,
         @SerializedName("is_me")
-        val isMe: Boolean
+        val isMe: Boolean,
+        @SerializedName("is_reported")
+        val isReported: Boolean
     )
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/callvan/CallvanPostDetail.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/callvan/CallvanPostDetail.kt
@@ -15,6 +15,7 @@ data class CallvanPostDetail(
     data class CallvanParticipant(
         val userId: Int,
         val nickname: String,
-        val isMe: Boolean
+        val isMe: Boolean,
+        val isReported: Boolean
     )
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/CallvanEntry.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/CallvanEntry.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 
 @Composable
@@ -50,6 +52,10 @@ fun CallvanEntry(
                 title = stringResource(R.string.callvan_entry_find_title),
                 description = stringResource(R.string.callvan_entry_find_description),
                 onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.MAIN_CALLVAN_VIEW,
+                        ""
+                    )
                     context.startActivity(Intent(context, CallvanActivity::class.java))
                 }
             )
@@ -61,6 +67,10 @@ fun CallvanEntry(
                 title = stringResource(R.string.callvan_entry_recruit_title),
                 description = stringResource(R.string.callvan_entry_recruit_description),
                 onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.MAIN_CALLVAN_WRITE,
+                        ""
+                    )
                     context.startActivity(Intent(context, CallvanActivity::class.java)) // TODO: Navigate to create
                 }
             )

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.koin.feature.callvan.ui.detail
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,6 +13,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -22,6 +25,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -74,6 +78,7 @@ fun CallvanDetailScreen(
         currentParticipants = state.currentParticipants,
         maxParticipants = state.maxParticipants,
         participants = state.participants,
+        isLoading = state.isLoading,
         snackbarHostState = snackbarHostState,
         onTopbarBackClick = onTopbarBackClick,
         onNotificationClick = onNotificationClick,
@@ -92,6 +97,7 @@ fun CallvanDetailScreenImpl(
     maxParticipants: Int,
     participants: ImmutableList<CallvanDetailParticipantUiItem>,
     hasNewNotification: Boolean = false,
+    isLoading: Boolean = false,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onTopbarBackClick: () -> Unit = {},
     onNotificationClick: () -> Unit = {},
@@ -129,59 +135,71 @@ fun CallvanDetailScreenImpl(
         },
         containerColor = KoinTheme.colors.neutral0
     ) { contentPadding ->
-        val participantColorIndices = remember(participants) {
-            var count = 0
-            participants.map { item ->
-                if (item.isMe) {
-                    5
-                } else {
-                    count++
+        Box(modifier = Modifier.fillMaxSize()) {
+            val participantColorIndices = remember(participants) {
+                var count = 0
+                participants.map { item ->
+                    if (item.isMe) {
+                        5
+                    } else {
+                        count++
+                    }
                 }
             }
-        }
-        LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(contentPadding)
-                .padding(horizontal = 24.dp)
-        ) {
-            item {
-                Spacer(modifier = Modifier.height(16.dp))
-                ParticipantsHeader(
-                    currentParticipants = currentParticipants,
-                    maxParticipants = maxParticipants
-                )
-                Spacer(modifier = Modifier.height(12.dp))
-                CallvanDetailRouteCard(
-                    departure = departure,
-                    destination = destination,
-                    dateTime = dateTime
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-            }
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(contentPadding)
+                    .padding(horizontal = 24.dp)
+            ) {
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    ParticipantsHeader(
+                        currentParticipants = currentParticipants,
+                        maxParticipants = maxParticipants
+                    )
+                    Spacer(modifier = Modifier.height(12.dp))
+                    CallvanDetailRouteCard(
+                        departure = departure,
+                        destination = destination,
+                        dateTime = dateTime
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                }
 
-            itemsIndexed(participants, key = { _, participant -> participant.id }) { index, participant ->
-                if (index > 0) {
-                    HorizontalDivider(color = KoinTheme.colors.neutral200)
-                }
-                CallvanDetailParticipantItem(
-                    participant = participant,
-                    tint = callvanPersonIconColor(participantColorIndices[index]),
-                    menuItems = persistentListOf(
-                        CallvanDropdownMenuItem(
-                            text = { stringResource(R.string.callvan_detail_participant_report) },
-                            icon = {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.ic_siren),
-                                    contentDescription = null
-                                )
-                            },
-                            onClick = {
-                                onReportClick(participant.id)
-                            }
+                itemsIndexed(participants, key = { _, participant -> participant.id }) { index, participant ->
+                    if (index > 0) {
+                        HorizontalDivider(color = KoinTheme.colors.neutral200)
+                    }
+                    CallvanDetailParticipantItem(
+                        participant = participant,
+                        tint = callvanPersonIconColor(participantColorIndices[index]),
+                        menuItems = persistentListOf(
+                            CallvanDropdownMenuItem(
+                                text = { stringResource(R.string.callvan_detail_participant_report) },
+                                icon = {
+                                    Icon(
+                                        imageVector = ImageVector.vectorResource(R.drawable.ic_siren),
+                                        contentDescription = null
+                                    )
+                                },
+                                onClick = {
+                                    onReportClick(participant.id)
+                                }
+                            )
                         )
                     )
-                )
+                }
+            }
+            if (isLoading) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.White.copy(alpha = 0.6f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(color = RebrandKoinTheme.colors.primary500)
+                }
             }
         }
     }
@@ -223,12 +241,12 @@ private fun CallvanDetailScreenPreview() {
         currentParticipants = 6,
         maxParticipants = 8,
         participants = persistentListOf(
-            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true),
-            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false),
-            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false),
-            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false),
-            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false),
-            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false)
+            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true, isReported = false),
+            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false, isReported = true),
+            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false, isReported = false)
         )
     )
 }
@@ -244,12 +262,12 @@ private fun CallvanDetailScreenNotificationPreview() {
         maxParticipants = 8,
         hasNewNotification = true,
         participants = persistentListOf(
-            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true),
-            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false),
-            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false),
-            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false),
-            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false),
-            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false)
+            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true, isReported = false),
+            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false, isReported = true),
+            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false, isReported = false),
+            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false, isReported = false)
         )
     )
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHost
 import `in`.koreatech.koin.core.designsystem.component.snackbar.showSnackBarWithDismiss
@@ -125,7 +127,13 @@ fun CallvanDetailScreenImpl(
         bottomBar = {
             FilledButton(
                 text = stringResource(R.string.callvan_detail_enter_chat),
-                onClick = onEnterChatClick,
+                onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
+                        ""
+                    )
+                    onEnterChatClick()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp, vertical = 16.dp),

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -130,7 +130,7 @@ fun CallvanDetailScreenImpl(
                 text = stringResource(R.string.callvan_detail_enter_chat),
                 onClick = {
                     EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENTRY,
                         ""
                     )
                     onEnterChatClick()

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
@@ -75,8 +75,9 @@ fun CallvanDetailScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LifecycleResumeEffect(Unit) {
         viewModel.fetchHasNewNotification()
+        onPauseOrDispose {}
     }
 
     CallvanDetailScreenImpl(
@@ -129,7 +130,7 @@ fun CallvanDetailScreenImpl(
                 text = stringResource(R.string.callvan_detail_enter_chat),
                 onClick = {
                     EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
                         ""
                     )
                     onEnterChatClick()

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -238,6 +238,15 @@ private fun ParticipantsHeader(
     }
 }
 
+private val previewParticipants = persistentListOf(
+    CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true, isReported = false),
+    CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false, isReported = false),
+    CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false, isReported = false),
+    CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false, isReported = false),
+    CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false, isReported = true),
+    CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false, isReported = false)
+)
+
 @Preview(showBackground = true)
 @Composable
 private fun CallvanDetailScreenPreview() {
@@ -247,14 +256,7 @@ private fun CallvanDetailScreenPreview() {
         dateTime = "02.05 (월) 14:00",
         currentParticipants = 6,
         maxParticipants = 8,
-        participants = persistentListOf(
-            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true, isReported = false),
-            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false, isReported = true),
-            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false, isReported = false)
-        )
+        participants = previewParticipants
     )
 }
 
@@ -268,13 +270,6 @@ private fun CallvanDetailScreenNotificationPreview() {
         currentParticipants = 6,
         maxParticipants = 8,
         hasNewNotification = true,
-        participants = persistentListOf(
-            CallvanDetailParticipantUiItem(id = 1, name = "홍길동", isMe = true, isReported = false),
-            CallvanDetailParticipantUiItem(id = 2, name = "신짱구", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 3, name = "김철수", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 4, name = "한유리", isMe = false, isReported = true),
-            CallvanDetailParticipantUiItem(id = 5, name = "이훈이", isMe = false, isReported = false),
-            CallvanDetailParticipantUiItem(id = 6, name = "맹구", isMe = false, isReported = false)
-        )
+        participants = previewParticipants
     )
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -34,7 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
@@ -75,9 +75,8 @@ fun CallvanDetailScreen(
         }
     }
 
-    LifecycleResumeEffect(Unit) {
+    LaunchedEffect(Unit) {
         viewModel.fetchHasNewNotification()
-        onPauseOrDispose {}
     }
 
     CallvanDetailScreenImpl(

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -32,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHost
@@ -69,6 +71,10 @@ fun CallvanDetailScreen(
                 snackbarHostState.showSnackBarWithDismiss(context.getString(R.string.callvan_report_submit_success))
             }
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchHasNewNotification()
     }
 
     CallvanDetailScreenImpl(
@@ -195,7 +201,8 @@ fun CallvanDetailScreenImpl(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .background(Color.White.copy(alpha = 0.6f)),
+                        .background(Color.White.copy(alpha = 0.6f))
+                        .zIndex(1f),
                     contentAlignment = Alignment.Center
                 ) {
                     CircularProgressIndicator(color = RebrandKoinTheme.colors.primary500)

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -175,14 +175,14 @@ fun CallvanDetailScreenImpl(
 
                 itemsIndexed(participants, key = { _, participant -> participant.id }) { index, participant ->
                     if (index > 0) {
-                        HorizontalDivider(color = KoinTheme.colors.neutral200)
+                        HorizontalDivider(color = RebrandKoinTheme.colors.neutral200)
                     }
                     CallvanDetailParticipantItem(
                         participant = participant,
                         tint = callvanPersonIconColor(participantColorIndices[index]),
                         menuItems = persistentListOf(
                             CallvanDropdownMenuItem(
-                                text = { stringResource(R.string.callvan_detail_participant_report) },
+                                text = stringResource(R.string.callvan_detail_participant_report),
                                 icon = {
                                     Icon(
                                         imageVector = ImageVector.vectorResource(R.drawable.ic_siren),
@@ -220,20 +220,20 @@ private fun ParticipantsHeader(
     Row(verticalAlignment = Alignment.CenterVertically) {
         Text(
             text = stringResource(R.string.callvan_detail_participants_header),
-            style = KoinTheme.typography.medium18,
-            color = KoinTheme.colors.neutral800
+            style = RebrandKoinTheme.typography.medium18,
+            color = RebrandKoinTheme.colors.neutral800
         )
         Spacer(modifier = Modifier.width(8.dp))
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.ic_participants),
             contentDescription = null,
-            tint = KoinTheme.colors.neutral600,
+            tint = RebrandKoinTheme.colors.neutral600,
             modifier = Modifier.size(20.dp)
         )
         Spacer(modifier = Modifier.width(4.dp))
         Text(
             text = stringResource(R.string.callvan_detail_participants_count, currentParticipants, maxParticipants),
-            style = KoinTheme.typography.regular14.copy(color = KoinTheme.colors.neutral600)
+            style = RebrandKoinTheme.typography.regular14.copy(color = RebrandKoinTheme.colors.neutral600)
         )
     }
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModel.kt
@@ -30,7 +30,6 @@ class CallvanDetailViewModel @Inject constructor(
 
     init {
         fetchPostDetail()
-        fetchHasNewNotification()
         observeReportSuccess(savedStateHandle)
     }
 
@@ -69,7 +68,7 @@ class CallvanDetailViewModel @Inject constructor(
             }
     }
 
-    private fun fetchHasNewNotification() = intent {
+    fun fetchHasNewNotification() = intent {
         getNotificationsUseCase()
             .onSuccess { notifications ->
                 reduce {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModel.kt
@@ -68,7 +68,7 @@ class CallvanDetailViewModel @Inject constructor(
             }
     }
 
-    fun fetchHasNewNotification() = intent {
+    internal fun fetchHasNewNotification() = intent {
         getNotificationsUseCase()
             .onSuccess { notifications ->
                 reduce {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
@@ -23,7 +23,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.callvan.R
 import `in`.koreatech.koin.feature.callvan.ui.component.CallvanDropdownMenu
@@ -60,14 +59,14 @@ fun CallvanDetailParticipantItem(
             } else {
                 participant.name
             },
-            style = KoinTheme.typography.medium16,
-            color = KoinTheme.colors.neutral800
+            style = RebrandKoinTheme.typography.medium16,
+            color = RebrandKoinTheme.colors.neutral800
         )
         if (participant.isReported) {
             Spacer(modifier = Modifier.width(4.dp))
             Text(
                 text = stringResource(R.string.callvan_detail_participant_reported),
-                style = KoinTheme.typography.regular10,
+                style = RebrandKoinTheme.typography.regular10,
                 color = RebrandKoinTheme.colors.primary500
             )
         }
@@ -81,7 +80,7 @@ fun CallvanDetailParticipantItem(
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_menu_small),
                         contentDescription = null,
-                        tint = KoinTheme.colors.neutral600
+                        tint = RebrandKoinTheme.colors.neutral600
                     )
                 }
                 CallvanDropdownMenu(

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
@@ -61,9 +61,17 @@ fun CallvanDetailParticipantItem(
                 participant.name
             },
             style = KoinTheme.typography.medium16,
-            color = KoinTheme.colors.neutral800,
-            modifier = Modifier.weight(1f)
+            color = KoinTheme.colors.neutral800
         )
+        if (participant.isReported) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = stringResource(R.string.callvan_detail_participant_reported),
+                style = KoinTheme.typography.regular10,
+                color = RebrandKoinTheme.colors.primary500
+            )
+        }
+        Spacer(modifier.weight(1f))
         if (!participant.isMe) {
             Box {
                 IconButton(
@@ -94,7 +102,22 @@ private fun CallvanDetailParticipantItemPreview() {
         participant = CallvanDetailParticipantUiItem(
             id = 1,
             name = "홍길동",
-            isMe = false
+            isMe = false,
+            isReported = false
+        ),
+        menuItems = persistentListOf()
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CallvanDetailParticipantItemIsReportedPreview() {
+    CallvanDetailParticipantItem(
+        participant = CallvanDetailParticipantUiItem(
+            id = 1,
+            name = "홍길동",
+            isMe = false,
+            isReported = true
         ),
         menuItems = persistentListOf()
     )
@@ -107,7 +130,8 @@ private fun CallvanDetailParticipantItemIsMinePreview() {
         participant = CallvanDetailParticipantUiItem(
             id = 1,
             name = "홍길동",
-            isMe = true
+            isMe = true,
+            isReported = false
         ),
         menuItems = persistentListOf()
     )

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailParticipantItem.kt
@@ -71,7 +71,7 @@ fun CallvanDetailParticipantItem(
                 color = RebrandKoinTheme.colors.primary500
             )
         }
-        Spacer(modifier.weight(1f))
+        Spacer(Modifier.weight(1f))
         if (!participant.isMe) {
             Box {
                 IconButton(

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailRouteCard.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/component/CallvanDetailRouteCard.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.callvan.ui.component.CallvanRouteInfo
 
 @Composable
@@ -26,7 +26,7 @@ fun CallvanDetailRouteCard(
         modifier = modifier
             .fillMaxWidth()
             .border(
-                border = BorderStroke(1.dp, KoinTheme.colors.neutral200),
+                border = BorderStroke(1.dp, RebrandKoinTheme.colors.neutral200),
                 shape = RoundedCornerShape(8.dp)
             )
             .padding(horizontal = 16.dp, vertical = 12.dp),
@@ -39,8 +39,8 @@ fun CallvanDetailRouteCard(
         )
         Text(
             text = dateTime,
-            style = KoinTheme.typography.regular14,
-            color = KoinTheme.colors.neutral600
+            style = RebrandKoinTheme.typography.regular14,
+            color = RebrandKoinTheme.colors.neutral600
         )
     }
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/model/CallvanDetailParticipantUiItem.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/model/CallvanDetailParticipantUiItem.kt
@@ -7,11 +7,13 @@ import `in`.koreatech.koin.domain.model.callvan.CallvanPostDetail
 data class CallvanDetailParticipantUiItem(
     val id: Int,
     val name: String,
-    val isMe: Boolean
+    val isMe: Boolean,
+    val isReported: Boolean
 )
 
 fun CallvanPostDetail.CallvanParticipant.toUiItem() = CallvanDetailParticipantUiItem(
     id = userId,
     name = nickname,
-    isMe = isMe
+    isMe = isMe,
+    isReported = isReported
 )

--- a/feature/callvan/src/main/res/values/strings.xml
+++ b/feature/callvan/src/main/res/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="callvan_detail_destination">도착: %1$s</string>
     <string name="callvan_detail_me_suffix">(나)</string>
     <string name="callvan_detail_participant_name_me">%1$s (나)</string>
+    <string name="callvan_detail_participant_reported">(신고됨)</string>
     <string name="callvan_detail_enter_chat">단체 채팅방 입장</string>
     <string name="callvan_detail_participant_report">신고하기</string>
 

--- a/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
+++ b/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
@@ -146,8 +146,8 @@ class CallvanDetailViewModelTest {
         maxParticipants = 8,
         status = "OPEN",
         participants = listOf(
-            CallvanPostDetail.CallvanParticipant(userId = 2, nickname = "신짱구", isMe = false),
-            CallvanPostDetail.CallvanParticipant(userId = 1, nickname = "홍길동", isMe = true)
+            CallvanPostDetail.CallvanParticipant(userId = 2, nickname = "신짱구", isMe = false, isReported = false),
+            CallvanPostDetail.CallvanParticipant(userId = 1, nickname = "홍길동", isMe = true, isReported = false)
         )
     )
 

--- a/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
+++ b/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
@@ -77,28 +77,6 @@ class CallvanDetailViewModelTest {
     }
 
     @Test
-    fun `상세 조회 실패 시 isLoading이 false가 된다`() = runTest {
-        fakeRepository.postDetailResult = Result.failure(Exception("network error"))
-        fakeRepository.notificationsResult = Result.success(
-            listOf(fakeNotification(isRead = false))
-        )
-
-        val viewModel = createViewModel()
-        viewModel.fetchHasNewNotification()
-
-        viewModel.container.stateFlow.test {
-            var loadingState = awaitItem()
-            assertFalse(loadingState.isLoading)
-
-            while (!loadingState.hasNewNotification) {
-                loadingState = awaitItem()
-            }
-            assertFalse(loadingState.isLoading)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `읽지 않은 알림이 있으면 hasNewNotification이 true다`() = runTest {
         fakeRepository.postDetailResult = Result.success(fakePostDetail)
         fakeRepository.notificationsResult = Result.success(

--- a/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
+++ b/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
@@ -84,6 +84,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var loadingState = awaitItem()
@@ -105,6 +106,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var state = awaitItem()
@@ -124,6 +126,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var state = awaitItem()

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
@@ -156,7 +156,7 @@ private fun GroupChatScreenImpl(
             onImageButtonClick = onImageButtonClick,
             onSendClick = {
                 EventLogger.logCampusClickEvent(
-                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
                     ""
                 )
                 onSendClick()

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
@@ -28,6 +28,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.chat.R
 import `in`.koreatech.koin.feature.chat.ui.groupchat.component.GroupChatContent
@@ -152,7 +154,13 @@ private fun GroupChatScreenImpl(
             showImage = showImage,
             onChatInputValueChange = onChatInputValueChange,
             onImageButtonClick = onImageButtonClick,
-            onSendClick = onSendClick,
+            onSendClick = {
+                EventLogger.logCampusClickEvent(
+                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                    ""
+                )
+                onSendClick()
+            },
             onShowImageChange = onShowImageChange
         )
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -585,6 +585,10 @@ abstract class KoinNavigationDrawerActivity :
     }
 
     private fun goToCallvanActivity() {
+        EventLogger.logCampusClickEvent(
+            AnalyticsConstant.Label.Callvan.CALLVAN_HAMBURGER,
+            "콜밴팟 모집"
+        )
         if (menuState != MenuState.Main) {
             goToActivityFinish(Intent(this, CallvanActivity::class.java))
         } else {


### PR DESCRIPTION
## PR 개요
이슈 번호: #1283

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 신고된 사용자(`isReported`)를 UI에 표시하도록 `CallvanDetailParticipantUiItem`, `CallvanDetailParticipantItem` 수정
- `CallvanPostDetailResponse` 및 `CallvanPostDetail` 도메인 모델에 `isReported` 필드 추가
- `CallvanMapper`에서 `isReported` 매핑 처리
- `fetchHasNewNotification()`을 `init` 블록에서 제거하고 Screen의 `LaunchedEffect`로 이동하여 생명주기에 맞게 호출되도록 변경

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 참여자에 "(신고됨)" 레이블 표시 및 신고 상태 노출
  * 상세 화면에서 로딩 오버레이(원형 인디케이터) 표시

* **개선 사항**
  * 화면 구성 시(진입 시) 알림 조회를 트리거해 알림 상태 반영
  * UI 테마 색상·타이포그래피 참조 갱신(시각 일관성 개선)
  * 미리보기·샘플 데이터에 신고 상태 반영 및 테스트 업데이트

* **기타**
  * 몇몇 화면에서 사용자 동작에 대한 분석 이벤트 로깅 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->