### PR TITLE
[Feature] 콜밴 진입, 상세, 채팅 화면 Analytics 로깅 추가

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -181,6 +181,14 @@ object AnalyticsConstant {
             const val DINING_AB_TEST_DESIGN_A = "design_A"
             const val DINING_AB_TEST_DESIGN_B = "design_B"
         }
+
+        object Callvan {
+            const val MAIN_CALLVAN_VIEW = "main_callvan_view"
+            const val MAIN_CALLVAN_WRITE = "main_callvan_write"
+            const val CALLVAN_HAMBURGER = "hamburger"
+            const val CALLVAN_CHAT_SEND = "callvan_chat_send"
+            const val CALLVAN_CHAT_ENRTY = "callvan_chat_entry"
+        }
     }
 
     const val PREVIOUS_PAGE = "previous_page"

--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -187,7 +187,7 @@ object AnalyticsConstant {
             const val MAIN_CALLVAN_WRITE = "main_callvan_write"
             const val CALLVAN_HAMBURGER = "hamburger"
             const val CALLVAN_CHAT_SEND = "callvan_chat_send"
-            const val CALLVAN_CHAT_ENRTY = "callvan_chat_entry"
+            const val CALLVAN_CHAT_ENTRY = "callvan_chat_entry"
         }
     }
 

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/CallvanEntry.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/CallvanEntry.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 
 @Composable
@@ -50,6 +52,10 @@ fun CallvanEntry(
                 title = stringResource(R.string.callvan_entry_find_title),
                 description = stringResource(R.string.callvan_entry_find_description),
                 onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.MAIN_CALLVAN_VIEW,
+                        ""
+                    )
                     context.startActivity(Intent(context, CallvanActivity::class.java))
                 }
             )
@@ -61,6 +67,10 @@ fun CallvanEntry(
                 title = stringResource(R.string.callvan_entry_recruit_title),
                 description = stringResource(R.string.callvan_entry_recruit_description),
                 onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.MAIN_CALLVAN_WRITE,
+                        ""
+                    )
                     context.startActivity(Intent(context, CallvanActivity::class.java)) // TODO: Navigate to create
                 }
             )

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
 import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHost
 import `in`.koreatech.koin.core.designsystem.component.snackbar.showSnackBarWithDismiss
@@ -125,7 +127,13 @@ fun CallvanDetailScreenImpl(
         bottomBar = {
             FilledButton(
                 text = stringResource(R.string.callvan_detail_enter_chat),
-                onClick = onEnterChatClick,
+                onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
+                        ""
+                    )
+                    onEnterChatClick()
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp, vertical = 16.dp),

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -130,7 +130,7 @@ fun CallvanDetailScreenImpl(
                 text = stringResource(R.string.callvan_detail_enter_chat),
                 onClick = {
                     EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENTRY,
                         ""
                     )
                     onEnterChatClick()

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -35,6 +34,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.LifecycleResumeEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
@@ -75,8 +75,9 @@ fun CallvanDetailScreen(
         }
     }
 
-    LaunchedEffect(Unit) {
+    LifecycleResumeEffect(Unit) {
         viewModel.fetchHasNewNotification()
+        onPauseOrDispose {}
     }
 
     CallvanDetailScreenImpl(
@@ -129,7 +130,7 @@ fun CallvanDetailScreenImpl(
                 text = stringResource(R.string.callvan_detail_enter_chat),
                 onClick = {
                     EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
+                        AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
                         ""
                     )
                     onEnterChatClick()

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -34,7 +35,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
@@ -75,9 +75,8 @@ fun CallvanDetailScreen(
         }
     }
 
-    LifecycleResumeEffect(Unit) {
+    LaunchedEffect(Unit) {
         viewModel.fetchHasNewNotification()
-        onPauseOrDispose {}
     }
 
     CallvanDetailScreenImpl(

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
@@ -156,7 +156,7 @@ private fun GroupChatScreenImpl(
             onImageButtonClick = onImageButtonClick,
             onSendClick = {
                 EventLogger.logCampusClickEvent(
-                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_SEND,
                     ""
                 )
                 onSendClick()

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/groupchat/GroupChatScreen.kt
@@ -28,6 +28,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.chat.R
 import `in`.koreatech.koin.feature.chat.ui.groupchat.component.GroupChatContent
@@ -152,7 +154,13 @@ private fun GroupChatScreenImpl(
             showImage = showImage,
             onChatInputValueChange = onChatInputValueChange,
             onImageButtonClick = onImageButtonClick,
-            onSendClick = onSendClick,
+            onSendClick = {
+                EventLogger.logCampusClickEvent(
+                    AnalyticsConstant.Label.Callvan.CALLVAN_CHAT_ENRTY,
+                    ""
+                )
+                onSendClick()
+            },
             onShowImageChange = onShowImageChange
         )
     }

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/KoinNavigationDrawerActivity.kt
@@ -585,6 +585,10 @@ abstract class KoinNavigationDrawerActivity :
     }
 
     private fun goToCallvanActivity() {
+        EventLogger.logCampusClickEvent(
+            AnalyticsConstant.Label.Callvan.CALLVAN_HAMBURGER,
+            "콜밴팟 모집"
+        )
         if (menuState != MenuState.Main) {
             goToActivityFinish(Intent(this, CallvanActivity::class.java))
         } else {


### PR DESCRIPTION
## PR 개요
이슈 번호: #1283

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `AnalyticsConstant`에 `Callvan` 객체 추가 (MAIN_CALLVAN_VIEW, MAIN_CALLVAN_WRITE, CALLVAN_HAMBURGER, CALLVAN_CHAT_SEND, CALLVAN_CHAT_ENRTY)
- `CallvanEntry`: 콜밴 목록 조회 / 모집 버튼 클릭 시 로깅 추가
- `CallvanDetailScreen`: 채팅 입장 버튼 클릭 시 로깅 추가
- `GroupChatScreen`: 채팅 메시지 전송 버튼 클릭 시 로깅 추가
- `KoinNavigationDrawerActivity`: 햄버거 메뉴에서 콜밴 진입 시 로깅 추가

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 콜밴 관련 사용 분석 이벤트가 추가되었습니다: 메인 보기, 글쓰기, 햄버거 메뉴 선택, 채팅 전송, 채팅 진입.
  * 내비게이션에서 콜밴 진입 시 이벤트가 기록되도록 반영되었습니다.
  * 콜밴 진입 화면 및 채팅 전송/진입 동작에서 이벤트 로그가 발생하도록 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->