### PR TITLE
[Feature] 콜벤 이용 정지 다이얼로그 추가 및 콜밴 알림 설명문 수정

### DIFF
--- a/data/src/test/java/in/koreatech/koin/data/api/FakeCallvanAuthApi.kt
+++ b/data/src/test/java/in/koreatech/koin/data/api/FakeCallvanAuthApi.kt
@@ -9,6 +9,7 @@ import `in`.koreatech.koin.data.response.callvan.CallvanNotificationResponse
 import `in`.koreatech.koin.data.response.callvan.CallvanPostCreateResponse
 import `in`.koreatech.koin.data.response.callvan.CallvanPostDetailResponse
 import `in`.koreatech.koin.data.response.callvan.CallvanPostSearchResponse
+import `in`.koreatech.koin.data.response.callvan.CallvanRestrictionResponse
 
 class FakeCallvanAuthApi : CallvanAuthApi {
 
@@ -72,4 +73,7 @@ class FakeCallvanAuthApi : CallvanAuthApi {
     override suspend fun leaveCallvanPost(postId: Int) = throw NotImplementedError()
 
     override suspend fun reopenCallvanPost(postId: Int) = throw NotImplementedError()
+
+    override suspend fun getCallvanRestriction(): CallvanRestrictionResponse =
+        throw NotImplementedError()
 }

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/model/CallvanRestrictionUiState.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/model/CallvanRestrictionUiState.kt
@@ -9,7 +9,9 @@ data class CallvanRestrictionUiState(
     val restrictedUntil: LocalDate?
 ) {
     enum class RestrictionType(val days: Int?) {
-        TEMPORARY_14_DAYS(14), PERMANENT(null), NONE(null)
+        TEMPORARY_14_DAYS(14),
+        PERMANENT(null),
+        NONE(null)
     }
 }
 

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/model/CallvanRestrictionUiState.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/model/CallvanRestrictionUiState.kt
@@ -1,0 +1,24 @@
+package `in`.koreatech.koin.feature.callvan.model
+
+import `in`.koreatech.koin.domain.model.callvan.CallvanRestriction
+import java.time.LocalDate
+
+data class CallvanRestrictionUiState(
+    val isRestricted: Boolean,
+    val restrictionType: RestrictionType,
+    val restrictedUntil: LocalDate?
+) {
+    enum class RestrictionType(val days: Int?) {
+        TEMPORARY_14_DAYS(14), PERMANENT(null), NONE(null)
+    }
+}
+
+fun CallvanRestriction.toUiState() = CallvanRestrictionUiState(
+    isRestricted = isRestricted,
+    restrictionType = when (restrictionType) {
+        CallvanRestriction.CallvanRestrictionType.TemporaryRestriction14Days -> CallvanRestrictionUiState.RestrictionType.TEMPORARY_14_DAYS
+        CallvanRestriction.CallvanRestrictionType.PermanentRestriction -> CallvanRestrictionUiState.RestrictionType.PERMANENT
+        CallvanRestriction.CallvanRestrictionType.NoRestriction -> CallvanRestrictionUiState.RestrictionType.NONE
+    },
+    restrictedUntil = restrictedUntil?.let { runCatching { LocalDate.parse(it) }.getOrNull() }
+)

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/component/CallvanBanDialog.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/component/CallvanBanDialog.kt
@@ -1,0 +1,113 @@
+package `in`.koreatech.koin.feature.callvan.ui.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.callvan.R
+import `in`.koreatech.koin.feature.callvan.model.CallvanRestrictionUiState
+import java.time.LocalDate
+
+@Composable
+fun CallvanBanDialog(
+    restrictionType: CallvanRestrictionUiState.RestrictionType,
+    restrictedUntil: LocalDate?,
+    onDismiss: () -> Unit
+) {
+    if (restrictionType == CallvanRestrictionUiState.RestrictionType.NONE) return
+
+    val formattedDate = if (restrictedUntil != null) {
+        stringResource(R.string.callvan_ban_date_format, restrictedUntil.monthValue, restrictedUntil.dayOfMonth)
+    } else null
+
+    val title = when (restrictionType) {
+        CallvanRestrictionUiState.RestrictionType.TEMPORARY_14_DAYS ->
+            stringResource(R.string.callvan_ban_title_temporary, restrictionType.days ?: 0)
+        CallvanRestrictionUiState.RestrictionType.PERMANENT ->
+            stringResource(R.string.callvan_ban_title_permanent)
+        CallvanRestrictionUiState.RestrictionType.NONE -> return
+    }
+
+    val description = when (restrictionType) {
+        CallvanRestrictionUiState.RestrictionType.TEMPORARY_14_DAYS ->
+            stringResource(R.string.callvan_ban_description_temporary, formattedDate.orEmpty())
+        CallvanRestrictionUiState.RestrictionType.PERMANENT ->
+            stringResource(R.string.callvan_ban_description_permanent)
+        CallvanRestrictionUiState.RestrictionType.NONE -> return
+    }
+
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            shape = RebrandKoinTheme.shapes.small,
+            colors = CardDefaults.cardColors(containerColor = RebrandKoinTheme.colors.neutral0)
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 32.dp, vertical = 24.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = title,
+                    style = RebrandKoinTheme.typography.medium18,
+                    color = RebrandKoinTheme.colors.neutral800,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(
+                    text = description,
+                    style = RebrandKoinTheme.typography.regular14,
+                    color = RebrandKoinTheme.colors.neutral600,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(20.dp))
+                FilledButton(
+                    text = stringResource(R.string.callvan_ban_close),
+                    onClick = onDismiss,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RebrandKoinTheme.shapes.medium,
+                    contentPadding = PaddingValues(vertical = 14.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = RebrandKoinTheme.colors.primary500)
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CallvanBanDialogTemporaryPreview() {
+    RebrandKoinTheme {
+        CallvanBanDialog(
+            restrictionType = CallvanRestrictionUiState.RestrictionType.TEMPORARY_14_DAYS,
+            restrictedUntil = LocalDate.of(2025, 3, 26),
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CallvanBanDialogPermanentPreview() {
+    RebrandKoinTheme {
+        CallvanBanDialog(
+            restrictionType = CallvanRestrictionUiState.RestrictionType.PERMANENT,
+            restrictedUntil = null,
+            onDismiss = {}
+        )
+    }
+}

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/component/CallvanBanDialog.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/component/CallvanBanDialog.kt
@@ -34,7 +34,9 @@ fun CallvanBanDialog(
 
     val formattedDate = if (restrictedUntil != null) {
         stringResource(R.string.callvan_ban_date_format, restrictedUntil.monthValue, restrictedUntil.dayOfMonth)
-    } else null
+    } else {
+        null
+    }
 
     val title = when (restrictionType) {
         CallvanRestrictionUiState.RestrictionType.TEMPORARY_14_DAYS ->

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateScreen.kt
@@ -23,11 +23,11 @@ import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.callvan.R
 import `in`.koreatech.koin.feature.callvan.model.CallvanLocationOption
+import `in`.koreatech.koin.feature.callvan.ui.component.CallvanBanDialog
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanDateField
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanLocationPickerBottomSheet
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanLocationSection
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanParticipantsSection
-import `in`.koreatech.koin.feature.callvan.ui.component.CallvanBanDialog
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanSubmitBottomBar
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanTimeField
 import `in`.koreatech.koin.feature.callvan.ui.displayNameRes

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -26,6 +27,7 @@ import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanDateField
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanLocationPickerBottomSheet
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanLocationSection
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanParticipantsSection
+import `in`.koreatech.koin.feature.callvan.ui.component.CallvanBanDialog
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanSubmitBottomBar
 import `in`.koreatech.koin.feature.callvan.ui.create.component.CallvanTimeField
 import `in`.koreatech.koin.feature.callvan.ui.displayNameRes
@@ -53,6 +55,18 @@ fun CallvanCreateScreen(
                 context.getString(R.string.callvan_create_past_time_error)
             )
         }
+    }
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchRestriction()
+    }
+
+    if (state.showBanDialog) {
+        CallvanBanDialog(
+            restrictionType = state.restriction.restrictionType,
+            restrictedUntil = state.restriction.restrictedUntil,
+            onDismiss = { viewModel.updateBanDialogVisible(false) }
+        )
     }
 
     if (state.isLocationPickerVisible) {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateState.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateState.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.feature.callvan.ui.create
 
 import `in`.koreatech.koin.feature.callvan.MIN_PARTICIPANTS_COUNT
 import `in`.koreatech.koin.feature.callvan.model.CallvanLocationOption
+import `in`.koreatech.koin.feature.callvan.model.CallvanRestrictionUiState
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -17,7 +18,13 @@ data class CallvanCreateState(
     val isTimePickerVisible: Boolean = false,
     val isLocationPickerVisible: Boolean = false,
     val isPickingDeparture: Boolean = true,
-    val isSubmitting: Boolean = false
+    val isSubmitting: Boolean = false,
+    val restriction: CallvanRestrictionUiState = CallvanRestrictionUiState(
+        isRestricted = false,
+        restrictionType = CallvanRestrictionUiState.RestrictionType.NONE,
+        restrictedUntil = null
+    ),
+    val showBanDialog: Boolean = false
 ) {
     val isFormComplete: Boolean
         get() {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
@@ -5,10 +5,10 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.error.callvan.KoinCallvanException
 import `in`.koreatech.koin.domain.usecase.callvan.CreateCallvanPostUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.GetCallvanRestrictionUseCase
-import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.MAX_PARTICIPANTS_COUNT
 import `in`.koreatech.koin.feature.callvan.MIN_PARTICIPANTS_COUNT
 import `in`.koreatech.koin.feature.callvan.model.CallvanLocationOption
+import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.ui.create.model.SubmitErrorType
 import java.time.LocalDate
 import java.time.LocalDateTime

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.error.callvan.KoinCallvanException
 import `in`.koreatech.koin.domain.usecase.callvan.CreateCallvanPostUseCase
+import `in`.koreatech.koin.domain.usecase.callvan.GetCallvanRestrictionUseCase
+import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.MAX_PARTICIPANTS_COUNT
 import `in`.koreatech.koin.feature.callvan.MIN_PARTICIPANTS_COUNT
 import `in`.koreatech.koin.feature.callvan.model.CallvanLocationOption
@@ -23,7 +25,8 @@ import org.orbitmvi.orbit.viewmodel.container
 @Suppress("TooManyFunctions")
 @HiltViewModel
 class CallvanCreateViewModel @Inject constructor(
-    private val createCallvanPostUseCase: CreateCallvanPostUseCase
+    private val createCallvanPostUseCase: CreateCallvanPostUseCase,
+    private val getCallvanRestrictionUseCase: GetCallvanRestrictionUseCase
 ) : ViewModel(), ContainerHost<CallvanCreateState, CallvanCreateSideEffect> {
 
     override val container: Container<CallvanCreateState, CallvanCreateSideEffect> = container(
@@ -137,15 +140,33 @@ class CallvanCreateViewModel @Inject constructor(
         }
     }
 
+    fun updateBanDialogVisible(visible: Boolean) = blockingIntent {
+        reduce { state.copy(showBanDialog = visible) }
+    }
+
+    fun fetchRestriction() = intent {
+        getCallvanRestrictionUseCase()
+            .onSuccess { restriction ->
+                val uiState = restriction.toUiState()
+                reduce { state.copy(restriction = uiState, showBanDialog = uiState.isRestricted) }
+            }
+    }
+
     private fun isDepartureInPast(state: CallvanCreateState): Boolean {
         val selected = LocalDateTime.of(state.selectedDate, state.selectedTime)
         return selected.isBefore(LocalDateTime.now())
     }
 
+    @Suppress("CognitiveComplexMethod")
     fun submit() = intent {
         val currentState = state
         if (!currentState.isFormComplete || currentState.isSubmitting) return@intent
         if (currentState.departureLocation == null || currentState.arrivalLocation == null) return@intent
+
+        if (currentState.restriction.isRestricted) {
+            reduce { state.copy(showBanDialog = true) }
+            return@intent
+        }
 
         /* 현재 날짜 이후 검증 로직 */
         if (isDepartureInPast(currentState)) {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
@@ -34,6 +34,8 @@ import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.callvan.R
+import `in`.koreatech.koin.feature.callvan.model.CallvanRestrictionUiState
+import `in`.koreatech.koin.feature.callvan.ui.component.CallvanBanDialog
 import `in`.koreatech.koin.feature.callvan.ui.component.CallvanConfirmBottomSheet
 import `in`.koreatech.koin.feature.callvan.ui.component.CallvanNotificationIcon
 import `in`.koreatech.koin.feature.callvan.ui.list.component.CallvanFAB
@@ -70,7 +72,6 @@ fun CallvanListScreen(
     val state by viewModel.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
-
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
             is CallvanListSideEffect.ShowSnackbar -> {
@@ -96,14 +97,16 @@ fun CallvanListScreen(
 
     LaunchedEffect(state.isLoggedIn) {
         viewModel.fetchHasNewNotification()
-        if (state.isLoggedIn) viewModel.checkNotificationSuggest()
+        if (state.isLoggedIn) {
+            viewModel.checkNotificationSuggest()
+            //viewModel.fetchRestriction()
+        }
     }
 
     CallvanListScreenImpl(
         searchValue = state.searchValue,
         items = state.items,
         pendingFilterState = state.pendingFilterState,
-        filterState = state.filterState,
         hasNewNotification = state.hasNewNotification,
         isLoginVisible = state.isLoginVisible,
         isFilterVisible = state.isFilterVisible,
@@ -141,7 +144,10 @@ fun CallvanListScreen(
         onDetailClick = onDetailClick,
         onNotificationSuggestConfirm = viewModel::enableCallvanNotification,
         onNotificationSuggestDismiss = viewModel::dismissNotificationSuggest,
-        snackbarHostState = snackbarHostState
+        snackbarHostState = snackbarHostState,
+        showBanDialog = state.showBanDialog,
+        restriction = state.restriction,
+        onBanDialogDismiss = { viewModel.updateBanDialogVisible(false) }
     )
 }
 
@@ -151,7 +157,6 @@ fun CallvanListScreenImpl(
     searchValue: String,
     items: ImmutableList<CallvanListUiState>,
     pendingFilterState: FilterBottomSheetState = FilterBottomSheetState(),
-    filterState: FilterBottomSheetState = FilterBottomSheetState(),
     hasNewNotification: Boolean = false,
     isLoginVisible: Boolean = false,
     isFilterVisible: Boolean = false,
@@ -183,7 +188,14 @@ fun CallvanListScreenImpl(
     onDetailClick: (Int) -> Unit = {},
     onNotificationSuggestConfirm: () -> Unit = {},
     onNotificationSuggestDismiss: () -> Unit = {},
-    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    showBanDialog: Boolean = false,
+    restriction: CallvanRestrictionUiState = CallvanRestrictionUiState(
+        isRestricted = false,
+        restrictionType = CallvanRestrictionUiState.RestrictionType.NONE,
+        restrictedUntil = null
+    ),
+    onBanDialogDismiss: () -> Unit = {}
 ) {
     val listState = rememberLazyListState()
 
@@ -238,6 +250,14 @@ fun CallvanListScreenImpl(
                 onPendingCompletePostIdChange(null)
             },
             onDismiss = { onPendingCompletePostIdChange(null) }
+        )
+    }
+
+    if (showBanDialog) {
+        CallvanBanDialog(
+            restrictionType = restriction.restrictionType,
+            restrictedUntil = restriction.restrictedUntil,
+            onDismiss = onBanDialogDismiss
         )
     }
 

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
@@ -99,7 +99,7 @@ fun CallvanListScreen(
         viewModel.fetchHasNewNotification()
         if (state.isLoggedIn) {
             viewModel.checkNotificationSuggest()
-            //viewModel.fetchRestriction()
+            // viewModel.fetchRestriction()
         }
     }
 

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListState.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListState.kt
@@ -7,7 +7,6 @@ import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanListUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.FilterBottomSheetState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import java.time.LocalDate
 
 @Immutable
 data class CallvanListState(

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListState.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListState.kt
@@ -1,15 +1,22 @@
 package `in`.koreatech.koin.feature.callvan.ui.list
 
 import androidx.compose.runtime.Immutable
+import `in`.koreatech.koin.feature.callvan.model.CallvanRestrictionUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanConfirmType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanListUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.FilterBottomSheetState
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import java.time.LocalDate
 
 @Immutable
 data class CallvanListState(
     val items: ImmutableList<CallvanListUiState> = persistentListOf(),
+    val restriction: CallvanRestrictionUiState = CallvanRestrictionUiState(
+        isRestricted = false,
+        restrictionType = CallvanRestrictionUiState.RestrictionType.NONE,
+        restrictedUntil = null
+    ),
     val searchValue: String = "",
     val filterState: FilterBottomSheetState = FilterBottomSheetState(),
     val pendingFilterState: FilterBottomSheetState = FilterBottomSheetState(),
@@ -24,5 +31,6 @@ data class CallvanListState(
     val isFilterVisible: Boolean = false,
     val pendingConfirm: Pair<CallvanConfirmType, Int>? = null,
     val pendingCompletePostId: Int? = null,
-    val showNotificationSuggest: Boolean = false
+    val showNotificationSuggest: Boolean = false,
+    val showBanDialog: Boolean = false
 )

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListViewModel.kt
@@ -18,6 +18,7 @@ import `in`.koreatech.koin.domain.usecase.notification.UpdateNotificationSubscri
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.domain.util.onFailure
 import `in`.koreatech.koin.domain.util.onSuccess
+import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanConfirmType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType.ArrivalsFilterType
@@ -27,7 +28,6 @@ import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType.SortT
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType.StatusesType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanListErrorType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.FilterBottomSheetState
-import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.toListErrorType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.toUiState
 import javax.inject.Inject

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListViewModel.kt
@@ -8,6 +8,7 @@ import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.callvan.CloseCallvanPostUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.CompleteCallvanPostUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.GetCallvanPostsUseCase
+import `in`.koreatech.koin.domain.usecase.callvan.GetCallvanRestrictionUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.GetNotificationsUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.JoinCallvanPostUseCase
 import `in`.koreatech.koin.domain.usecase.callvan.LeaveCallvanPostUseCase
@@ -26,6 +27,7 @@ import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType.SortT
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanFilterType.StatusesType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.CallvanListErrorType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.FilterBottomSheetState
+import `in`.koreatech.koin.feature.callvan.model.toUiState
 import `in`.koreatech.koin.feature.callvan.ui.list.model.toListErrorType
 import `in`.koreatech.koin.feature.callvan.ui.list.model.toUiState
 import javax.inject.Inject
@@ -48,6 +50,7 @@ import org.orbitmvi.orbit.viewmodel.container
 @Suppress("LongParameterList", "TooManyFunctions")
 class CallvanListViewModel @Inject constructor(
     private val getCallvanPostsUseCase: GetCallvanPostsUseCase,
+    private val getCallvanRestrictionUseCase: GetCallvanRestrictionUseCase,
     private val joinCallvanPostUseCase: JoinCallvanPostUseCase,
     private val leaveCallvanPostUseCase: LeaveCallvanPostUseCase,
     private val closeCallvanPostUseCase: CloseCallvanPostUseCase,
@@ -86,6 +89,24 @@ class CallvanListViewModel @Inject constructor(
         }
     }
 
+    fun updateBanDialogVisible(visible: Boolean) = blockingIntent {
+        reduce { state.copy(showBanDialog = visible) }
+    }
+
+    fun fetchRestriction() = intent {
+        if (!state.isLoggedIn) return@intent
+        getCallvanRestrictionUseCase()
+            .onSuccess { restriction ->
+                val uiState = restriction.toUiState()
+                reduce {
+                    state.copy(
+                        restriction = uiState,
+                        showBanDialog = uiState.isRestricted
+                    )
+                }
+            }
+    }
+
     internal fun fetchHasNewNotification() = intent {
         if (state.isLoggedIn) {
             getNotificationsUseCase()
@@ -108,6 +129,10 @@ class CallvanListViewModel @Inject constructor(
     fun join(postId: Int) = intent {
         if (!state.isLoggedIn) {
             reduce { state.copy(isLoginVisible = true) }
+            return@intent
+        }
+        if (state.restriction.isRestricted) {
+            reduce { state.copy(showBanDialog = true) }
             return@intent
         }
         joinCallvanPostUseCase(postId)

--- a/feature/callvan/src/main/res/values/strings.xml
+++ b/feature/callvan/src/main/res/values/strings.xml
@@ -170,6 +170,13 @@
     <string name="callvan_create_submit_error_not_found_user">사용자를 찾을 수 없습니다.</string>
     <string name="callvan_create_submit_error_unknown">게시글 작성에 실패했습니다.</string>
 
+    <string name="callvan_ban_date_format">%1$d월 %2$d일</string>
+    <string name="callvan_ban_title_temporary">%1$d일 이용 정지</string>
+    <string name="callvan_ban_title_permanent">영구 이용 정지</string>
+    <string name="callvan_ban_description_temporary">해당 계정은 %1$s까지\n콜벤팟 기능을 사용할 수 없습니다.</string>
+    <string name="callvan_ban_description_permanent">해당 계정은 콜벤팟 기능을\n영구적으로 사용할 수 없습니다.</string>
+    <string name="callvan_ban_close">닫기</string>
+
     <string name="callvan_notification_suggest_title">알림을 켜볼까요?</string>
     <string name="callvan_notification_suggest_description">채팅부터 출발까지, 필요한 순간을 놓치지 않게 알려드려요</string>
     <string name="callvan_notification_suggest_confirm">알림 켜기</string>

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -359,7 +359,7 @@
     <string name="notification_permission_dialog_negative">취소</string>
 
     <string name="notification_callvan">콜밴팟 알림</string>
-    <string name="notification_callvan_description">콜밴팟 알림을 받습니다.</string>
+    <string name="notification_callvan_description">모든 콜밴팟의 알림을 받습니다.</string>
 
     <!-- force update -->
     <string name="force_update_do_update">업데이트하기</string>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1425

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `CallvanRestrictionUiState` feature 모델 추가 및 domain 모델 매핑
- `CallvanBanDialog` 컴포저블 추가 (기간 정지 / 영구 정지 타입별 표시)
- `CallvanListViewModel`: 로그인 상태에서 restriction 조회, join 시 밴 상태 검증
- `CallvanCreateViewModel`: 화면 진입 시 restriction 조회, submit 시 밴 상태 검증
- List/Create 화면에서 `showBanDialog` state로 다이얼로그 노출 및 dismiss 처리
- 콜밴 알림 설명문 수정("모든 콜밴팟의 알림을 받습니다.")

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다