### PR TITLE
[Feature] 콜벤 그룹채팅 진입 구현

### DIFF
--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
@@ -33,4 +33,9 @@ interface Navigator {
     fun navigateToChatRoom(
         context: Context
     ): Intent
+
+    fun navigateToGroupChat(
+        context: Context,
+        postId: Int
+    ): Intent
 }

--- a/feature/callvan/build.gradle.kts
+++ b/feature/callvan/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     implementation(projects.core.onboarding)
     implementation(projects.core.designsystem)
     implementation(projects.core.analytics)
+    implementation(projects.core.navigation)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/navigation/Navigation.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/navigation/Navigation.kt
@@ -1,9 +1,14 @@
 package `in`.koreatech.koin.feature.callvan.navigation
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.feature.callvan.ui.detail.CallvanDetailScreen
 import `in`.koreatech.koin.feature.callvan.ui.detail.CallvanDetailViewModel
 import `in`.koreatech.koin.feature.callvan.ui.notification.CallvanNotificationsScreen
@@ -31,6 +36,17 @@ fun NavGraphBuilder.koinCallvanGraph(
     }
 
     composable<CallvanNavType.CallvanChat> {
+        val navigator = rememberNavigator()
+        val context = navController.context
+        val intent = remember { navigator.navigateToGroupChat(context, it.toRoute<CallvanNavType.CallvanChat>().postId) }
+        val launcher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult()
+        ) {
+            navController.popBackStack()
+        }
+        LaunchedEffect(Unit) {
+            launcher.launch(intent)
+        }
     }
 
     composable<CallvanNavType.CallvanNotifications> {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/navigation/Navigation.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/navigation/Navigation.kt
@@ -4,6 +4,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
@@ -37,7 +38,7 @@ fun NavGraphBuilder.koinCallvanGraph(
 
     composable<CallvanNavType.CallvanChat> {
         val navigator = rememberNavigator()
-        val context = navController.context
+        val context = LocalContext.current
         val intent = remember { navigator.navigateToGroupChat(context, it.toRoute<CallvanNavType.CallvanChat>().postId) }
         val launcher = rememberLauncherForActivityResult(
             contract = ActivityResultContracts.StartActivityForResult()

--- a/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
+++ b/feature/callvan/src/test/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailViewModelTest.kt
@@ -84,6 +84,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var loadingState = awaitItem()
@@ -105,6 +106,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var state = awaitItem()
@@ -124,6 +126,7 @@ class CallvanDetailViewModelTest {
         )
 
         val viewModel = createViewModel()
+        viewModel.fetchHasNewNotification()
 
         viewModel.container.stateFlow.test {
             var state = awaitItem()

--- a/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
@@ -6,6 +6,7 @@ import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.navigation.utils.buildDeepLinkIntent
 import `in`.koreatech.koin.core.navigation.utils.buildIntent
 import `in`.koreatech.koin.core.navigation.utils.isValidDeepLink
+import `in`.koreatech.koin.feature.chat.ui.groupchat.GroupChatActivity
 import `in`.koreatech.koin.feature.chat.ui.room.ChatRoomActivity
 import `in`.koreatech.koin.feature.store.StoreActivity
 import `in`.koreatech.koin.feature.user.ui.signin.SignInActivity
@@ -64,6 +65,12 @@ class NavigatorImpl @Inject constructor() : Navigator {
 
     override fun navigateToChatRoom(context: Context): Intent {
         return context.buildIntent(ChatRoomActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+    }
+
+    override fun navigateToGroupChat(context: Context, postId: Int): Intent {
+        return GroupChatActivity.createIntent(context, postId).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
     }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1283

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 콜벤 상세 화면에서 그룹채팅(GroupChatActivity)으로 진입하는 기능 구현
- 채팅 화면 종료 시 백스택을 pop하여 이전 화면으로 복귀 처리
- 콜벤 진입, 상세, 채팅 화면에 대한 애널리틱스 로깅 추가
- 중복되는 previewParticipants 코드 컴포넌트로 추출

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 그룹 채팅으로 이동하는 내비게이션이 추가되어, 특정 게시물에서 바로 그룹 채팅 화면을 열 수 있습니다. 호출 흐름에서 화면 실행과 복귀 처리가 개선되었습니다.

* **테스트**
  * 테스트 코드가 간소화되어 중복 호출이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->