### PR TITLE
[Feature] 분실물 키워드 관리 화면 구현

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
@@ -1,10 +1,5 @@
 package `in`.koreatech.koin.feature.lostandfound.component
 
-import androidx.compose.animation.ExperimentalSharedTransitionApi
-import androidx.compose.animation.animateBounds
-import androidx.compose.animation.animateContentSize
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -15,27 +10,12 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateListOf
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,19 +25,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.LookaheadScope
-import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import `in`.koreatech.koin.core.designsystem.component.chip.ChipOverflowStrategy.Flow
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipColors
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipDefaults
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
-import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun KeywordChipGroup(
@@ -227,197 +201,3 @@ fun keywordChipColors() =
         selectedContentColor = KoinTheme.colors.neutral100,
         unselectedContentColor = KoinTheme.colors.neutral500
     )
-
-@Composable
-fun LostAndFoundKeywordChip(
-    title: String,
-    backgroundColor: Color,
-    textColor: Color,
-    iconVector: ImageVector,
-    onClick: () -> Unit,
-    modifier: Modifier = Modifier
-) {
-    // Article keyword screen Material Chip 기본 동등 매칭
-    //  - chip height 32dp (Material chipMinHeight)
-    //  - start 12dp / end 6dp horizontal padding
-    //  - text→icon 간격 8dp / closeIconSize 12dp
-    //  - Text 의 lineHeight 1.6× 가 단일 라인에서 vertical padding 처럼 누적되는 것을 막기 위해
-    //    명시적 height + LineHeightStyle 로 vertical alignment 처리
-    Row(
-        modifier = modifier
-            .requiredHeight(32.dp)
-            .clip(CircleShape)
-            .background(backgroundColor)
-            .noRippleClickable(onClick = onClick)
-            .padding(start = 12.dp, end = 6.dp),
-        horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Text(
-            modifier = Modifier.weight(1f, fill = false),
-            text = title,
-            style = KoinTheme.typography.medium14.copy(
-                lineHeight = 14.sp,
-                platformStyle = PlatformTextStyle(includeFontPadding = false)
-            ),
-            color = textColor,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis
-        )
-        Icon(
-            modifier = Modifier
-                .padding(start = 8.dp)
-                .size(12.dp),
-            imageVector = iconVector,
-            contentDescription = null,
-            tint = textColor
-        )
-    }
-}
-
-@Composable
-fun LostAndFoundDeletableKeywordChip(
-    title: String,
-    onDelete: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LostAndFoundKeywordChip(
-        title = title,
-        backgroundColor = KoinTheme.colors.neutral100,
-        textColor = KoinTheme.colors.neutral500,
-        iconVector = Icons.Default.Close,
-        onClick = { onDelete(title) },
-        modifier = modifier
-    )
-}
-
-@Composable
-fun LostAndFoundAddableKeywordChip(
-    title: String,
-    onAdd: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    LostAndFoundKeywordChip(
-        title = title,
-        backgroundColor = KoinTheme.colors.neutral100,
-        textColor = KoinTheme.colors.neutral500,
-        iconVector = Icons.Default.Add,
-        onClick = { onAdd(title) },
-        modifier = modifier
-    )
-}
-
-@Composable
-fun LostAndFoundDeletableChipFlowGroup(
-    keywords: ImmutableList<String>,
-    onDelete: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    AnimatedKeywordChipFlowGroup(
-        items = keywords,
-        modifier = modifier
-    ) { keyword ->
-        LostAndFoundDeletableKeywordChip(title = keyword, onDelete = onDelete)
-    }
-}
-
-@Composable
-fun LostAndFoundAddableChipFlowGroup(
-    keywords: ImmutableList<String>,
-    onAdd: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    AnimatedKeywordChipFlowGroup(
-        items = keywords,
-        modifier = modifier
-    ) { keyword ->
-        LostAndFoundAddableKeywordChip(title = keyword, onAdd = onAdd)
-    }
-}
-
-// Article 키워드 화면의 ChipGroup `android:animateLayoutChanges="true"` 와 동일한 Layout
-// Transition 타이밍을 재현한다.
-//  - APPEARING:           새 chip 페이드인 300ms (start delay 300ms — 형제 위치 이동 후 등장)
-//  - DISAPPEARING:        제거되는 chip 페이드아웃 300ms (start delay 0)
-//  - CHANGE_APPEARING:    형제 chip 위치 이동 300ms (start delay 0, 즉시)
-//  - CHANGE_DISAPPEARING: 형제 chip 위치 이동 300ms (start delay 300ms — 페이드아웃 후 합치기)
-//
-// Exit fade 를 위해 [items] 에서 빠진 키워드도 fade-out 이 끝날 때까지 [displayedItems] 에
-// 남겨둔 뒤, 알파 애니메이션 종료 시점에 컴포지션에서 제거한다. 컴포지션 제거 직후 형제 chip 의
-// LookaheadScope 측정값이 변경되며 [Modifier.animateBounds] 가 위치 이동을 보간한다. 결과적으로
-// 형제 chip 의 위치 이동은 페이드아웃 종료 시점부터 시작되어 LayoutTransition 의 기본
-// CHANGE_DISAPPEARING delay (= 300ms) 와 동일하게 동작한다.
-@OptIn(ExperimentalLayoutApi::class, ExperimentalSharedTransitionApi::class)
-@Composable
-private fun AnimatedKeywordChipFlowGroup(
-    items: ImmutableList<String>,
-    modifier: Modifier = Modifier,
-    chip: @Composable (String) -> Unit
-) {
-    val displayedItems = remember { mutableStateListOf<String>() }
-    val visibility = remember { mutableStateMapOf<String, Boolean>() }
-
-    LaunchedEffect(items) {
-        // 아직 displayedItems 에 없는 키워드는 [items] 순서를 유지하도록 삽입한다.
-        // 단순 append 는 한 번 fade-out 후 사라졌다 되돌아올 때 원래 위치를 잃어버려
-        // 추천 키워드의 캐논 순서가 어긋나는 문제를 일으킨다.
-        items.forEachIndexed { itemIdx, key ->
-            if (key !in displayedItems) {
-                val insertAt = (itemIdx - 1 downTo 0)
-                    .asSequence()
-                    .map { displayedItems.indexOf(items[it]) }
-                    .firstOrNull { it >= 0 }
-                    ?.let { it + 1 }
-                    ?: 0
-                displayedItems.add(insertAt, key)
-            }
-            visibility[key] = true
-        }
-        displayedItems.toList().forEach { key ->
-            if (key !in items && visibility[key] != false) visibility[key] = false
-        }
-    }
-
-    LookaheadScope {
-        FlowRow(
-            modifier = modifier.animateContentSize(animationSpec = tween(durationMillis = 300)),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            displayedItems.forEach { keyword ->
-                key(keyword) {
-                    var hasStartedEntry by remember { mutableStateOf(false) }
-                    LaunchedEffect(Unit) { hasStartedEntry = true }
-                    val isVisible = visibility[keyword] ?: true
-                    val targetAlpha = if (hasStartedEntry && isVisible) 1f else 0f
-                    val alphaSpec = if (isVisible) {
-                        tween<Float>(durationMillis = 300, delayMillis = 300)
-                    } else {
-                        tween<Float>(durationMillis = 300)
-                    }
-                    val alpha by animateFloatAsState(
-                        targetValue = targetAlpha,
-                        animationSpec = alphaSpec,
-                        label = "keywordChipAlpha",
-                        finishedListener = { finalValue ->
-                            if (finalValue == 0f && visibility[keyword] == false) {
-                                displayedItems.remove(keyword)
-                                visibility.remove(keyword)
-                            }
-                        }
-                    )
-                    Box(
-                        modifier = Modifier
-                            .animateBounds(
-                                lookaheadScope = this@LookaheadScope,
-                                boundsTransform = { _, _ -> tween(durationMillis = 300) }
-                            )
-                            .graphicsLayer { this.alpha = alpha }
-                    ) {
-                        chip(keyword)
-                    }
-                }
-            }
-        }
-    }
-}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
@@ -1,5 +1,10 @@
 package `in`.koreatech.koin.feature.lostandfound.component
 
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -10,6 +15,8 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -19,9 +26,16 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -32,9 +46,12 @@ import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import `in`.koreatech.koin.core.designsystem.component.chip.ChipOverflowStrategy.Flow
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipColors
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipDefaults
@@ -220,35 +237,41 @@ fun LostAndFoundKeywordChip(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(
+    // Article keyword screen Material Chip 기본 동등 매칭
+    //  - chip height 32dp (Material chipMinHeight)
+    //  - start 12dp / end 6dp horizontal padding
+    //  - text→icon 간격 8dp / closeIconSize 12dp
+    //  - Text 의 lineHeight 1.6× 가 단일 라인에서 vertical padding 처럼 누적되는 것을 막기 위해
+    //    명시적 height + LineHeightStyle 로 vertical alignment 처리
+    Row(
         modifier = modifier
-            .minimumInteractiveComponentSize()
-            .noRippleClickable(onClick = onClick),
-        contentAlignment = Alignment.Center
+            .requiredHeight(32.dp)
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .noRippleClickable(onClick = onClick)
+            .padding(start = 12.dp, end = 6.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        Row(
+        Text(
+            modifier = Modifier.weight(1f, fill = false),
+            text = title,
+            style = KoinTheme.typography.medium14.copy(
+                lineHeight = 14.sp,
+                platformStyle = PlatformTextStyle(includeFontPadding = false)
+            ),
+            color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Icon(
             modifier = Modifier
-                .clip(CircleShape)
-                .background(backgroundColor)
-                .padding(horizontal = 12.dp, vertical = 6.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                modifier = Modifier.weight(1f, fill = false),
-                text = title,
-                style = KoinTheme.typography.medium14,
-                color = textColor,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
-            Icon(
-                modifier = Modifier.padding(start = 4.dp),
-                imageVector = iconVector,
-                contentDescription = null,
-                tint = textColor
-            )
-        }
+                .padding(start = 8.dp)
+                .size(12.dp),
+            imageVector = iconVector,
+            contentDescription = null,
+            tint = textColor
+        )
     }
 }
 
@@ -284,41 +307,116 @@ fun LostAndFoundAddableKeywordChip(
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LostAndFoundDeletableChipFlowGroup(
     keywords: ImmutableList<String>,
     onDelete: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        keywords.forEach { keyword ->
-            androidx.compose.runtime.key(keyword) {
-                LostAndFoundDeletableKeywordChip(title = keyword, onDelete = onDelete)
-            }
-        }
+    AnimatedKeywordChipFlowGroup(
+        items = keywords,
+        modifier = modifier
+    ) { keyword ->
+        LostAndFoundDeletableKeywordChip(title = keyword, onDelete = onDelete)
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun LostAndFoundAddableChipFlowGroup(
     keywords: ImmutableList<String>,
     onAdd: (String) -> Unit,
     modifier: Modifier = Modifier
 ) {
-    FlowRow(
-        modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        keywords.forEach { keyword ->
-            androidx.compose.runtime.key(keyword) {
-                LostAndFoundAddableKeywordChip(title = keyword, onAdd = onAdd)
+    AnimatedKeywordChipFlowGroup(
+        items = keywords,
+        modifier = modifier
+    ) { keyword ->
+        LostAndFoundAddableKeywordChip(title = keyword, onAdd = onAdd)
+    }
+}
+
+// Article 키워드 화면의 ChipGroup `android:animateLayoutChanges="true"` 와 동일한 Layout
+// Transition 타이밍을 재현한다.
+//  - APPEARING:           새 chip 페이드인 300ms (start delay 300ms — 형제 위치 이동 후 등장)
+//  - DISAPPEARING:        제거되는 chip 페이드아웃 300ms (start delay 0)
+//  - CHANGE_APPEARING:    형제 chip 위치 이동 300ms (start delay 0, 즉시)
+//  - CHANGE_DISAPPEARING: 형제 chip 위치 이동 300ms (start delay 300ms — 페이드아웃 후 합치기)
+//
+// Exit fade 를 위해 [items] 에서 빠진 키워드도 fade-out 이 끝날 때까지 [displayedItems] 에
+// 남겨둔 뒤, 알파 애니메이션 종료 시점에 컴포지션에서 제거한다. 컴포지션 제거 직후 형제 chip 의
+// LookaheadScope 측정값이 변경되며 [Modifier.animateBounds] 가 위치 이동을 보간한다. 결과적으로
+// 형제 chip 의 위치 이동은 페이드아웃 종료 시점부터 시작되어 LayoutTransition 의 기본
+// CHANGE_DISAPPEARING delay (= 300ms) 와 동일하게 동작한다.
+@OptIn(ExperimentalLayoutApi::class, ExperimentalSharedTransitionApi::class)
+@Composable
+private fun AnimatedKeywordChipFlowGroup(
+    items: ImmutableList<String>,
+    modifier: Modifier = Modifier,
+    chip: @Composable (String) -> Unit
+) {
+    val displayedItems = remember { mutableStateListOf<String>() }
+    val visibility = remember { mutableStateMapOf<String, Boolean>() }
+
+    LaunchedEffect(items) {
+        // 아직 displayedItems 에 없는 키워드는 [items] 순서를 유지하도록 삽입한다.
+        // 단순 append 는 한 번 fade-out 후 사라졌다 되돌아올 때 원래 위치를 잃어버려
+        // 추천 키워드의 캐논 순서가 어긋나는 문제를 일으킨다.
+        items.forEachIndexed { itemIdx, key ->
+            if (key !in displayedItems) {
+                val insertAt = (itemIdx - 1 downTo 0)
+                    .asSequence()
+                    .map { displayedItems.indexOf(items[it]) }
+                    .firstOrNull { it >= 0 }
+                    ?.let { it + 1 }
+                    ?: 0
+                displayedItems.add(insertAt, key)
+            }
+            visibility[key] = true
+        }
+        displayedItems.toList().forEach { key ->
+            if (key !in items && visibility[key] != false) visibility[key] = false
+        }
+    }
+
+    LookaheadScope {
+        FlowRow(
+            modifier = modifier.animateContentSize(animationSpec = tween(durationMillis = 300)),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            displayedItems.forEach { keyword ->
+                key(keyword) {
+                    var hasStartedEntry by remember { mutableStateOf(false) }
+                    LaunchedEffect(Unit) { hasStartedEntry = true }
+                    val isVisible = visibility[keyword] ?: true
+                    val targetAlpha = if (hasStartedEntry && isVisible) 1f else 0f
+                    val alphaSpec = if (isVisible) {
+                        tween<Float>(durationMillis = 300, delayMillis = 300)
+                    } else {
+                        tween<Float>(durationMillis = 300)
+                    }
+                    val alpha by animateFloatAsState(
+                        targetValue = targetAlpha,
+                        animationSpec = alphaSpec,
+                        label = "keywordChipAlpha",
+                        finishedListener = { finalValue ->
+                            if (finalValue == 0f && visibility[keyword] == false) {
+                                displayedItems.remove(keyword)
+                                visibility.remove(keyword)
+                            }
+                        }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .animateBounds(
+                                lookaheadScope = this@LookaheadScope,
+                                boundsTransform = { _, _ -> tween(durationMillis = 300) }
+                            )
+                            .graphicsLayer { this.alpha = alpha }
+                    ) {
+                        chip(keyword)
+                    }
+                }
             }
         }
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
@@ -260,8 +260,8 @@ fun LostAndFoundDeletableKeywordChip(
 ) {
     LostAndFoundKeywordChip(
         title = title,
-        backgroundColor = KoinTheme.colors.primary500,
-        textColor = KoinTheme.colors.neutral100,
+        backgroundColor = KoinTheme.colors.neutral100,
+        textColor = KoinTheme.colors.neutral500,
         iconVector = Icons.Default.Close,
         onClick = { onDelete(title) },
         modifier = modifier

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/KeywordChipGroup.kt
@@ -11,9 +11,15 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -25,13 +31,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.component.chip.ChipOverflowStrategy.Flow
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipColors
 import `in`.koreatech.koin.core.designsystem.component.chip.TextChipDefaults
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun KeywordChipGroup(
@@ -201,3 +210,116 @@ fun keywordChipColors() =
         selectedContentColor = KoinTheme.colors.neutral100,
         unselectedContentColor = KoinTheme.colors.neutral500
     )
+
+@Composable
+fun LostAndFoundKeywordChip(
+    title: String,
+    backgroundColor: Color,
+    textColor: Color,
+    iconVector: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .minimumInteractiveComponentSize()
+            .noRippleClickable(onClick = onClick),
+        contentAlignment = Alignment.Center
+    ) {
+        Row(
+            modifier = Modifier
+                .clip(CircleShape)
+                .background(backgroundColor)
+                .padding(horizontal = 12.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                modifier = Modifier.weight(1f, fill = false),
+                text = title,
+                style = KoinTheme.typography.medium14,
+                color = textColor,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Icon(
+                modifier = Modifier.padding(start = 4.dp),
+                imageVector = iconVector,
+                contentDescription = null,
+                tint = textColor
+            )
+        }
+    }
+}
+
+@Composable
+fun LostAndFoundDeletableKeywordChip(
+    title: String,
+    onDelete: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LostAndFoundKeywordChip(
+        title = title,
+        backgroundColor = KoinTheme.colors.primary500,
+        textColor = KoinTheme.colors.neutral100,
+        iconVector = Icons.Default.Close,
+        onClick = { onDelete(title) },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun LostAndFoundAddableKeywordChip(
+    title: String,
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LostAndFoundKeywordChip(
+        title = title,
+        backgroundColor = KoinTheme.colors.neutral100,
+        textColor = KoinTheme.colors.neutral500,
+        iconVector = Icons.Default.Add,
+        onClick = { onAdd(title) },
+        modifier = modifier
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun LostAndFoundDeletableChipFlowGroup(
+    keywords: ImmutableList<String>,
+    onDelete: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        keywords.forEach { keyword ->
+            androidx.compose.runtime.key(keyword) {
+                LostAndFoundDeletableKeywordChip(title = keyword, onDelete = onDelete)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun LostAndFoundAddableChipFlowGroup(
+    keywords: ImmutableList<String>,
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        keywords.forEach { keyword ->
+            androidx.compose.runtime.key(keyword) {
+                LostAndFoundAddableKeywordChip(title = keyword, onAdd = onAdd)
+            }
+        }
+    }
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostAndFoundKeywordChip.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostAndFoundKeywordChip.kt
@@ -170,28 +170,18 @@ private fun AnimatedKeywordChipFlowGroup(
     modifier: Modifier = Modifier,
     chip: @Composable (String) -> Unit
 ) {
-    val displayedItems = remember { mutableStateListOf<String>() }
-    val visibility = remember { mutableStateMapOf<String, Boolean>() }
+    // 첫 컴포지션 시점에 이미 존재하는 키워드는 entry 애니메이션 없이 즉시 보이도록
+    // displayedItems / visibility 를 미리 채워 두고, 첫 프레임이 끝났는지 추적한다.
+    // 첫 프레임 이후에 새로 등장하는 칩(또는 제거 후 재추가된 칩)만 fade-in 한다.
+    val displayedItems = remember { mutableStateListOf<String>().apply { addAll(items) } }
+    val visibility = remember {
+        mutableStateMapOf<String, Boolean>().apply { items.forEach { put(it, true) } }
+    }
+    var hasInitialFrameRendered by remember { mutableStateOf(false) }
+    LaunchedEffect(Unit) { hasInitialFrameRendered = true }
 
     LaunchedEffect(items) {
-        // 아직 displayedItems 에 없는 키워드는 [items] 순서를 유지하도록 삽입한다.
-        // 단순 append 는 한 번 fade-out 후 사라졌다 되돌아올 때 원래 위치를 잃어버려
-        // 추천 키워드의 캐논 순서가 어긋나는 문제를 일으킨다.
-        items.forEachIndexed { itemIdx, key ->
-            if (key !in displayedItems) {
-                val insertAt = (itemIdx - 1 downTo 0)
-                    .asSequence()
-                    .map { displayedItems.indexOf(items[it]) }
-                    .firstOrNull { it >= 0 }
-                    ?.let { it + 1 }
-                    ?: 0
-                displayedItems.add(insertAt, key)
-            }
-            visibility[key] = true
-        }
-        displayedItems.toList().forEach { key ->
-            if (key !in items && visibility[key] != false) visibility[key] = false
-        }
+        syncDisplayedItems(items, displayedItems, visibility)
     }
 
     LookaheadScope {
@@ -202,38 +192,87 @@ private fun AnimatedKeywordChipFlowGroup(
         ) {
             displayedItems.forEach { keyword ->
                 key(keyword) {
-                    var hasStartedEntry by remember { mutableStateOf(false) }
-                    LaunchedEffect(Unit) { hasStartedEntry = true }
-                    val isVisible = visibility[keyword] ?: true
-                    val targetAlpha = if (hasStartedEntry && isVisible) 1f else 0f
-                    val alphaSpec = if (isVisible) {
-                        tween<Float>(durationMillis = 300, delayMillis = 300)
-                    } else {
-                        tween<Float>(durationMillis = 300)
-                    }
-                    val alpha by animateFloatAsState(
-                        targetValue = targetAlpha,
-                        animationSpec = alphaSpec,
-                        label = "keywordChipAlpha",
-                        finishedListener = { finalValue ->
-                            if (finalValue == 0f && visibility[keyword] == false) {
-                                displayedItems.remove(keyword)
-                                visibility.remove(keyword)
-                            }
-                        }
+                    AnimatedKeywordChipSlot(
+                        keyword = keyword,
+                        visibility = visibility,
+                        displayedItems = displayedItems,
+                        startVisible = !hasInitialFrameRendered,
+                        lookaheadScope = this@LookaheadScope,
+                        chip = chip
                     )
-                    Box(
-                        modifier = Modifier
-                            .animateBounds(
-                                lookaheadScope = this@LookaheadScope,
-                                boundsTransform = { _, _ -> tween(durationMillis = 300) }
-                            )
-                            .graphicsLayer { this.alpha = alpha }
-                    ) {
-                        chip(keyword)
-                    }
                 }
             }
         }
+    }
+}
+
+/**
+ * displayedItems 를 새 [items] 와 동기화한다. 새 키워드는 [items] 순서를 유지하도록 삽입하고,
+ * [items] 에서 빠진 키워드는 visibility=false 로 표시해 fade-out 을 트리거한다.
+ *
+ * 단순 append 는 한 번 fade-out 후 사라졌다 되돌아올 때 원래 위치를 잃어버려 추천 키워드의 캐논
+ * 순서가 어긋나는 문제를 일으키므로, 인접한 기존 키워드를 기준으로 삽입 위치를 계산한다.
+ */
+private fun syncDisplayedItems(
+    items: ImmutableList<String>,
+    displayedItems: MutableList<String>,
+    visibility: MutableMap<String, Boolean>
+) {
+    items.forEachIndexed { itemIdx, key ->
+        if (key !in displayedItems) {
+            val insertAt = (itemIdx - 1 downTo 0)
+                .asSequence()
+                .map { displayedItems.indexOf(items[it]) }
+                .firstOrNull { it >= 0 }
+                ?.let { it + 1 }
+                ?: 0
+            displayedItems.add(insertAt, key)
+        }
+        visibility[key] = true
+    }
+    displayedItems.toList().forEach { key ->
+        if (key !in items && visibility[key] != false) visibility[key] = false
+    }
+}
+
+@OptIn(ExperimentalSharedTransitionApi::class)
+@Composable
+private fun AnimatedKeywordChipSlot(
+    keyword: String,
+    visibility: MutableMap<String, Boolean>,
+    displayedItems: MutableList<String>,
+    startVisible: Boolean,
+    lookaheadScope: LookaheadScope,
+    chip: @Composable (String) -> Unit
+) {
+    var hasStartedEntry by remember { mutableStateOf(startVisible) }
+    LaunchedEffect(Unit) { hasStartedEntry = true }
+    val isVisible = visibility[keyword] ?: true
+    val targetAlpha = if (hasStartedEntry && isVisible) 1f else 0f
+    val alphaSpec = if (isVisible) {
+        tween<Float>(durationMillis = 300, delayMillis = 300)
+    } else {
+        tween<Float>(durationMillis = 300)
+    }
+    val alpha by animateFloatAsState(
+        targetValue = targetAlpha,
+        animationSpec = alphaSpec,
+        label = "keywordChipAlpha",
+        finishedListener = { finalValue ->
+            if (finalValue == 0f && visibility[keyword] == false) {
+                displayedItems.remove(keyword)
+                visibility.remove(keyword)
+            }
+        }
+    )
+    Box(
+        modifier = Modifier
+            .animateBounds(
+                lookaheadScope = lookaheadScope,
+                boundsTransform = { _, _ -> tween(durationMillis = 300) }
+            )
+            .graphicsLayer { this.alpha = alpha }
+    ) {
+        chip(keyword)
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostAndFoundKeywordChip.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LostAndFoundKeywordChip.kt
@@ -1,0 +1,239 @@
+package `in`.koreatech.koin.feature.lostandfound.component
+
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.animateBounds
+import androidx.compose.animation.animateContentSize
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.LookaheadScope
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import `in`.koreatech.koin.core.designsystem.noRippleClickable
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import kotlinx.collections.immutable.ImmutableList
+
+@Composable
+fun LostAndFoundKeywordChip(
+    title: String,
+    backgroundColor: Color,
+    textColor: Color,
+    iconVector: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    // Article keyword screen Material Chip 기본 동등 매칭
+    //  - chip height 32dp (Material chipMinHeight)
+    //  - start 12dp / end 6dp horizontal padding
+    //  - text→icon 간격 8dp / closeIconSize 12dp
+    //  - Text 의 lineHeight 1.6× 가 단일 라인에서 vertical padding 처럼 누적되는 것을 막기 위해
+    //    명시적 height + LineHeightStyle 로 vertical alignment 처리
+    Row(
+        modifier = modifier
+            .requiredHeight(32.dp)
+            .clip(CircleShape)
+            .background(backgroundColor)
+            .noRippleClickable(onClick = onClick)
+            .padding(start = 12.dp, end = 6.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            modifier = Modifier.weight(1f, fill = false),
+            text = title,
+            style = KoinTheme.typography.medium14.copy(
+                lineHeight = 14.sp,
+                platformStyle = PlatformTextStyle(includeFontPadding = false)
+            ),
+            color = textColor,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+        Icon(
+            modifier = Modifier
+                .padding(start = 8.dp)
+                .size(12.dp),
+            imageVector = iconVector,
+            contentDescription = null,
+            tint = textColor
+        )
+    }
+}
+
+@Composable
+fun LostAndFoundDeletableKeywordChip(
+    title: String,
+    onDelete: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LostAndFoundKeywordChip(
+        title = title,
+        backgroundColor = KoinTheme.colors.neutral100,
+        textColor = KoinTheme.colors.neutral500,
+        iconVector = Icons.Default.Close,
+        onClick = { onDelete(title) },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun LostAndFoundAddableKeywordChip(
+    title: String,
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LostAndFoundKeywordChip(
+        title = title,
+        backgroundColor = KoinTheme.colors.neutral100,
+        textColor = KoinTheme.colors.neutral500,
+        iconVector = Icons.Default.Add,
+        onClick = { onAdd(title) },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun LostAndFoundDeletableChipFlowGroup(
+    keywords: ImmutableList<String>,
+    onDelete: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedKeywordChipFlowGroup(
+        items = keywords,
+        modifier = modifier
+    ) { keyword ->
+        LostAndFoundDeletableKeywordChip(title = keyword, onDelete = onDelete)
+    }
+}
+
+@Composable
+fun LostAndFoundAddableChipFlowGroup(
+    keywords: ImmutableList<String>,
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AnimatedKeywordChipFlowGroup(
+        items = keywords,
+        modifier = modifier
+    ) { keyword ->
+        LostAndFoundAddableKeywordChip(title = keyword, onAdd = onAdd)
+    }
+}
+
+// Article 키워드 화면의 ChipGroup `android:animateLayoutChanges="true"` 와 동일한 Layout
+// Transition 타이밍을 재현한다.
+//  - APPEARING:           새 chip 페이드인 300ms (start delay 300ms — 형제 위치 이동 후 등장)
+//  - DISAPPEARING:        제거되는 chip 페이드아웃 300ms (start delay 0)
+//  - CHANGE_APPEARING:    형제 chip 위치 이동 300ms (start delay 0, 즉시)
+//  - CHANGE_DISAPPEARING: 형제 chip 위치 이동 300ms (start delay 300ms — 페이드아웃 후 합치기)
+//
+// Exit fade 를 위해 [items] 에서 빠진 키워드도 fade-out 이 끝날 때까지 [displayedItems] 에
+// 남겨둔 뒤, 알파 애니메이션 종료 시점에 컴포지션에서 제거한다. 컴포지션 제거 직후 형제 chip 의
+// LookaheadScope 측정값이 변경되며 [Modifier.animateBounds] 가 위치 이동을 보간한다. 결과적으로
+// 형제 chip 의 위치 이동은 페이드아웃 종료 시점부터 시작되어 LayoutTransition 의 기본
+// CHANGE_DISAPPEARING delay (= 300ms) 와 동일하게 동작한다.
+@OptIn(ExperimentalLayoutApi::class, ExperimentalSharedTransitionApi::class)
+@Composable
+private fun AnimatedKeywordChipFlowGroup(
+    items: ImmutableList<String>,
+    modifier: Modifier = Modifier,
+    chip: @Composable (String) -> Unit
+) {
+    val displayedItems = remember { mutableStateListOf<String>() }
+    val visibility = remember { mutableStateMapOf<String, Boolean>() }
+
+    LaunchedEffect(items) {
+        // 아직 displayedItems 에 없는 키워드는 [items] 순서를 유지하도록 삽입한다.
+        // 단순 append 는 한 번 fade-out 후 사라졌다 되돌아올 때 원래 위치를 잃어버려
+        // 추천 키워드의 캐논 순서가 어긋나는 문제를 일으킨다.
+        items.forEachIndexed { itemIdx, key ->
+            if (key !in displayedItems) {
+                val insertAt = (itemIdx - 1 downTo 0)
+                    .asSequence()
+                    .map { displayedItems.indexOf(items[it]) }
+                    .firstOrNull { it >= 0 }
+                    ?.let { it + 1 }
+                    ?: 0
+                displayedItems.add(insertAt, key)
+            }
+            visibility[key] = true
+        }
+        displayedItems.toList().forEach { key ->
+            if (key !in items && visibility[key] != false) visibility[key] = false
+        }
+    }
+
+    LookaheadScope {
+        FlowRow(
+            modifier = modifier.animateContentSize(animationSpec = tween(durationMillis = 300)),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            displayedItems.forEach { keyword ->
+                key(keyword) {
+                    var hasStartedEntry by remember { mutableStateOf(false) }
+                    LaunchedEffect(Unit) { hasStartedEntry = true }
+                    val isVisible = visibility[keyword] ?: true
+                    val targetAlpha = if (hasStartedEntry && isVisible) 1f else 0f
+                    val alphaSpec = if (isVisible) {
+                        tween<Float>(durationMillis = 300, delayMillis = 300)
+                    } else {
+                        tween<Float>(durationMillis = 300)
+                    }
+                    val alpha by animateFloatAsState(
+                        targetValue = targetAlpha,
+                        animationSpec = alphaSpec,
+                        label = "keywordChipAlpha",
+                        finishedListener = { finalValue ->
+                            if (finalValue == 0f && visibility[keyword] == false) {
+                                displayedItems.remove(keyword)
+                                visibility.remove(keyword)
+                            }
+                        }
+                    )
+                    Box(
+                        modifier = Modifier
+                            .animateBounds(
+                                lookaheadScope = this@LookaheadScope,
+                                boundsTransform = { _, _ -> tween(durationMillis = 300) }
+                            )
+                            .graphicsLayer { this.alpha = alpha }
+                    ) {
+                        chip(keyword)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/LostAndFoundNavType.kt
@@ -7,6 +7,11 @@ sealed class LostAndFoundNavType {
     data object LostAndFoundListRoute : LostAndFoundNavType()
 
     @Serializable
+    data class LostAndFoundKeywordRoute(
+        val initialKeywordsCsv: String = ""
+    ) : LostAndFoundNavType()
+
+    @Serializable
     data class LostAndFoundDetailRoute(val articleId: Int) : LostAndFoundNavType()
 
     @Serializable
@@ -23,3 +28,4 @@ const val ARTICLE_ID = "articleId"
 const val CHAT_ARTICLE_ID = "article_id"
 const val LOST_OR_FOUND_TYPE = "lostOrFoundType"
 const val CANCEL_REFRESH_LIST = "cancel_refresh_list"
+const val KEY_KEYWORD_LIST = "keyword_list"

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -6,7 +6,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -1,24 +1,26 @@
 package `in`.koreatech.koin.feature.lostandfound.navigation
 
-import android.widget.Toast
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.feature.lostandfound.DEEP_LINK_LOST_AND_FOUND_BASE
-import `in`.koreatech.koin.feature.lostandfound.R
 import `in`.koreatech.koin.feature.lostandfound.ui.detail.LostAndFoundDetail
+import `in`.koreatech.koin.feature.lostandfound.ui.keyword.LostAndFoundKeyword
 import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundList
+import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListViewModel
 import `in`.koreatech.koin.feature.lostandfound.ui.modify.LostAndFoundModify
 import `in`.koreatech.koin.feature.lostandfound.ui.report.LostAndFoundReport
 import `in`.koreatech.koin.feature.lostandfound.ui.write.LostAndFoundWriteArticle
+import kotlinx.collections.immutable.toPersistentList
 
 fun NavGraphBuilder.koinLostAndFoundGraph(
     navController: NavController,
@@ -34,6 +36,11 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             }
     }
 
+    val onBackPressedWithCancel = {
+        cancelRefreshList(true)
+        onBackPressed()
+    }
+
     val navigateToList = { cancelRefresh: Boolean ->
         cancelRefreshList(cancelRefresh)
         navController.navigate(LostAndFoundNavType.LostAndFoundListRoute) {
@@ -44,12 +51,9 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         }
     }
 
-    val onBackPressed = {
-        cancelRefreshList(true)
-        onBackPressed()
-    }
-
     composable<LostAndFoundNavType.LostAndFoundListRoute> { backStackEntry ->
+        // hiltViewModel()을 한 번만 호출하여 LostAndFoundList에 명시적으로 전달
+        val listViewModel: LostAndFoundListViewModel = hiltViewModel()
         var isCancelRefresh by remember { mutableStateOf(false) }
 
         LaunchedEffect(Unit) {
@@ -58,10 +62,23 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             }
             backStackEntry.savedStateHandle.remove<Boolean>(CANCEL_REFRESH_LIST)
         }
+
+        // 키워드 화면에서 복귀 시 전달된 키워드 목록을 수신
+        LaunchedEffect(backStackEntry) {
+            backStackEntry.savedStateHandle
+                .getStateFlow<ArrayList<String>?>(KEY_KEYWORD_LIST, null)
+                .collect { keywords ->
+                    if (keywords != null) {
+                        listViewModel.updateKeywordsFromKeywordScreen(keywords.toPersistentList())
+                        backStackEntry.savedStateHandle.remove<ArrayList<String>>(KEY_KEYWORD_LIST)
+                    }
+                }
+        }
         val navigator = rememberNavigator()
         val context = LocalContext.current
         LostAndFoundList(
             cancelRefresh = isCancelRefresh,
+            viewModel = listViewModel,
             onTopbarBackClick = onBackPressed,
             navigateArticleDetail = { articleId ->
                 navController.navigate(LostAndFoundNavType.LostAndFoundDetailRoute(articleId))
@@ -77,12 +94,12 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             navigateToWrite = { typeName ->
                 navController.navigate(LostAndFoundNavType.LostAndFoundWriteRoute(typeName))
             },
-            navigateToKeywordSetting = {
-                Toast.makeText(
-                    context,
-                    R.string.keyword_setting_coming_soon,
-                    Toast.LENGTH_SHORT
-                ).show()
+            navigateToKeywordSetting = { keywords ->
+                navController.navigate(
+                    LostAndFoundNavType.LostAndFoundKeywordRoute(
+                        initialKeywordsCsv = keywords.joinToString("\u0001")
+                    )
+                )
             }
         )
     }
@@ -92,7 +109,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val context = LocalContext.current
         LostAndFoundDetail(
             navigateToArticleList = navigateToList,
-            onTopbarBackClick = onBackPressed,
+            onTopbarBackClick = onBackPressedWithCancel,
             refreshList = { cancelRefreshList(false) },
             navigateToChatRoom = { articleId ->
                 val intent = navigator.navigateToChatRoom(context)
@@ -120,27 +137,43 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     }
 
     composable<LostAndFoundNavType.LostAndFoundReportRoute> { backStackEntry ->
-        val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundDetailRoute>()
+        val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundReportRoute>()
         LostAndFoundReport(
             articleId = route.articleId,
-            onTopbarBackClick = onBackPressed,
+            onTopbarBackClick = onBackPressedWithCancel,
             onSuccess = { navigateToList(false) }
         )
     }
 
     composable<LostAndFoundNavType.LostAndFoundWriteRoute> {
         LostAndFoundWriteArticle(
-            onBackClick = onBackPressed,
+            onBackClick = onBackPressedWithCancel,
             onComplete = { navigateToList(false) }
         )
     }
 
     composable<LostAndFoundNavType.LostAndFoundModifyRoute> {
         LostAndFoundModify(
-            onBackClick = onBackPressed,
+            onBackClick = onBackPressedWithCancel,
             onComplete = { articleId ->
                 navigateToList(false)
                 navController.navigate(LostAndFoundNavType.LostAndFoundDetailRoute(articleId))
+            }
+        )
+    }
+
+    composable<LostAndFoundNavType.LostAndFoundKeywordRoute> {
+        LostAndFoundKeyword(
+            viewModel = hiltViewModel(),
+            onBackClick = { keywords ->
+                // previousBackStackEntry는 진짜 NavBackStackEntry?(nullable) → 안전한 ?.
+                navController.previousBackStackEntry
+                    ?.savedStateHandle
+                    ?.set(KEY_KEYWORD_LIST, ArrayList(keywords))
+                // 의도적으로 공용 onBackPressed 미사용:
+                // 공용 onBackPressed는 cancelRefreshList(true) → getBackStackEntry(ListRoute)를 호출하며,
+                // getBackStackEntry()는 비nullable이므로 deep-link 직접 진입 시 IllegalArgumentException 발생.
+                navController.popBackStack()
             }
         )
     }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -48,8 +48,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
@@ -66,8 +67,8 @@ private val ButtonShape = RoundedCornerShape(4.dp)
 
 @Composable
 fun LostAndFoundKeyword(
-    modifier: Modifier = Modifier,
     onBackClick: (keywords: ImmutableList<String>) -> Unit,
+    modifier: Modifier = Modifier,
     viewModel: LostAndFoundKeywordViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -406,7 +407,7 @@ private fun KoinKeywordSwitch(checked: Boolean) {
     ) {
         Box(
             modifier = Modifier
-                .offset(x = thumbOffsetX)
+                .offset { IntOffset(thumbOffsetX.roundToPx(), 0) }
                 .size(24.dp)
                 .clip(CircleShape)
                 .border(width = 3.dp, color = thumbRing, shape = CircleShape)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -117,6 +117,7 @@ private fun LostAndFoundKeywordContent(
 ) {
     Scaffold(
         modifier = modifier,
+        containerColor = KoinTheme.colors.neutral0,
         topBar = {
             KoinTopAppBar(
                 title = stringResource(R.string.lost_and_found_keyword_management),

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -1,0 +1,319 @@
+package `in`.koreatech.koin.feature.lostandfound.ui.keyword
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.toggleable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
+import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.feature.lostandfound.R
+import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundAddableChipFlowGroup
+import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundDeletableChipFlowGroup
+import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListSideEffect
+import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListState
+import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListViewModel
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
+
+@Composable
+fun LostAndFoundKeyword(
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Unit,
+    viewModel: LostAndFoundListViewModel
+) {
+    BackHandler(onBack = onBackClick)
+
+    val uiState by viewModel.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is LostAndFoundListSideEffect.ShowSnackbar -> {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(context.getString(sideEffect.messageResId))
+                }
+            }
+            LostAndFoundListSideEffect.FetchData -> { /* 목록 화면 전용 */ }
+            is LostAndFoundListSideEffect.UpdateSignInDialog -> { /* 목록 화면 전용 */ }
+        }
+    }
+
+    LostAndFoundKeywordContent(
+        modifier = modifier,
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        onBackClick = onBackClick,
+        onKeywordInputChanged = viewModel::onKeywordInputChanged,
+        onAddKeyword = viewModel::addKeyword,
+        onDeleteKeyword = viewModel::deleteKeyword,
+        onAddSuggestedKeyword = viewModel::addSuggestedKeyword,
+        onToggleNotification = viewModel::toggleNotification,
+        suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
+    )
+}
+
+@Composable
+private fun LostAndFoundKeywordContent(
+    modifier: Modifier = Modifier,
+    uiState: LostAndFoundListState,
+    snackbarHostState: SnackbarHostState,
+    onBackClick: () -> Unit,
+    onKeywordInputChanged: (String) -> Unit,
+    onAddKeyword: (String) -> Unit,
+    onDeleteKeyword: (String) -> Unit,
+    onAddSuggestedKeyword: (String) -> Unit,
+    onToggleNotification: () -> Unit,
+    suggestedKeywords: ImmutableList<String>
+) {
+    val focusManager = LocalFocusManager.current
+    val buttonShape = remember { androidx.compose.foundation.shape.RoundedCornerShape(8.dp) }
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            KoinTopAppBar(
+                title = stringResource(R.string.lost_and_found_keyword_management),
+                onNavigationIconClick = onBackClick
+            )
+        },
+        snackbarHost = {
+            SnackbarHost(snackbarHostState)
+        }
+    ) { contentPadding ->
+        Column(
+            modifier = Modifier
+                .padding(contentPadding)
+                .verticalScroll(rememberScrollState())
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 24.dp)
+            ) {
+                // 내 키워드 섹션
+                Spacer(modifier = Modifier.height(16.dp))
+
+                Text(
+                    text = stringResource(R.string.lost_and_found_my_keyword_count, uiState.keywords.size),
+                    style = KoinTheme.typography.bold16,
+                    color = KoinTheme.colors.neutral800
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = stringResource(R.string.keyword_notice_description),
+                    style = KoinTheme.typography.medium14,
+                    color = KoinTheme.colors.neutral600
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 키워드 입력 필드
+                OutlinedTextField(
+                    modifier = Modifier.fillMaxWidth(),
+                    value = uiState.keywordInput,
+                    onValueChange = onKeywordInputChanged,
+                    placeholder = {
+                        Text(
+                            text = stringResource(R.string.lost_and_found_keyword_input_hint),
+                            style = KoinTheme.typography.medium14,
+                            color = KoinTheme.colors.neutral400
+                        )
+                    },
+                    shape = buttonShape,
+                    textStyle = KoinTheme.typography.medium14,
+                    singleLine = true,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                    keyboardActions = KeyboardActions(
+                        onDone = {
+                            if (uiState.keywordInput.isNotBlank()) {
+                                onAddKeyword(uiState.keywordInput)
+                            }
+                            focusManager.clearFocus()
+                        }
+                    )
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // 추가 버튼
+                val isAddButtonEnabled = uiState.keywordInput.isNotBlank()
+                Button(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(48.dp),
+                    onClick = {
+                        onAddKeyword(uiState.keywordInput)
+                        focusManager.clearFocus()
+                    },
+                    enabled = isAddButtonEnabled,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = KoinTheme.colors.primary500,
+                        contentColor = KoinTheme.colors.neutral0,
+                        disabledContainerColor = KoinTheme.colors.neutral100,
+                        disabledContentColor = KoinTheme.colors.neutral500
+                    ),
+                    shape = buttonShape
+                ) {
+                    Text(
+                        text = stringResource(R.string.add_keyword),
+                        style = KoinTheme.typography.bold14
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // 등록된 키워드 칩
+                if (uiState.keywords.isNotEmpty()) {
+                    LostAndFoundDeletableChipFlowGroup(
+                        keywords = uiState.keywords,
+                        onDelete = onDeleteKeyword
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+
+                // 추천 키워드 섹션
+                Text(
+                    text = stringResource(R.string.suggestion_keywords),
+                    style = KoinTheme.typography.bold16,
+                    color = KoinTheme.colors.neutral800
+                )
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                LostAndFoundAddableChipFlowGroup(
+                    keywords = suggestedKeywords,
+                    onAdd = onAddSuggestedKeyword
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+
+            // Divider
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                color = KoinTheme.colors.neutral200,
+                thickness = 1.dp
+            )
+
+            Column(
+                modifier = Modifier.padding(horizontal = 24.dp)
+            ) {
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 키워드 알림 섹션
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .toggleable(
+                            value = uiState.isNotificationEnabled,
+                            role = Role.Switch,
+                            onValueChange = { onToggleNotification() }
+                        ),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.keyword_notification),
+                            style = KoinTheme.typography.bold16,
+                            color = KoinTheme.colors.neutral800
+                        )
+
+                        Spacer(modifier = Modifier.height(8.dp))
+
+                        Text(
+                            text = stringResource(R.string.lost_and_found_keyword_notification_description),
+                            style = KoinTheme.typography.medium12,
+                            color = KoinTheme.colors.neutral600
+                        )
+                    }
+
+                    Switch(
+                        checked = uiState.isNotificationEnabled,
+                        onCheckedChange = null
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+        }
+    }
+}
+
+@Preview(name = "키워드 없음", showBackground = true)
+@Composable
+private fun LostAndFoundKeywordContentEmptyPreview() {
+    KoinTheme {
+        LostAndFoundKeywordContent(
+            uiState = LostAndFoundListState(),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBackClick = {},
+            onKeywordInputChanged = {},
+            onAddKeyword = {},
+            onDeleteKeyword = {},
+            onAddSuggestedKeyword = {},
+            onToggleNotification = {},
+            suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
+        )
+    }
+}
+
+@Preview(name = "키워드 있음", showBackground = true)
+@Composable
+private fun LostAndFoundKeywordContentWithKeywordsPreview() {
+    KoinTheme {
+        LostAndFoundKeywordContent(
+            uiState = LostAndFoundListState(
+                keywords = persistentListOf("지갑", "학생증", "에어팟", "태블릿"),
+                isNotificationEnabled = true
+            ),
+            snackbarHostState = remember { SnackbarHostState() },
+            onBackClick = {},
+            onKeywordInputChanged = {},
+            onAddKeyword = {},
+            onDeleteKeyword = {},
+            onAddSuggestedKeyword = {},
+            onToggleNotification = {},
+            suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
+        )
+    }
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -1,27 +1,35 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.keyword
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.foundation.toggleable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -29,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
@@ -36,75 +45,76 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundAddableChipFlowGroup
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundDeletableChipFlowGroup
-import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListSideEffect
-import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListState
-import `in`.koreatech.koin.feature.lostandfound.ui.list.LostAndFoundListViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
+private val ButtonShape = RoundedCornerShape(4.dp)
+
 @Composable
 fun LostAndFoundKeyword(
     modifier: Modifier = Modifier,
-    onBackClick: () -> Unit,
-    viewModel: LostAndFoundListViewModel
+    onBackClick: (keywords: ImmutableList<String>) -> Unit,
+    viewModel: LostAndFoundKeywordViewModel = hiltViewModel()
 ) {
-    BackHandler(onBack = onBackClick)
-
     val uiState by viewModel.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
 
+    val keywords = uiState.keywords
+
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is LostAndFoundListSideEffect.ShowSnackbar -> {
+            is LostAndFoundKeywordSideEffect.ShowSnackbar -> {
                 coroutineScope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(context.getString(sideEffect.messageResId))
                 }
             }
-            LostAndFoundListSideEffect.FetchData -> { /* 목록 화면 전용 */ }
-            is LostAndFoundListSideEffect.UpdateSignInDialog -> { /* 목록 화면 전용 */ }
         }
+    }
+
+    BackHandler {
+        onBackClick(keywords)
     }
 
     LostAndFoundKeywordContent(
         modifier = modifier,
         uiState = uiState,
         snackbarHostState = snackbarHostState,
-        onBackClick = onBackClick,
+        onBackClick = { onBackClick(keywords) },
         onKeywordInputChanged = viewModel::onKeywordInputChanged,
         onAddKeyword = viewModel::addKeyword,
         onDeleteKeyword = viewModel::deleteKeyword,
         onAddSuggestedKeyword = viewModel::addSuggestedKeyword,
         onToggleNotification = viewModel::toggleNotification,
-        suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
+        suggestedKeywords = LostAndFoundKeywordViewModel.SUGGESTED_KEYWORDS
     )
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun LostAndFoundKeywordContent(
     modifier: Modifier = Modifier,
-    uiState: LostAndFoundListState,
+    uiState: LostAndFoundKeywordState,
     snackbarHostState: SnackbarHostState,
     onBackClick: () -> Unit,
     onKeywordInputChanged: (String) -> Unit,
     onAddKeyword: (String) -> Unit,
     onDeleteKeyword: (String) -> Unit,
     onAddSuggestedKeyword: (String) -> Unit,
-    onToggleNotification: () -> Unit,
+    onToggleNotification: (Boolean) -> Unit,
     suggestedKeywords: ImmutableList<String>
 ) {
-    val focusManager = LocalFocusManager.current
-    val buttonShape = remember { androidx.compose.foundation.shape.RoundedCornerShape(8.dp) }
-
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -122,198 +132,290 @@ private fun LostAndFoundKeywordContent(
                 .padding(contentPadding)
                 .verticalScroll(rememberScrollState())
         ) {
-            Column(
-                modifier = Modifier.padding(horizontal = 24.dp)
-            ) {
-                // 내 키워드 섹션
-                Spacer(modifier = Modifier.height(16.dp))
-
-                Text(
-                    text = stringResource(R.string.lost_and_found_my_keyword_count, uiState.keywords.size),
-                    style = KoinTheme.typography.bold16,
-                    color = KoinTheme.colors.neutral800
-                )
-
-                Spacer(modifier = Modifier.height(8.dp))
-
-                Text(
-                    text = stringResource(R.string.keyword_notice_description),
-                    style = KoinTheme.typography.medium14,
-                    color = KoinTheme.colors.neutral600
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                // 키워드 입력 필드
-                OutlinedTextField(
-                    modifier = Modifier.fillMaxWidth(),
-                    value = uiState.keywordInput,
-                    onValueChange = onKeywordInputChanged,
-                    placeholder = {
-                        Text(
-                            text = stringResource(R.string.lost_and_found_keyword_input_hint),
-                            style = KoinTheme.typography.medium14,
-                            color = KoinTheme.colors.neutral400
-                        )
-                    },
-                    shape = buttonShape,
-                    textStyle = KoinTheme.typography.medium14,
-                    singleLine = true,
-                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                    keyboardActions = KeyboardActions(
-                        onDone = {
-                            if (uiState.keywordInput.isNotBlank()) {
-                                onAddKeyword(uiState.keywordInput)
-                            }
-                            focusManager.clearFocus()
-                        }
-                    )
-                )
-
-                Spacer(modifier = Modifier.height(12.dp))
-
-                // 추가 버튼
-                val isAddButtonEnabled = uiState.keywordInput.isNotBlank()
-                Button(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(48.dp),
-                    onClick = {
-                        onAddKeyword(uiState.keywordInput)
-                        focusManager.clearFocus()
-                    },
-                    enabled = isAddButtonEnabled,
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = KoinTheme.colors.primary500,
-                        contentColor = KoinTheme.colors.neutral0,
-                        disabledContainerColor = KoinTheme.colors.neutral100,
-                        disabledContentColor = KoinTheme.colors.neutral500
-                    ),
-                    shape = buttonShape
-                ) {
-                    Text(
-                        text = stringResource(R.string.add_keyword),
-                        style = KoinTheme.typography.bold14
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(24.dp))
-
-                // 등록된 키워드 칩
-                if (uiState.keywords.isNotEmpty()) {
-                    LostAndFoundDeletableChipFlowGroup(
-                        keywords = uiState.keywords,
-                        onDelete = onDeleteKeyword
-                    )
-
-                    Spacer(modifier = Modifier.height(24.dp))
-                }
-
-                // 추천 키워드 섹션
-                Text(
-                    text = stringResource(R.string.suggestion_keywords),
-                    style = KoinTheme.typography.bold16,
-                    color = KoinTheme.colors.neutral800
-                )
-
-                Spacer(modifier = Modifier.height(16.dp))
-
-                LostAndFoundAddableChipFlowGroup(
-                    keywords = suggestedKeywords,
-                    onAdd = onAddSuggestedKeyword
-                )
-
-                Spacer(modifier = Modifier.height(24.dp))
-            }
-
-            // Divider
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(),
-                color = KoinTheme.colors.neutral200,
-                thickness = 1.dp
+            MyKeywordSection(
+                keywords = uiState.keywords,
+                keywordInput = uiState.keywordInput,
+                onKeywordInputChanged = onKeywordInputChanged,
+                onAddKeyword = onAddKeyword,
+                onDeleteKeyword = onDeleteKeyword,
+                modifier = Modifier.fillMaxWidth()
             )
 
-            Column(
-                modifier = Modifier.padding(horizontal = 24.dp)
-            ) {
-                Spacer(modifier = Modifier.height(16.dp))
+            SuggestedKeywordSection(
+                suggestedKeywords = suggestedKeywords,
+                onAdd = onAddSuggestedKeyword,
+                modifier = Modifier.fillMaxWidth()
+            )
 
-                // 키워드 알림 섹션
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .toggleable(
-                            value = uiState.isNotificationEnabled,
-                            role = Role.Switch,
-                            onValueChange = { onToggleNotification() }
-                        ),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.keyword_notification),
-                            style = KoinTheme.typography.bold16,
-                            color = KoinTheme.colors.neutral800
-                        )
+            // Section divider (Figma: 6dp neutral100)
+            HorizontalDivider(
+                modifier = Modifier.fillMaxWidth(),
+                color = KoinTheme.colors.neutral100,
+                thickness = 6.dp
+            )
 
-                        Spacer(modifier = Modifier.height(8.dp))
+            KeywordNotificationSection(
+                isEnabled = uiState.isNotificationEnabled,
+                onToggle = onToggleNotification,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}
 
-                        Text(
-                            text = stringResource(R.string.lost_and_found_keyword_notification_description),
-                            style = KoinTheme.typography.medium12,
-                            color = KoinTheme.colors.neutral600
-                        )
-                    }
+@Composable
+private fun MyKeywordSection(
+    keywords: ImmutableList<String>,
+    keywordInput: String,
+    onKeywordInputChanged: (String) -> Unit,
+    onAddKeyword: (String) -> Unit,
+    onDeleteKeyword: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val focusManager = LocalFocusManager.current
 
-                    Switch(
-                        checked = uiState.isNotificationEnabled,
-                        onCheckedChange = null
+    Column(
+        modifier = modifier.padding(horizontal = 24.dp)
+    ) {
+        // 내 키워드 섹션 (Figma 51322:186002, SemiBold 18 + Regular 14 supplementary)
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(R.string.lost_and_found_my_keyword_count, keywords.size),
+            style = KoinTheme.typography.bold18,
+            color = KoinTheme.colors.neutral800
+        )
+
+        Spacer(modifier = Modifier.height(2.dp))
+
+        Text(
+            text = stringResource(R.string.keyword_notice_description),
+            style = KoinTheme.typography.medium12,
+            color = KoinTheme.colors.neutral500
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        // 키워드 입력 + 추가 버튼 (수평 배치, Figma 51322:185997)
+        val isAddButtonEnabled = keywordInput.isNotBlank()
+        val interactionSource = remember { MutableInteractionSource() }
+        val isFocused by interactionSource.collectIsFocusedAsState()
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            BasicTextField(
+                modifier = Modifier
+                    .weight(1f)
+                    .heightIn(min = 38.dp)
+                    .background(KoinTheme.colors.neutral100, ButtonShape)
+                    .border(
+                        width = 1.dp,
+                        color = if (isFocused) KoinTheme.colors.primary400 else KoinTheme.colors.neutral100,
+                        shape = ButtonShape
                     )
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                value = keywordInput,
+                onValueChange = onKeywordInputChanged,
+                textStyle = KoinTheme.typography.medium14.copy(color = KoinTheme.colors.neutral800),
+                singleLine = true,
+                cursorBrush = SolidColor(KoinTheme.colors.primary400),
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        if (keywordInput.isNotBlank()) {
+                            onAddKeyword(keywordInput)
+                        }
+                        focusManager.clearFocus()
+                    }
+                ),
+                interactionSource = interactionSource,
+                decorationBox = { innerTextField ->
+                    Box(contentAlignment = Alignment.CenterStart) {
+                        if (keywordInput.isEmpty()) {
+                            Text(
+                                text = stringResource(R.string.lost_and_found_keyword_input_hint),
+                                style = KoinTheme.typography.medium14,
+                                color = KoinTheme.colors.neutral500
+                            )
+                        }
+                        innerTextField()
+                    }
                 }
+            )
 
-                Spacer(modifier = Modifier.height(24.dp))
+            Button(
+                modifier = Modifier.height(38.dp),
+                onClick = {
+                    onAddKeyword(keywordInput)
+                    focusManager.clearFocus()
+                },
+                enabled = isAddButtonEnabled,
+                contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = KoinTheme.colors.primary500,
+                    contentColor = KoinTheme.colors.neutral0,
+                    disabledContainerColor = KoinTheme.colors.neutral100,
+                    disabledContentColor = KoinTheme.colors.neutral500
+                ),
+                shape = ButtonShape
+            ) {
+                Text(
+                    text = stringResource(R.string.add_keyword),
+                    style = KoinTheme.typography.medium13
+                )
             }
         }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        // 등록된 키워드 칩
+        if (keywords.isNotEmpty()) {
+            LostAndFoundDeletableChipFlowGroup(
+                keywords = keywords,
+                onDelete = onDeleteKeyword
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun SuggestedKeywordSection(
+    suggestedKeywords: ImmutableList<String>,
+    onAdd: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+    ) {
+        // 추천 키워드 섹션 (Figma 51322:186023, Medium 16)
+        Text(
+            text = stringResource(R.string.suggestion_keywords),
+            style = KoinTheme.typography.medium16,
+            color = KoinTheme.colors.neutral800
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        LostAndFoundAddableChipFlowGroup(
+            keywords = suggestedKeywords,
+            onAdd = onAdd
+        )
+    }
+}
+
+@Composable
+private fun KeywordNotificationSection(
+    isEnabled: Boolean,
+    onToggle: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        // "키워드 알림" 섹션 헤더 (Figma 51322:186042)
+        Text(
+            text = stringResource(R.string.lost_and_found_keyword_notification_section_title),
+            style = KoinTheme.typography.bold18,
+            color = KoinTheme.colors.neutral800,
+            modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+        )
+
+        // 알림 토글 행 (Figma 51322:186044: 양 끝 정렬, 24x/16y padding, bottom border)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .toggleable(
+                    value = isEnabled,
+                    role = Role.Switch,
+                    onValueChange = onToggle
+                )
+                .padding(horizontal = 24.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = stringResource(R.string.lost_and_found_keyword_notification_title),
+                    style = KoinTheme.typography.medium16,
+                    color = KoinTheme.colors.neutral800
+                )
+
+                Spacer(modifier = Modifier.height(2.dp))
+
+                Text(
+                    text = stringResource(R.string.lost_and_found_keyword_notification_description),
+                    style = KoinTheme.typography.medium12,
+                    color = KoinTheme.colors.neutral500
+                )
+            }
+
+            Switch(
+                checked = isEnabled,
+                onCheckedChange = null,
+                colors = SwitchDefaults.colors(
+                    checkedThumbColor = KoinTheme.colors.neutral0,
+                    checkedTrackColor = KoinTheme.colors.primary500,
+                    uncheckedThumbColor = KoinTheme.colors.neutral0,
+                    uncheckedTrackColor = KoinTheme.colors.neutral300
+                )
+            )
+        }
+
+        HorizontalDivider(
+            modifier = Modifier.fillMaxWidth(),
+            color = KoinTheme.colors.neutral100,
+            thickness = 1.dp
+        )
+    }
+}
+
+@Composable
+private fun PreviewLostAndFoundKeywordContent(
+    uiState: LostAndFoundKeywordState
+) {
+    KoinTheme {
+        LostAndFoundKeywordContent(
+            uiState = uiState,
+            snackbarHostState = remember { SnackbarHostState() },
+            onBackClick = {},
+            onKeywordInputChanged = {},
+            onAddKeyword = {},
+            onDeleteKeyword = {},
+            onAddSuggestedKeyword = {},
+            onToggleNotification = {},
+            suggestedKeywords = LostAndFoundKeywordViewModel.SUGGESTED_KEYWORDS
+        )
     }
 }
 
 @Preview(name = "키워드 없음", showBackground = true)
 @Composable
 private fun LostAndFoundKeywordContentEmptyPreview() {
-    KoinTheme {
-        LostAndFoundKeywordContent(
-            uiState = LostAndFoundListState(),
-            snackbarHostState = remember { SnackbarHostState() },
-            onBackClick = {},
-            onKeywordInputChanged = {},
-            onAddKeyword = {},
-            onDeleteKeyword = {},
-            onAddSuggestedKeyword = {},
-            onToggleNotification = {},
-            suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
-        )
-    }
+    PreviewLostAndFoundKeywordContent(LostAndFoundKeywordState())
 }
 
 @Preview(name = "키워드 있음", showBackground = true)
 @Composable
 private fun LostAndFoundKeywordContentWithKeywordsPreview() {
-    KoinTheme {
-        LostAndFoundKeywordContent(
-            uiState = LostAndFoundListState(
-                keywords = persistentListOf("지갑", "학생증", "에어팟", "태블릿"),
-                isNotificationEnabled = true
-            ),
-            snackbarHostState = remember { SnackbarHostState() },
-            onBackClick = {},
-            onKeywordInputChanged = {},
-            onAddKeyword = {},
-            onDeleteKeyword = {},
-            onAddSuggestedKeyword = {},
-            onToggleNotification = {},
-            suggestedKeywords = LostAndFoundListViewModel.SUGGESTED_KEYWORDS
+    PreviewLostAndFoundKeywordContent(
+        LostAndFoundKeywordState(
+            keywords = persistentListOf("지갑", "학생증", "에어팟", "태블릿"),
+            isNotificationEnabled = true
         )
-    }
+    )
+}
+
+@Preview(name = "입력 활성화", showBackground = true)
+@Composable
+private fun LostAndFoundKeywordContentInputActivePreview() {
+    PreviewLostAndFoundKeywordContent(
+        LostAndFoundKeywordState(
+            keywordInput = "아이패드",
+            keywords = persistentListOf("지갑")
+        )
+    )
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -181,11 +181,21 @@ private fun MyKeywordSection(
         // 내 키워드 섹션 (Figma 51322:186002, SemiBold 18 + Regular 14 supplementary)
         Spacer(modifier = Modifier.height(8.dp))
 
-        Text(
-            text = stringResource(R.string.lost_and_found_my_keyword_count, keywords.size),
-            style = KoinTheme.typography.bold18,
-            color = KoinTheme.colors.neutral800
-        )
+        Row(
+            verticalAlignment = Alignment.Bottom,
+            horizontalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.lost_and_found_my_keyword_label),
+                style = KoinTheme.typography.bold18,
+                color = KoinTheme.colors.neutral800
+            )
+            Text(
+                text = stringResource(R.string.lost_and_found_my_keyword_count, keywords.size),
+                style = KoinTheme.typography.regular14,
+                color = KoinTheme.colors.neutral500
+            )
+        }
 
         Spacer(modifier = Modifier.height(2.dp))
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -1,6 +1,7 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.keyword
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -14,9 +15,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
@@ -28,8 +32,6 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -37,6 +39,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
@@ -53,6 +57,7 @@ import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundAddableChi
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundDeletableChipFlowGroup
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -87,6 +92,10 @@ fun LostAndFoundKeyword(
         onBackClick(keywords)
     }
 
+    // Article keyword 화면처럼, 이미 등록된 키워드는 추천 키워드에서 제거
+    val availableSuggestions = remember(keywords) {
+        (LostAndFoundKeywordViewModel.SUGGESTED_KEYWORDS - keywords.toSet()).toPersistentList()
+    }
     LostAndFoundKeywordContent(
         modifier = modifier,
         uiState = uiState,
@@ -97,7 +106,7 @@ fun LostAndFoundKeyword(
         onDeleteKeyword = viewModel::deleteKeyword,
         onAddSuggestedKeyword = viewModel::addSuggestedKeyword,
         onToggleNotification = viewModel::toggleNotification,
-        suggestedKeywords = LostAndFoundKeywordViewModel.SUGGESTED_KEYWORDS
+        suggestedKeywords = availableSuggestions
     )
 }
 
@@ -364,16 +373,7 @@ private fun KeywordNotificationSection(
                 )
             }
 
-            Switch(
-                checked = isEnabled,
-                onCheckedChange = null,
-                colors = SwitchDefaults.colors(
-                    checkedThumbColor = KoinTheme.colors.neutral0,
-                    checkedTrackColor = KoinTheme.colors.primary500,
-                    uncheckedThumbColor = KoinTheme.colors.neutral0,
-                    uncheckedTrackColor = KoinTheme.colors.neutral300
-                )
-            )
+            KoinKeywordSwitch(checked = isEnabled)
         }
 
         HorizontalDivider(
@@ -383,6 +383,40 @@ private fun KeywordNotificationSection(
         )
     }
 }
+
+/**
+ * Mirrors the article keyword screen's SwitchCompat style:
+ * - Track 52x24dp, 50dp radius (gray3 OFF / primary500 ON)
+ * - Thumb 24x24dp circle with 3dp ring (gray10 fill + gray3 ring OFF / white fill + primary500 ring ON)
+ */
+@Composable
+private fun KoinKeywordSwitch(checked: Boolean) {
+    val trackColor = if (checked) KoinTheme.colors.primary500 else KeywordSwitchTrackOff
+    val thumbFill = if (checked) KoinTheme.colors.neutral0 else KeywordSwitchThumbOffFill
+    val thumbRing = if (checked) KoinTheme.colors.primary500 else KeywordSwitchTrackOff
+    val thumbOffsetX by animateDpAsState(
+        targetValue = if (checked) 28.dp else 0.dp,
+        label = "thumbOffsetX"
+    )
+    Box(
+        modifier = Modifier
+            .size(width = 52.dp, height = 24.dp)
+            .clip(RoundedCornerShape(50))
+            .background(trackColor)
+    ) {
+        Box(
+            modifier = Modifier
+                .offset(x = thumbOffsetX)
+                .size(24.dp)
+                .clip(CircleShape)
+                .border(width = 3.dp, color = thumbRing, shape = CircleShape)
+                .background(thumbFill, CircleShape)
+        )
+    }
+}
+
+private val KeywordSwitchTrackOff = Color(0xFFE3E3E3)
+private val KeywordSwitchThumbOffFill = Color(0xFF828282)
 
 @Composable
 private fun PreviewLostAndFoundKeywordContent(

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordSideEffect.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordSideEffect.kt
@@ -1,0 +1,7 @@
+package `in`.koreatech.koin.feature.lostandfound.ui.keyword
+
+import androidx.annotation.StringRes
+
+sealed class LostAndFoundKeywordSideEffect {
+    data class ShowSnackbar(@StringRes val messageResId: Int) : LostAndFoundKeywordSideEffect()
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
@@ -1,13 +1,10 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.keyword
 
-import android.os.Parcelable
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.parcelize.Parcelize
 
-@Parcelize
 data class LostAndFoundKeywordState(
-    val keywords: ImmutableList<String> = persistentListOf(),
+    val keywords: PersistentList<String> = persistentListOf(),
     val keywordInput: String = "",
     val isNotificationEnabled: Boolean = false
-) : Parcelable
+)

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.feature.lostandfound.ui.keyword
+
+import android.os.Parcelable
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class LostAndFoundKeywordState(
+    val keywords: ImmutableList<String> = persistentListOf(),
+    val keywordInput: String = "",
+    val isNotificationEnabled: Boolean = false
+) : Parcelable

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
@@ -1,10 +1,12 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.keyword
 
-import kotlinx.collections.immutable.PersistentList
+import androidx.compose.runtime.Immutable
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
+@Immutable
 data class LostAndFoundKeywordState(
-    val keywords: PersistentList<String> = persistentListOf(),
+    val keywords: ImmutableList<String> = persistentListOf(),
     val keywordInput: String = "",
     val isNotificationEnabled: Boolean = false
 )

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
@@ -1,12 +1,16 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.keyword
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.feature.lostandfound.R
+import `in`.koreatech.koin.feature.lostandfound.navigation.LostAndFoundNavType
 import javax.inject.Inject
-import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
+import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -15,11 +19,23 @@ import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
-class LostAndFoundKeywordViewModel @Inject constructor() :
+class LostAndFoundKeywordViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) :
     ViewModel(),
     ContainerHost<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect> {
-    override val container = container<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect>(
-        initialState = LostAndFoundKeywordState()
+    override val container: Container<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect> = container(
+        initialState = LostAndFoundKeywordState(
+            keywords = try {
+                val route = savedStateHandle.toRoute<LostAndFoundNavType.LostAndFoundKeywordRoute>()
+                route.initialKeywordsCsv
+                    .split("\u0001")
+                    .filter { it.isNotEmpty() }
+                    .toPersistentList()
+            } catch (@Suppress("SwallowedException") e: IllegalArgumentException) {
+                persistentListOf()
+            }
+        )
     )
 
     fun onKeywordInputChanged(input: String) {
@@ -30,46 +46,44 @@ class LostAndFoundKeywordViewModel @Inject constructor() :
 
     fun addKeyword(keyword: String) {
         intent {
-            val trimmed = keyword.trim()
-            when {
-                trimmed.isEmpty() -> {
-                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_require_input))
-                    return@intent
-                }
-                trimmedKeywordRegex.containsMatchIn(trimmed) -> {
-                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_blank_not_allowed))
-                    return@intent
-                }
-                trimmed.length < MIN_KEYWORD_LENGTH || trimmed.length > MAX_KEYWORD_LENGTH -> {
-                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_invalid_length))
-                    return@intent
-                }
+            val validationError = validateKeyword(keyword)
+            if (validationError != null) {
+                postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(validationError))
+                return@intent
             }
 
-            when {
-                state.keywords.size >= MAX_KEYWORD_COUNT -> {
-                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_limit_exceeded))
-                }
-                state.keywords.contains(trimmed) -> {
-                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_already_exist))
-                }
-                else -> {
-                    reduce {
-                        state.copy(
-                            keywords = (state.keywords + trimmed).toPersistentList(),
-                            keywordInput = ""
-                        )
-                    }
+            val addError = checkAddability(state, keyword)
+            if (addError != null) {
+                postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(addError))
+            } else {
+                reduce {
+                    state.copy(
+                        keywords = state.keywords.add(keyword),
+                        keywordInput = ""
+                    )
                 }
             }
         }
+    }
+
+    private fun validateKeyword(keyword: String): Int? = when {
+        keyword.isEmpty() -> R.string.keyword_add_require_input
+        WHITESPACE_REGEX.containsMatchIn(keyword) -> R.string.keyword_add_blank_not_allowed
+        keyword.length < MIN_KEYWORD_LENGTH || keyword.length > MAX_KEYWORD_LENGTH -> R.string.keyword_add_invalid_length
+        else -> null
+    }
+
+    private fun checkAddability(currentState: LostAndFoundKeywordState, keyword: String): Int? = when {
+        currentState.keywords.contains(keyword) -> R.string.keyword_add_already_exist
+        currentState.keywords.size >= MAX_KEYWORD_COUNT -> R.string.keyword_add_limit_exceeded
+        else -> null
     }
 
     fun deleteKeyword(keyword: String) {
         intent {
             reduce {
                 state.copy(
-                    keywords = state.keywords.minus(keyword).toPersistentList()
+                    keywords = state.keywords.remove(keyword)
                 )
             }
         }
@@ -79,9 +93,9 @@ class LostAndFoundKeywordViewModel @Inject constructor() :
         addKeyword(keyword)
     }
 
-    fun toggleNotification() {
+    fun toggleNotification(isEnabled: Boolean) {
         intent {
-            reduce { state.copy(isNotificationEnabled = !state.isNotificationEnabled) }
+            reduce { state.copy(isNotificationEnabled = isEnabled) }
         }
     }
 
@@ -89,7 +103,7 @@ class LostAndFoundKeywordViewModel @Inject constructor() :
         private const val MAX_KEYWORD_COUNT = 10
         private const val MAX_KEYWORD_LENGTH = 20
         private const val MIN_KEYWORD_LENGTH = 2
-        private val trimmedKeywordRegex = Regex("""\s+""")
-        val SUGGESTED_KEYWORDS: ImmutableList<String> = persistentListOf("지갑", "카드", "학생증", "에어팟", "핸드폰")
+        private val WHITESPACE_REGEX = Regex("""\s""")
+        val SUGGESTED_KEYWORDS: PersistentList<String> = persistentListOf("지갑", "카드", "학생증", "에어팟", "핸드폰")
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
@@ -58,7 +58,7 @@ class LostAndFoundKeywordViewModel @Inject constructor(
             } else {
                 reduce {
                     state.copy(
-                        keywords = state.keywords.add(keyword),
+                        keywords = state.keywords.toPersistentList().add(keyword),
                         keywordInput = ""
                     )
                 }
@@ -83,7 +83,7 @@ class LostAndFoundKeywordViewModel @Inject constructor(
         intent {
             reduce {
                 state.copy(
-                    keywords = state.keywords.remove(keyword)
+                    keywords = state.keywords.toPersistentList().remove(keyword)
                 )
             }
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
@@ -1,0 +1,95 @@
+package `in`.koreatech.koin.feature.lostandfound.ui.keyword
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.feature.lostandfound.R
+import javax.inject.Inject
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+
+@HiltViewModel
+class LostAndFoundKeywordViewModel @Inject constructor() :
+    ViewModel(),
+    ContainerHost<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect> {
+    override val container = container<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect>(
+        initialState = LostAndFoundKeywordState()
+    )
+
+    fun onKeywordInputChanged(input: String) {
+        blockingIntent {
+            reduce { state.copy(keywordInput = input) }
+        }
+    }
+
+    fun addKeyword(keyword: String) {
+        intent {
+            val trimmed = keyword.trim()
+            when {
+                trimmed.isEmpty() -> {
+                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_require_input))
+                    return@intent
+                }
+                trimmedKeywordRegex.containsMatchIn(trimmed) -> {
+                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_blank_not_allowed))
+                    return@intent
+                }
+                trimmed.length < MIN_KEYWORD_LENGTH || trimmed.length > MAX_KEYWORD_LENGTH -> {
+                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_invalid_length))
+                    return@intent
+                }
+            }
+
+            when {
+                state.keywords.size >= MAX_KEYWORD_COUNT -> {
+                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_limit_exceeded))
+                }
+                state.keywords.contains(trimmed) -> {
+                    postSideEffect(LostAndFoundKeywordSideEffect.ShowSnackbar(R.string.keyword_add_already_exist))
+                }
+                else -> {
+                    reduce {
+                        state.copy(
+                            keywords = (state.keywords + trimmed).toPersistentList(),
+                            keywordInput = ""
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    fun deleteKeyword(keyword: String) {
+        intent {
+            reduce {
+                state.copy(
+                    keywords = state.keywords.minus(keyword).toPersistentList()
+                )
+            }
+        }
+    }
+
+    fun addSuggestedKeyword(keyword: String) {
+        addKeyword(keyword)
+    }
+
+    fun toggleNotification() {
+        intent {
+            reduce { state.copy(isNotificationEnabled = !state.isNotificationEnabled) }
+        }
+    }
+
+    companion object {
+        private const val MAX_KEYWORD_COUNT = 10
+        private const val MAX_KEYWORD_LENGTH = 20
+        private const val MIN_KEYWORD_LENGTH = 2
+        private val trimmedKeywordRegex = Regex("""\s+""")
+        val SUGGESTED_KEYWORDS: ImmutableList<String> = persistentListOf("지갑", "카드", "학생증", "에어팟", "핸드폰")
+    }
+}

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -53,7 +53,7 @@ fun LostAndFoundList(
     navigateToLogin: () -> Unit = {},
     navigateArticleDetail: (Int) -> Unit = {},
     navigateToWrite: (String) -> Unit = {},
-    navigateToKeywordSetting: () -> Unit = {}
+    navigateToKeywordSetting: (List<String>) -> Unit = {}
 ) {
     val uiState by viewModel.collectAsState()
 
@@ -201,7 +201,7 @@ fun LostAndFoundList(
                 keywords = uiState.keywords,
                 selectedKeywordIndex = uiState.selectedKeywordIndex,
                 onKeywordSelect = viewModel::selectKeyword,
-                onSettingClick = navigateToKeywordSetting
+                onSettingClick = { navigateToKeywordSetting(uiState.keywords) }
             )
             if (!uiState.isFirstPageLoading) {
                 if (uiState.searchedArticles.isEmpty()) {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundListViewModel.kt
@@ -15,11 +15,13 @@ import `in`.koreatech.koin.feature.lostandfound.enums.LostAndFoundSortType
 import `in`.koreatech.koin.feature.lostandfound.model.toLostAndFoundItemState
 import `in`.koreatech.koin.feature.lostandfound.ui.detail.LostAndFoundDetailViewModel.Companion.PAGE_SIZE
 import javax.inject.Inject
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
@@ -28,11 +30,12 @@ import org.orbitmvi.orbit.viewmodel.container
 import timber.log.Timber
 
 @HiltViewModel
+@Suppress("TooManyFunctions") // updateKeywordsFromKeywordScreen() 필수 추가
 class LostAndFoundListViewModel @Inject constructor(
     private val fetchLostAndFoundArticlePaginationV2UseCase: FetchLostAndFoundArticlePaginationV2UseCase,
     private val getUserStatusUseCase: GetUserStatusUseCase
 ) : ViewModel(), ContainerHost<LostAndFoundListState, LostAndFoundListSideEffect> {
-    override val container = container<LostAndFoundListState, LostAndFoundListSideEffect>(
+    override val container: Container<LostAndFoundListState, LostAndFoundListSideEffect> = container(
         initialState = LostAndFoundListState()
     )
 
@@ -223,6 +226,25 @@ class LostAndFoundListViewModel @Inject constructor(
     fun selectKeyword(index: Int) {
         intent {
             reduce { state.copy(selectedKeywordIndex = index) }
+        }
+    }
+
+    fun updateKeywordsFromKeywordScreen(keywords: ImmutableList<String>) {
+        intent {
+            // 기존에 선택되어 있던 키워드 문자열 확보
+            val oldSelectedKeyword = state.keywords.getOrNull(state.selectedKeywordIndex)
+            // 새 키워드 리스트에서 해당 문자열의 인덱스를 탐색 (없으면 0으로 폴백)
+            val newIndex = oldSelectedKeyword?.let { keywords.indexOf(it) }?.takeIf { it >= 0 } ?: 0
+
+            reduce {
+                state.copy(keywords = keywords, selectedKeywordIndex = newIndex)
+            }
+
+            // 선택된 키워드가 실질적으로 변경되었으면 리스트 데이터 갱신
+            val newSelectedKeyword = keywords.getOrNull(newIndex)
+            if (oldSelectedKeyword != newSelectedKeyword) {
+                postSideEffect(LostAndFoundListSideEffect.FetchData)
+            }
         }
     }
 }

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -239,7 +239,8 @@
 
     <!-- Keyword Management Screen -->
     <string name="lost_and_found_keyword_management">분실물 키워드 관리</string>
-    <string name="lost_and_found_my_keyword_count">내 키워드 %1$d/10</string>
+    <string name="lost_and_found_my_keyword_label">내 키워드</string>
+    <string name="lost_and_found_my_keyword_count">%1$d/10</string>
     <string name="lost_and_found_keyword_input_hint">잃어버린 물건을 입력해 주세요.</string>
     <string name="lost_and_found_keyword_notification_section_title">키워드 알림</string>
     <string name="lost_and_found_keyword_notification_title">분실물 키워드 알림받기</string>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -241,6 +241,7 @@
     <string name="lost_and_found_keyword_management">분실물 키워드 관리</string>
     <string name="lost_and_found_my_keyword_count">내 키워드 %1$d/10</string>
     <string name="lost_and_found_keyword_input_hint">잃어버린 물건을 입력해 주세요.</string>
+    <string name="lost_and_found_keyword_notification_section_title">키워드 알림</string>
     <string name="lost_and_found_keyword_notification_title">분실물 키워드 알림받기</string>
     <string name="lost_and_found_keyword_notification_description">키워드가 포함된 분실물 게시글의 알림을 받습니다.</string>
 </resources>

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -236,4 +236,11 @@
     <string name="lost_and_found_my_filter_can_use_logged_in_negative">닫기</string>
 
     <string name="lost_and_found_search_hint">검색어를 입력해주세요.</string>
+
+    <!-- Keyword Management Screen -->
+    <string name="lost_and_found_keyword_management">분실물 키워드 관리</string>
+    <string name="lost_and_found_my_keyword_count">내 키워드 %1$d/10</string>
+    <string name="lost_and_found_keyword_input_hint">잃어버린 물건을 입력해 주세요.</string>
+    <string name="lost_and_found_keyword_notification_title">분실물 키워드 알림받기</string>
+    <string name="lost_and_found_keyword_notification_description">키워드가 포함된 분실물 게시글의 알림을 받습니다.</string>
 </resources>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1434

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- Jetpack Compose와 Orbit MVI 패턴을 사용하여 분실물 키워드 관리 화면(`LostAndFoundKeyword`)을 구현했습니다.
- 키워드 추가, 삭제, 검증(최대 10개, 2-20자, 공백 불가, 중복 불가)을 포함한 로컬 상태 관리를 구현했습니다.
- Typed route의 `List<String>` 제한을 극복하기 위해 `SavedStateHandle`을 통해 구분자(`\u0001`)로 인코딩된 문자열로 키워드를 전달하도록 네비게이션을 리팩토링했습니다.
- 이전 리뷰에서 지적된 Critical 및 Minor 결함들을 수정했습니다:
    - CSV 구분자 불일치 문제 수정.
    - `ImmutableList`를 `PersistentList`로 변경하여 키워드 관리에 필요한 메서드 지원.
    - Compose 리컴포지션 최적화 (불필요한 `collectAsStateWithLifecycle` 제거, `LaunchedEffect` 내 직접 `collect()` 사용).
- 키워드 표시, 추천 키워드, 알림 토글 컴포넌트를 포함한 UI를 구현했습니다.
- 키워드 화면 복귀 시 `LostAndFoundList` 화면과의 데이터 동기화를 위해 `SavedStateHandle`을 사용했습니다.
- `LostAndFoundListViewModel`에 `updateKeywordsFromKeywordScreen()` 메서드를 추가하여 데이터 동기화를 지원했습니다 (범위 외 수정, 승인됨).
- 향후 API 연동 및 `SubscribesType` enum 업데이트는 별도 이슈로 분리됩니다.

### 논의 사항
- Jetpack Navigation Compose의 Typed Route에서 `List<String>`과 같은 복합 타입을 직접 지원하지 않으므로, 키워드 목록 전달을 위해 `LostAndFoundList`와 `LostAndFoundKeyword` 화면 간에 구분자(`\u0001`)로 인코딩된 문자열을 사용합니다.
- `LostAndFoundKeywordState` 및 `LostAndFoundKeywordViewModel`에서 키워드 목록 타입이 `ImmutableList<String>`에서 `PersistentList<String>`으로 변경되었습니다. 이는 `add` 및 `remove`와 같은 변경 메서드를 지원하기 위함입니다.
- `LostAndFoundListViewModel`에 `updateKeywordsFromKeywordScreen()`을 추가하여 키워드 화면에서 돌아올 때 데이터 동기화를 처리했습니다. 이는 본 기능 구현을 위해 필수적인 범위 외 수정으로 승인되었습니다.

### 스크린샷
"분실물 키워드 관리" 화면에서는 사용자가 분실물 관련 키워드를 관리할 수 있습니다. 현재 설정된 키워드 수(예: "내 키워드 4/10")를 표시하고, 입력 필드를 통해 새 키워드를 추가할 수 있습니다. 사용자는 텍스트 입력 또는 추천 칩(예: "지갑", "카드")을 통해 키워드를 추가할 수 있으며, 등록된 키워드는 삭제 가능한 칩 형태로 표시됩니다. 또한, 키워드 알림 수신 여부를 켜거나 끌 수 있는 토글 스위치가 제공됩니다. 빈 키워드 목록, 키워드 추가 중 상태, 입력 유효성 검사 오류 등 다양한 화면 상태를 처리합니다.

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 키워드 관리 화면 추가 — 키워드 입력, 제안 키워드 적용 및 삭제 가능
* 키워드 최대 10개 제한과 입력 유효성 검사(공백/중복/길이) 적용, 실패 시 스낵바 안내
* 제안 키워드·내 키워드 간 빠른 적용을 위한 칩 UI(애니메이션 포함) 추가
* 키워드 기반 알림 토글 제공 및 키워드 선택이 목록 화면에 안전하게 반영되도록 내비게이션 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1435)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->