### PR TITLE
[Feature] Agent Skills 추가

### DIFF
--- a/.agents/skills/create-api-endpoint/SKILL.md
+++ b/.agents/skills/create-api-endpoint/SKILL.md
@@ -93,7 +93,7 @@ If the user's path doesn't appear verbatim, also probe naming variants (hyphen v
 **Extract the matched path's full block (path through next path):**
 
 ```bash
-awk '/^  \/course\/registration\/search:$/{f=1} f && /^  \/[a-z_-]/&&!/^  \/course\/registration\/search:$/{exit} f' "$SPEC"
+awk '/^  \/course\/registration\/search:$/{f=1} f && /^  \/[a-z{_-]/&&!/^  \/course\/registration\/search:$/{exit} f' "$SPEC"
 ```
 
 (Adjust the regex to JSON form if the spec is JSON — but YAML is preferred.)

--- a/.agents/skills/create-api-endpoint/SKILL.md
+++ b/.agents/skills/create-api-endpoint/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: create-api-endpoint
+description: Add a new REST endpoint to the KOIN Android codebase end-to-end (8-file pipeline) — Api interface + Request DTO + Response DTO + Mapper + RemoteDataSource + Repository interface method + RepositoryImpl method + (when needed) DI registration + (when needed) `Koin<Feature>Exception` cases. Uses **WebFetch** to read the **stage** OpenAPI spec at `https://api.stage.koreatech.in/v3/api-docs` and auto-fills request/response field names + types + the `mapHttpFailure { on(code, "ERROR_CODE") throws ... }` block from the spec's 4xx responses, creating any missing Exception classes in the process. If the target feature has no Repository yet, this skill **automatically invokes `create-repository` first** (via the Skill tool) to scaffold the empty Repository pair, then continues. Trigger this skill whenever the user asks to add an endpoint, "신규 엔드포인트", "API 추가", a method+path pattern (e.g. "POST /callvan/posts/{id}/ban"), or `/create-api-endpoint`. Do NOT use for WebSocket/STOMP endpoints (different transport). Do NOT use for legacy Java code.
+---
+
+# Role
+
+You are the dedicated **KOIN endpoint scaffolder**. Given an HTTP method + path (and a feature name derivable from the path), produce a single endpoint's full pipeline: from Retrofit interface method down to the RepositoryImpl override, with HTTP failure mapping and Exception classes synchronized. The result must compile cleanly with `./gradlew :data:assembleDebug`.
+
+# Required tools
+
+This skill needs `WebFetch, Read, Write, Edit, Glob, Grep, Bash`. The OpenAPI spec fetch is core — without WebFetch the skill degrades to a manual-input fallback.
+
+# OpenAPI spec — auto-fetch + reference
+
+**Spec URLs** (default = stage, used for fetching):
+
+- Stage JSON: `https://api.stage.koreatech.in/v3/api-docs` ← **default fetch target**
+- Prod JSON: `https://api.koreatech.in/v3/api-docs` (only when the user explicitly says "prod 기준" or "production")
+- Swagger UI (humans): `https://api.stage.koreatech.in/swagger-ui/index.html`
+
+**Why stage:** stage tracks development, has the latest endpoints, and is what KOIN devs verify against before shipping. Prod URL is only useful if the user is debugging production behavior.
+
+# Workflow (6 steps)
+
+## Step 1 — Parse the request, validate the feature
+
+1. Extract from the user's input:
+   - HTTP method (`GET / POST / PUT / PATCH / DELETE`)
+   - Path (e.g., `/callvan/posts/{postId}/ban`)
+   - Feature hint (usually the first path segment: `callvan`)
+2. Normalize feature: lowercase = `callvan`, PascalCase = `Callvan`.
+3. Run these Greps in parallel to map existing files:
+   ```
+   data/src/main/java/in/koreatech/koin/data/api/auth/<Feature>AuthApi.kt
+   data/src/main/java/in/koreatech/koin/data/api/<Feature>Api.kt
+   data/src/main/java/in/koreatech/koin/data/source/remote/<Feature>RemoteDataSource.kt
+   data/src/main/java/in/koreatech/koin/data/repository/<Feature>RepositoryImpl.kt
+   data/src/main/java/in/koreatech/koin/data/mapper/<Feature>Mapper.kt
+   domain/src/main/java/in/koreatech/koin/domain/repository/<Feature>Repository.kt
+   domain/src/main/java/in/koreatech/koin/domain/error/<feature>/Koin<Feature>Exception.kt
+   ```
+4. **If `<Feature>Repository.kt` does not exist** → invoke the `create-repository` skill **automatically** to scaffold it, then continue. Do not stop, do not re-prompt the user.
+   - Use the Skill tool: `Skill(skill="create-repository", args="<Feature>")`.
+   - That skill will create `domain/.../<Feature>Repository.kt` (empty interface), `data/.../<Feature>RepositoryImpl.kt` (empty `@Inject constructor()`), and add a `@Binds` entry to `BindsRepositoryModule.kt`. It also runs `:data:ktlintFormat` and `:data:assembleDebug`.
+   - On its successful completion (Repository pair now exists), proceed to Step 1.5. The endpoint method will be `Edit`-appended to the just-created interface and impl in Step 3.
+   - If `create-repository` fails (e.g. ktlint/build error), surface its error and stop — do not paper over.
+   - In your final output to the user, mention this dependency was auto-resolved (line: "ℹ️ <Feature>Repository 가 없어서 create-repository 를 자동 실행했습니다.").
+5. **Always ask the user about Auth vs NoAuth.** The OpenAPI spec cannot reliably tell us which (proven in Step 1.5c — `security`/`401`/descriptions all give wrong answers for KOIN's split). Skip the spec for this question entirely. Ask in the *same* AskUserQuestion call as method/path if those are missing, otherwise ask alone:
+   - Question label: "이 endpoint 는 Auth 인가요 NoAuth 인가요?"
+   - Options: `Auth (Bearer 토큰 필요)` / `NoAuth (토큰 없이 호출)` — no recommended/default. If the user typed `Auth` or `NoAuth` literally in the prompt, skip this question and use what they said.
+6. If method or path is missing from the user's input, include them in the same AskUserQuestion call as the auth question (single round, multiple sub-questions).
+
+## Step 1.5 — Fetch the OpenAPI spec for this endpoint
+
+### Why not just trust WebFetch's summary?
+
+The OpenAPI spec is ~1MB YAML/JSON with hundreds of paths. WebFetch's response is a **model-generated summary** of the document — at this size, the summarizer routinely misses paths and confidently reports "not found" when the path is actually present. **Never trust a "not found" or a field list returned by WebFetch's summary.** Use it only to download the file; query the saved file directly with grep/awk/sed.
+
+### 1.5a — Download the spec (one WebFetch)
+
+```
+WebFetch(
+  "https://api.stage.koreatech.in/v3/api-docs.yaml",
+  prompt: "Save the file. Return only its first 30 characters and the on-disk path."
+)
+```
+
+(Use `.yaml` over `.json` — both contain the same content but YAML grep is line-oriented and easier to slice with awk.)
+
+WebFetch always saves the body to disk and surfaces the path in its response, in a line shaped like:
+
+```
+[Binary content (application/vnd.oai.openapi, 1MB) also saved to /home/<user>/.claude/projects/<project>/<sessionId>/tool-results/webfetch-<id>.bin]
+```
+
+Parse that path out of the response. Confirm `head -c 30 <path>` starts with `openapi:` (YAML) or `{"openapi":` (JSON). If it doesn't, the fetch failed — go to manual fallback at the bottom of this step.
+
+### 1.5b — Query the saved file with grep/awk
+
+Bind `SPEC=<the saved path>` for the rest of this step. From here on, every spec lookup is a bash one-liner — no more WebFetch summarization.
+
+**Find candidate paths matching the user's request:**
+
+```bash
+grep -nE '"?(/[^":[:space:]]*<feature_or_keyword>[^":[:space:]]*)"?:' "$SPEC"
+```
+
+For YAML: paths look like `  /course/registration/search:` (no quotes, two-space indent, trailing colon). For JSON: `"/course/registration/search":`. The above regex handles both.
+
+If the user's path doesn't appear verbatim, also probe naming variants (hyphen vs slash, singular vs plural, camelCase) and **report exactly what you found** — never silently substitute.
+
+**Extract the matched path's full block (path through next path):**
+
+```bash
+awk '/^  \/course\/registration\/search:$/{f=1} f && /^  \/[a-z_-]/&&!/^  \/course\/registration\/search:$/{exit} f' "$SPEC"
+```
+
+(Adjust the regex to JSON form if the spec is JSON — but YAML is preferred.)
+
+This gives you the path's methods, parameters, requestBody, responses, and security inline.
+
+**Resolve `$ref` to component schemas:**
+
+When you see `$ref: '#/components/schemas/<RefName>'`, extract the schema body the same way:
+
+```bash
+awk '/^    <RefName>:$/{f=1; print; next} f && /^    [A-Za-z]/{exit} f' "$SPEC"
+```
+
+If `<RefName>` contains dots (e.g. `in.koreatech.koin.domain.course_registration.dto.CourseRegistrationLectureResponse`), include them literally in the awk pattern — the dots are part of the key name in the YAML.
+
+Recurse for nested `$ref`s.
+
+### 1.5c — Persist the extraction
+
+For the rest of the workflow you need:
+
+- `parameters`: list of `{name, in (path/query/header), required, schema.type, schema.items, schema.format}` — read from the path block.
+- `requestBody.content."application/json".schema.properties` + `required` — only if the method has a body. **GET/DELETE often have no requestBody — that's normal, not an error.**
+- `responses."200".content."application/json".schema` (or `"201"`, or any 2xx). **The schema can be a bare `array` whose `items.$ref` points to a single response item type — in that case the Retrofit return type is `List<X>`, NOT a wrapper object.** This was the exact case that broke the previous run (`/course/registration/search`'s 200 is `array of CourseRegistrationLectureResponse`).
+- `responses."4xx"` and `responses."5xx"`: for each, the spec's documented error code (look in `examples.value.code`, `schema.properties.code.enum`, or `description`). Status-only when no code. Spec-driven 5xx is rare in KOIN today but the DSL supports it (`on(500..599)`) — see Step 3a.
+- `security`: **Do NOT infer Auth/NoAuth from the spec.** The spec is unreliable for KOIN's Auth/NoAuth split — verified empirically:
+  - `/banners/{categoryId}` is NoAuth in KOIN code yet has no `security: []` override and even has `"401"` in responses.
+  - `/course/registration/search` has no per-path security and no `"401"` — could be either.
+  - Same backend endpoint may be wired both ways in code (e.g. `ChatApi` NoAuth + `ChatAuthApi` Auth) — the split is a *client-side* policy, not a backend property.
+  - "로그인 필요" appears just once in 1MB of spec — not a systematic signal.
+  - Therefore: ignore `security`, ignore `"401"` heuristics, ignore description Korean keywords, and **always ask the user** in Step 1 (see Step 1's auth question below).
+
+### 1.5d — Manual fallback
+
+Only enter this when:
+
+1. WebFetch itself failed (network, redirect, HTML returned), OR
+2. grep on the saved file found **zero** candidates after trying naming variants.
+
+In that case, AskUserQuestion to collect: auth y/n, http method, request body fields, response body fields, expected error codes. Mark all with `(spec unavailable — manual)`.
+
+**Do NOT enter the fallback because WebFetch's summary said "not found".** That's the WebFetch summarizer hallucinating, not a real signal. Always grep the saved file before concluding the path is missing.
+
+## Step 2 — Generate / append the data layer (parallel writes/edits)
+
+Issue all of these in a single message with parallel tool calls:
+
+| Path | Action | Driven by |
+|---|---|---|
+| `data/src/main/java/in/koreatech/koin/data/api/[auth/]<Feature>[Auth]Api.kt` | Edit if exists, Write if new | Spec parameters + request/response types |
+| `data/src/main/java/in/koreatech/koin/data/request/<feature>/<Feature><Action>Request.kt` | Write (only if HTTP body is present) | Spec requestBody schema. **No domain mirror needed** — Request stays in data layer; Repository takes primitive args. |
+| `data/src/main/java/in/koreatech/koin/data/response/<feature>/<Feature><Action>Response.kt` | Write (only if response body is present) | Spec 200/201 response schema. **Triggers a domain-model decision in Step 3d**. |
+| `data/src/main/java/in/koreatech/koin/data/mapper/<Feature>Mapper.kt` | Edit if exists, Write if new | Response → Domain field mapping |
+| `data/src/main/java/in/koreatech/koin/data/source/remote/<Feature>RemoteDataSource.kt` | Edit if exists, Write if new | Same signature as the Api method |
+
+Templates: `references/Api-method.kt.tmpl`, `references/Request.kt.tmpl`, `references/Response.kt.tmpl`, `references/Mapper-fun.kt.tmpl`, `references/RemoteDataSource-method.kt.tmpl`.
+
+**Naming derived from method + path:**
+
+- `<Action>` = a concise PascalCase verb describing the operation: `Ban`, `Create`, `Search`, `Close`, `Reopen`. Look at neighbouring methods in the existing Api file for tone.
+- Method name (camelCase): `<verb><Feature><Object>` — e.g. `banCallvanUser`, `createCallvanPost`. Follow what's already in the Api file.
+- Request DTO: `<Feature><Action>Request` (e.g. `CallvanPostCreateRequest`, `CallvanUserReportCreateRequest`). Check existing files in `data/request/<feature>/` for the precise convention; `<Feature>` may be richer than the feature name (e.g. `CallvanPost...` instead of `Callvan...`).
+- Response DTO: same shape with `Response` suffix.
+- Mapper: `fun <Feature><Action>Response.to<DomainModel>() = <DomainModel>(...)`.
+
+**Field types (OpenAPI → Kotlin):**
+
+| OpenAPI | Kotlin (required) | Kotlin (optional) |
+|---|---|---|
+| `string` | `String` | `String?` |
+| `string`, `format=date-time` | `String` (KOIN keeps ISO-8601 as String) | `String?` |
+| `integer`, `format=int32` | `Int` | `Int?` |
+| `integer`, `format=int64` | `Long` | `Long?` |
+| `number`, `format=double` | `Double` | `Double?` |
+| `boolean` | `Boolean` | `Boolean?` |
+| `array` | `List<T>` (T from `items`) | `List<T>?` |
+| `object` | nested data class (declare inside the parent file) | nested? |
+
+`required` array in the schema decides nullability — fields not listed are nullable. Don't guess.
+
+## Step 3 — Update domain + repository impl + Exception classes
+
+Order matters: write/append the Exception classes FIRST, then RepositoryImpl, so RepositoryImpl's `mapHttpFailure` references compile.
+
+### 3a. Sync `Koin<Feature>Exception.kt` with the spec's 4xx + 5xx errors
+
+For each (status, errorCode) extracted from `responses."4xx"` and `responses."5xx"`:
+
+1. Decide the Exception class name:
+   - `errorCode` snake_case or SCREAMING_SNAKE → PascalCase + `Exception` suffix.
+     - `INVALID_REQUEST_BODY` → `InvalidRequestBodyException`
+     - `CALLVAN_RESTRICTED_USER` → `CallvanRestrictedUserException`
+   - No errorCode (status only) → derive from status semantics + `responses.<code>.description` (e.g. `404 "User not found"` → `NotFoundUserException`, `500 "Internal server error"` → `ServerException`). When in doubt, ask the user for one round of confirmation rather than make up a name.
+2. Read `domain/src/main/java/in/koreatech/koin/domain/error/<feature>/Koin<Feature>Exception.kt`:
+   - **File missing (Case A — new feature):** Write a new file using `references/KoinXxxException.kt.tmpl`. Group classes by status code with the `/* Exceptions for <N> */` comment style. Mirror `KoinCallvanException.kt`'s formatting exactly.
+   - **File present, class already declared (Case B-1):** skip — idempotent.
+   - **File present, class missing (Case B-2):** Edit the file. Find the matching `/* Exceptions for <N> */` group; if present, append the new class line at the end of that group. If absent, append a new group block (comment + class) just before the file's final `}`.
+
+**5xx note:** No KOIN repository today maps 5xx (no concrete `ServerException` class exists yet either). However, `mapHttpFailure`'s KDoc (`data/util/NetworkUtil.kt:53-58`) lists `on(500..599) throws KoinException.ServerException()` as a canonical example, and the deprecated overload had a dedicated `e500` parameter. Conclusion: 5xx mapping is **supported by design** but not exercised yet. If the spec documents 5xx for this endpoint, map them. The KDoc-preferred form for 5xx is the range — `on(500..599)` — rather than enumerated single status codes. When the new Exception class doesn't exist anywhere in the codebase yet (e.g. the first `ServerException`), Step 3a creates it like any other.
+
+Never rename, reorder, or delete an existing Exception class. Append-only.
+
+### 3b. Append the Repository interface method
+
+Edit `domain/src/main/java/in/koreatech/koin/domain/repository/<Feature>Repository.kt` — append:
+
+```kotlin
+suspend fun <methodName>(
+    <param>: <Type>,
+    ...
+): Result<<DomainReturnType>>
+```
+
+`<DomainReturnType>` = `Unit` for void responses, the domain model otherwise. Anchor the Edit on the closing `}` of the interface and insert before it.
+
+### 3c. Append the RepositoryImpl override
+
+Edit `data/src/main/java/in/koreatech/koin/data/repository/<Feature>RepositoryImpl.kt` — append the block from `references/RepositoryImpl-method.kt.tmpl`. The `ERROR_MAPPINGS` block lists every (status, errorCode) extracted in Step 1.5 with its corresponding Exception class from Step 3a. Status-only mappings use the single-arg `on(code)` form; coded mappings use `on(code, "CODE")`.
+
+Add the necessary imports at the top of the file if missing (`mapHttpFailure`, the new Exception, the mapper extension, and the Request DTO when applicable). ktlintFormat will sort them.
+
+### 3d. Domain model — **required whenever a Response DTO was created**
+
+Whenever Step 2 created a new Response DTO, this endpoint's Repository method returns a domain model — that domain model **must exist** in `domain/model/<feature>/`. The skill chooses one of three branches; never "skip":
+
+1. **Response shape exactly matches an existing domain model** in `domain/model/<feature>/<Model>.kt` (same fields, same types after stripping `@SerializedName`). → reuse it. Domain Repository method's return type is the existing model. No new domain file. The mapper extension still gets a new function (`fun NewResponse.toExistingModel() = ...`).
+2. **Response shape is novel** (no existing domain model fits). → **Write** a new `domain/model/<feature>/<DomainModel>.kt`:
+   ```kotlin
+   package `in`.koreatech.koin.domain.model.<feature>
+
+   data class <DomainModel>(
+       val id: Int,
+       val name: String,
+       ...
+   )
+   ```
+   Plain Kotlin types only — no Gson, no annotations, nullability follows the Response DTO. Nested objects → nested data classes inside the same file (mirror existing patterns like `CallvanPostSearch` containing inner result types).
+3. **Endpoint has no Response body** (DELETE, 204 No Content, Unit return). → Repository method returns `Result<Unit>`. No domain model to write.
+
+**Pattern justification (KOIN convention check):**
+- Every existing Response DTO in `data/response/<feature>/` has a matching domain model under `domain/model/<feature>/`. The mapper extension function is the bridge.
+- Request DTOs do **not** have domain mirrors. Repository methods take primitive parameters (`String`, `Int`, etc.). The lone exception (`domain/model/timetable/request/TimetableLecturesUpdateQuery.kt`) is an orphan — never referenced anywhere in active code.
+
+So: Request DTO created → no domain action. Response DTO created → branch 1 / 2 / 3 above.
+
+## Step 4 — Register DI (only if a NEW Api file was created in Step 2)
+
+If Step 2 created a brand-new Api interface file (the user added a new feature's first endpoint), register it:
+
+- **Auth:** Edit `koin/src/main/java/in/koreatech/koin/di/network/AuthNetworkModule.kt` — append a `provide<Feature>AuthApi(@Auth retrofit)` block (see `references/DI-Provides.kt.tmpl`). Anchor on the last existing `provide*AuthApi` block.
+- **NoAuth:** Edit `data/src/main/java/in/koreatech/koin/data/di/network/NoAuthNetworkModule.kt` — append a `provide<Feature>Api(@NoAuth retrofit)` block. Anchor on the last existing `provide*Api` block.
+
+If Step 2 only edited an existing Api file (added one method), skip Step 4 — DI is unchanged.
+
+RemoteDataSource and Repository are auto-wired by `@Inject constructor` and `@Binds` (in `BindsRepositoryModule.kt` — managed by `create-repository` skill); no manual registration here.
+
+## Step 5 — Format
+
+Run:
+
+```bash
+./gradlew :domain:ktlintFormat :data:ktlintFormat -q
+```
+
+Both modules are touched (domain Exceptions + domain Repository; data DTOs + impl + mapper + DataSource + DI). One command formats both. ktlintFormat reorders imports alphabetically — the appended imports in Step 3c will be slotted into place.
+
+## Step 6 — Verify
+
+```bash
+./gradlew :data:assembleDebug -q
+```
+
+This proves:
+
+1. Retrofit interface compiles (annotations correct).
+2. Hilt sees `@Inject constructor(<Feature>RemoteDataSource)` etc. — no `[Dagger/MissingBinding]`.
+3. RepositoryImpl's `mapHttpFailure` block references real Exception classes that exist after Step 3a.
+4. The mapper extension function compiles against both Response DTO and Domain model.
+
+If a new Api file + DI block was added (Step 4 fired), additionally:
+
+```bash
+./gradlew :koin:assembleDebug -q
+```
+
+Failures → fix the underlying issue. Do not retry blindly. Common pitfalls:
+
+- `[Dagger/DuplicateBindings]` — already-existing repo in the legacy `RepositoryModule.kt`. Use `BindsRepositoryModule` (the one `create-repository` writes to) and remove duplicate.
+- `unresolved reference: <Exception>` — Step 3a missed a class. Re-check the Exception file.
+- `Type mismatch: required X, found X?` — nullability from spec `required` was misread; recheck the Request/Response DTO.
+- KAPT warnings about `dagger.hilt.*` are normal and can be ignored.
+
+# Output to the user
+
+Concise checklist after success:
+
+```
+✅ <METHOD> <PATH> 추가 완료
+
+생성/수정된 파일:
+- data/api/[auth/]<Feature>[Auth]Api.kt              (메서드 추가 / 새 파일)
+- data/request/<feature>/<Feature><Action>Request.kt (신규, body 있는 경우)
+- data/response/<feature>/<Feature><Action>Response.kt (신규)
+- data/mapper/<Feature>Mapper.kt                     (toDomain() 함수 추가)
+- data/source/remote/<Feature>RemoteDataSource.kt    (메서드 추가)
+- domain/repository/<Feature>Repository.kt           (suspend fun 추가)
+- data/repository/<Feature>RepositoryImpl.kt         (override 추가, mapHttpFailure 자동 채움)
+- domain/error/<feature>/Koin<Feature>Exception.kt   (새 case N개 추가 / 새 파일)
+- domain/model/<feature>/<Model>.kt                  (Response DTO 가 새로 생겼고 기존 모델 재사용 불가일 때 신규 생성. Unit 응답이면 생략)
+- (옵션) AuthNetworkModule.kt 또는 NoAuthNetworkModule.kt (새 Api 파일 등록)
+
+Spec 출처: stage `https://api.stage.koreatech.in/v3/api-docs`
+Auth: <Auth | NoAuth> (사용자 답변 기반 — spec 으로 결정 불가)
+4xx 매핑: <count>개 (KoinXxxException 신규 N / 기존 M)
+
+검증:
+- :domain:ktlintFormat   ✅
+- :data:ktlintFormat     ✅
+- :data:assembleDebug    ✅
+
+다음:
+- ViewModel 에서 <FeatureRepository>.<methodName>(...) 호출
+- spec 의 description 을 보고 Exception 메시지 / UI error copy 작성
+- 새 도메인 모델이 생겼다면 use case 추가 (use case 는 별도 작업)
+```
+
+Adapt the file list to what actually changed.
+
+# What NOT to do
+
+- One endpoint per invocation. Don't bundle multiple endpoints in one run.
+- Don't invent error codes. Only use what the spec returned (4xx and 5xx alike).
+- Don't use the legacy `RepositoryModule.kt` (`@Provides`). The Repository binding belongs in `BindsRepositoryModule.kt` — managed by the `create-repository` skill.
+- Don't change or delete existing endpoint methods, Exception classes, or DTOs. Append-only.
+- Don't write a Repository interface/Impl from scratch in this skill. If `<Feature>Repository.kt` is absent, **delegate to `create-repository` via the Skill tool** (see Step 1 item 4) — the role-separated scaffolder handles that, then control returns here.
+- Don't fetch prod spec unless the user explicitly asks.
+- Don't trust the WebFetch result's *summary text* — it routinely hallucinates "not found" on long specs. Validate by `head -c 30` on the saved file (must start with `openapi:` or `{"openapi":`) then query with grep on disk. Only enter manual fallback when the saved file itself is unusable or grep finds zero candidates after trying naming variants.
+- Don't touch Java files. KOIN treats `.java` as legacy.
+- Don't create domain `use cases`. They are deliberately out of scope.
+
+# Reference files
+
+- `references/Api-method.kt.tmpl` — Retrofit method block
+- `references/Request.kt.tmpl` — Request DTO
+- `references/Response.kt.tmpl` — Response DTO (with nested-class guidance)
+- `references/Mapper-fun.kt.tmpl` — extension fun for Response → Domain
+- `references/RemoteDataSource-method.kt.tmpl` — class skeleton + method
+- `references/RepositoryImpl-method.kt.tmpl` — runCatching + mapHttpFailure block
+- `references/KoinXxxException.kt.tmpl` — sealed class skeleton (Case A) + append rules (Case B)
+- `references/DI-Provides.kt.tmpl` — `@Provides` block for new Api files
+
+# Anchoring KOIN reference implementations (for self-validation)
+
+When unsure about a stylistic choice, sanity-check against:
+
+- `data/.../api/auth/CallvanAuthApi.kt` — most varied Auth API (POST/GET/PATCH/DELETE)
+- `data/.../api/BannerApi.kt` — minimal NoAuth API
+- `data/.../request/callvan/CallvanPostCreateRequest.kt` — Request DTO style
+- `data/.../response/callvan/CallvanPostCreateResponse.kt` — Response DTO style
+- `data/.../mapper/CallvanMapper.kt` — extension function mapper
+- `data/.../source/remote/CallvanRemoteDataSource.kt` — class @Inject constructor
+- `data/.../repository/CallvanRepositoryImpl.kt` — full runCatching + mapHttpFailure example
+- `data/.../util/NetworkUtil.kt` — `mapHttpFailure` DSL signature (`on(code) / on(code, errorCode) throws`)
+- `domain/.../error/callvan/KoinCallvanException.kt` — sealed class with status-grouped classes
+- `koin/.../di/network/AuthNetworkModule.kt` — `provide*AuthApi` registration
+- `data/.../di/network/NoAuthNetworkModule.kt` — `provide*Api` registration
+
+If your output diverges from these in form (whitespace, naming, structure), reconsider before writing.

--- a/.agents/skills/create-api-endpoint/evals/evals.json
+++ b/.agents/skills/create-api-endpoint/evals/evals.json
@@ -22,7 +22,7 @@
     {
       "id": 4,
       "prompt": "GET /banner-categories 추가",
-      "expected_output": "spec.security 가 비어있음 확인 → NoAuth 분기. data/api/BannerApi.kt 가 이미 있으므로 메서드만 append. NoAuthNetworkModule.kt 변경 없음 (기존 파일에 메서드 추가). KoinBannerException 이 없으면 4xx 매핑 시점에 신규 sealed class 파일 자동 생성.",
+      "expected_output": "Step 1 에서 사용자에게 Auth/NoAuth 를 물음 (spec 추론 금지 — SKILL.md Step 1.5c 정책). 사용자가 'NoAuth' 응답 시 NoAuth 분기. data/api/BannerApi.kt 가 이미 있으므로 메서드만 append. NoAuthNetworkModule.kt 변경 없음 (기존 파일에 메서드 추가). KoinBannerException 이 없으면 4xx 매핑 시점에 신규 sealed class 파일 자동 생성.",
       "files": []
     },
     {

--- a/.agents/skills/create-api-endpoint/evals/evals.json
+++ b/.agents/skills/create-api-endpoint/evals/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "create-api-endpoint",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "DELETE /callvan/posts/{postId}/ban 추가",
+      "expected_output": "stage spec fetch 후 callvan 기존 파일들에 메서드 append: CallvanAuthApi (DELETE), CallvanRemoteDataSource (메서드), CallvanRepository (suspend fun), CallvanRepositoryImpl (runCatching + mapHttpFailure). spec 의 4xx 응답에서 추출한 에러 코드 중 KoinCallvanException 에 없는 case 가 있으면 sealed class 본문에 자동 추가 + RepositoryImpl 의 mapHttpFailure 가 그 새 Exception 참조. :data:assembleDebug 통과.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "GET /callvan/posts/{postId}/participants 추가. 응답 모델은 새로 만들어야 해.",
+      "expected_output": "spec fetch 후 응답 schema 가 기존 callvan 도메인 모델과 다르면 domain/model/callvan/<NewModel>.kt Write. CallvanMapper 에 toNewModel 추가. CallvanResponse 신규 + 모든 계층 메서드 append.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "GET /libraries 추가",
+      "expected_output": "Step 1 에서 LibraryRepository 가 domain 에 없음을 감지 → Skill 도구로 'create-repository Library' 자동 호출 → 그 skill 이 LibraryRepository / LibraryRepositoryImpl 생성 + BindsRepositoryModule.kt 등록 + ktlintFormat + assembleDebug 통과. 컨트롤이 돌아오면 Step 1.5 부터 endpoint 추가 흐름 계속. 사용자에게 묻지 않고 자동 진행. 최종 출력에 'ℹ️ LibraryRepository 가 없어서 create-repository 를 자동 실행했습니다.' 라인 포함.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "GET /banner-categories 추가",
+      "expected_output": "spec.security 가 비어있음 확인 → NoAuth 분기. data/api/BannerApi.kt 가 이미 있으므로 메서드만 append. NoAuthNetworkModule.kt 변경 없음 (기존 파일에 메서드 추가). KoinBannerException 이 없으면 4xx 매핑 시점에 신규 sealed class 파일 자동 생성.",
+      "files": []
+    },
+    {
+      "id": 5,
+      "prompt": "POST /libraries/reservations body: { date: String, seatId: Int }",
+      "expected_output": "LibraryRepository 가 없으면 #3 처럼 create-repository 자동 호출 후 진행. spec fetch 결과 path 가 없으면 '(spec unavailable — manual)' 표기 + 사용자가 입력한 body 필드로 LibraryReservationRequest 생성.",
+      "files": []
+    },
+    {
+      "id": 6,
+      "prompt": "/create-api-endpoint POST /callvan/posts (prod 기준)",
+      "expected_output": "사용자가 'prod 기준' 명시했으므로 prod spec URL (https://api.koreatech.in/v3/api-docs) 로 WebFetch. 나머지는 #1 과 동일.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/create-api-endpoint/references/Api-method.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/Api-method.kt.tmpl
@@ -1,0 +1,18 @@
+// Append this block as a new method inside an existing <Feature>[Auth]Api interface.
+// For a brand-new Api file, prepend the standard `package ...` + `interface <Feature>[Auth]Api {`
+// header, then this method, then the closing `}`.
+
+@{{HTTP_METHOD}}("{{PATH}}")
+suspend fun {{METHOD_NAME}}(
+{{PARAMETERS}}
+){{RETURN_TYPE_CLAUSE}}
+
+// PARAMETERS — each line indented 4 spaces, comma-trailing except last:
+//     @Path("postId") postId: Int,
+//     @Query("limit") limit: Int? = null,
+//     @Body request: <Feature><Action>Request
+//
+// RETURN_TYPE_CLAUSE — one of:
+//   `: <Feature><Action>Response`  (when 200/201 has body)
+//   ``                              (empty — when response is Unit / 204 No Content)
+//   `: Response<Unit>`              (only when caller needs to inspect response code, e.g. close/cancel)

--- a/.agents/skills/create-api-endpoint/references/DI-Provides.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/DI-Provides.kt.tmpl
@@ -1,0 +1,16 @@
+// Append this @Provides block when a brand-new Api file (Auth or NoAuth) was created.
+// Imports needed (add at top of file if missing — ktlintFormat will sort):
+//   import `in`.koreatech.koin.data.api.[auth.]<Feature>[Auth]Api
+
+@Provides
+@Singleton
+fun provide{{FEATURE}}{{API_SUFFIX}}(@{{QUALIFIER}} retrofit: Retrofit): {{FEATURE}}{{API_SUFFIX}} {
+    return retrofit.create({{FEATURE}}{{API_SUFFIX}}::class.java)
+}
+
+// API_SUFFIX  — `AuthApi`  for Bearer-token endpoints, `Api` for NoAuth endpoints.
+// QUALIFIER   — `Auth`     for Auth APIs (file: koin/.../di/network/AuthNetworkModule.kt),
+//               `NoAuth`   for NoAuth APIs (file: data/.../di/network/NoAuthNetworkModule.kt).
+//
+// Anchor for Edit: append after the LAST existing `provide<...>Api` block in the matching file.
+// Idempotency: Grep `provide{{FEATURE}}{{API_SUFFIX}}` first; skip if present.

--- a/.agents/skills/create-api-endpoint/references/KoinXxxException.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/KoinXxxException.kt.tmpl
@@ -1,0 +1,35 @@
+package `in`.koreatech.koin.domain.error.{{FEATURE_LOWER}}
+
+import `in`.koreatech.koin.domain.error.KoinErrorException
+
+sealed class Koin{{FEATURE}}Exception : KoinErrorException() {
+{{EXCEPTION_GROUPS}}
+}
+
+// EXCEPTION_GROUPS — one block per HTTP status code that has at least one mapped error.
+// Each group is preceded by a multi-line comment and contains `class <X>Exception : Koin<Feature>Exception()` lines.
+// Match the exact whitespace style of feature/callvan's KoinCallvanException.kt (4-space indent, blank lines between groups).
+//
+// Example output (4xx-only — server errors are never mapped here):
+//
+//     /*
+//      * Exceptions for 400
+//      */
+//     class InvalidRequestBodyException : KoinCallvanException()
+//     class InvalidCustomLocationNameException : KoinCallvanException()
+//
+//     /*
+//      * Exceptions for 403
+//      */
+//     class CallvanRestrictedUserException : KoinCallvanException()
+//
+//     /*
+//      * Exceptions for 404
+//      */
+//     class NotFoundUserException : KoinCallvanException()
+//
+// When APPENDING to an existing file (Case B in SKILL.md):
+//   - Read existing file. Find each `/* Exceptions for <N> */` group.
+//   - Insert each new class line at the END of the matching group.
+//   - If a status code has no group yet, append a new `/* Exceptions for <N> */ class ... : Koin<Feature>Exception()` block before the closing `}`.
+//   - NEVER reorder, rename, or remove existing classes.

--- a/.agents/skills/create-api-endpoint/references/Mapper-fun.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/Mapper-fun.kt.tmpl
@@ -1,0 +1,23 @@
+// Append this extension function to the existing <Feature>Mapper.kt file.
+// If the file does not exist, prepend the package declaration + necessary imports
+// (the response DTO + the domain model) before the function.
+//
+// File location: data/src/main/java/in/koreatech/koin/data/mapper/<Feature>Mapper.kt
+// Package:       `in`.koreatech.koin.data.mapper
+
+fun {{FEATURE}}{{ACTION}}Response.to{{DOMAIN_MODEL}}() = {{DOMAIN_MODEL}}(
+{{FIELD_ASSIGNMENTS}}
+)
+
+// FIELD_ASSIGNMENTS — each line indented 4 spaces, comma-trailing except last.
+// Map Response field name → Domain model property name. Almost always 1:1.
+//     id = id,
+//     author = author,
+//     departureType = departureType,
+//
+// Nested DTOs need their own toX() function (also extension):
+//     fun FooResponse.ItemDto.toItem() = Item(postId, title)
+//     // and the parent uses: items = items.map { it.toItem() }
+//
+// For new domain models (no Domain class yet), the skill writes the model file too —
+// see SKILL.md Step 3.

--- a/.agents/skills/create-api-endpoint/references/RemoteDataSource-method.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/RemoteDataSource-method.kt.tmpl
@@ -1,0 +1,31 @@
+// Append this method to <Feature>RemoteDataSource.kt
+// (`class <Feature>RemoteDataSource @Inject constructor(private val <feature>[Auth]Api: ...)`)
+//
+// For a brand-new RemoteDataSource file, prepend the standard header:
+//
+//     package `in`.koreatech.koin.data.source.remote
+//     import ...
+//     import javax.inject.Inject
+//
+//     class <Feature>RemoteDataSource @Inject constructor(
+//         private val {{API_PARAM}}: {{API_TYPE}}
+//     ) {
+//         <methods...>
+//     }
+
+suspend fun {{METHOD_NAME}}(
+{{PARAMETERS}}
+){{RETURN_TYPE_CLAUSE}} = {{API_PARAM}}.{{METHOD_NAME}}(
+{{ARG_FORWARDING}}
+)
+
+// PARAMETERS / RETURN_TYPE_CLAUSE — same as the Api method (no Retrofit annotations here).
+// API_PARAM — camelCase property name, e.g. `callvanAuthApi` or `bannerApi`.
+// API_TYPE  — `<Feature>AuthApi` or `<Feature>Api`.
+// ARG_FORWARDING — name = name (each line indented 4 spaces, comma-trailing except last).
+//
+// For Response<Unit> calls (rare), use the imperative style instead of `=`:
+//     suspend fun close(postId: Int) {
+//         val response = api.close(postId)
+//         if (!response.isSuccessful) throw HttpException(response)
+//     }

--- a/.agents/skills/create-api-endpoint/references/RepositoryImpl-method.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/RepositoryImpl-method.kt.tmpl
@@ -1,0 +1,54 @@
+// Append this `override` block to <Feature>RepositoryImpl.kt.
+// Imports needed (add at top of file if missing — ktlintFormat will sort):
+//   import `in`.koreatech.koin.data.util.mapHttpFailure
+//   import `in`.koreatech.koin.domain.error.<feature>.Koin<Feature>Exception
+//   import `in`.koreatech.koin.data.mapper.to<DomainModel>     (only if a mapper is used)
+//   import `in`.koreatech.koin.data.request.<feature>.<...>Request  (only if a body is sent)
+
+override suspend fun {{METHOD_NAME}}(
+{{PARAMETERS}}
+): Result<{{DOMAIN_RETURN_TYPE}}> {
+    return runCatching {
+        {{REMOTE_DATA_SOURCE_PARAM}}.{{METHOD_NAME}}(
+{{REMOTE_CALL_ARGS}}
+        ){{MAPPER_CALL}}
+    }.mapHttpFailure {
+{{ERROR_MAPPINGS}}
+    }
+}
+
+// PARAMETERS — public-facing args (no annotations). Same names + types as the
+// matching domain Repository interface method.
+//
+// DOMAIN_RETURN_TYPE — `CallvanPostCreate`, `Unit`, `List<Foo>`, etc.
+//   When the API returns Unit (DELETE / 204), use `Unit`. The trailing `.toX()` becomes empty.
+//
+// REMOTE_DATA_SOURCE_PARAM — the constructor-injected RemoteDataSource property
+// (e.g. `callvanRemoteDataSource`).
+//
+// REMOTE_CALL_ARGS — each line indented 12 spaces (3 levels), comma-trailing.
+//   For body-bearing calls, build the Request DTO inline:
+//       <Feature><Action>Request(
+//           field = field,
+//           ...
+//       )
+//
+// MAPPER_CALL — `.to<DomainModel>()` when there is a Response→Domain mapper.
+//   Empty string when DOMAIN_RETURN_TYPE == Unit and the call returns Unit.
+//
+// ERROR_MAPPINGS — one line per error code extracted from the OpenAPI spec
+// (4xx AND 5xx if the spec documents them).
+// All Exception classes referenced MUST exist in Koin<Feature>Exception.kt
+// (the skill creates/appends them in Step 3 BEFORE writing this method body):
+//
+//     on(400, "INVALID_REQUEST_BODY") throws KoinCallvanException.InvalidRequestBodyException()
+//     on(403, "FORBIDDEN_CALLVAN_RESTRICTED_USER") throws KoinCallvanException.CallvanRestrictedUserException()
+//     on(404) throws KoinCallvanException.NotFoundUserException()
+//
+// 5xx: rare in KOIN today but supported by the DSL. The KDoc-preferred form is the IntRange:
+//
+//     on(500..599) throws KoinXxxException.ServerException()
+//     on(500..599, "DB_TIMEOUT") throws KoinXxxException.DbTimeoutException()
+//
+// When the spec doesn't document 5xx (most common case in KOIN), omit 5xx mappings —
+// NetworkUtil's KoinUnknownErrorException fallback handles those automatically.

--- a/.agents/skills/create-api-endpoint/references/Request.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/Request.kt.tmpl
@@ -1,0 +1,17 @@
+package `in`.koreatech.koin.data.request.{{FEATURE_LOWER}}
+
+import com.google.gson.annotations.SerializedName
+
+data class {{FEATURE}}{{ACTION}}Request(
+{{FIELDS}}
+)
+
+// FIELDS — each line indented 4 spaces, comma-trailing except last.
+// Use Gson @SerializedName for snake_case API field, camelCase Kotlin property:
+//     @SerializedName("departure_type")
+//     val departureType: String,
+//     @SerializedName("departure_custom_name")
+//     val departureCustomName: String?,
+//
+// Nullability: a field is nullable iff it is NOT in OpenAPI's `required` array
+// for the requestBody schema. Required fields → non-null. Optional → `String?`/`Int?`.

--- a/.agents/skills/create-api-endpoint/references/Response.kt.tmpl
+++ b/.agents/skills/create-api-endpoint/references/Response.kt.tmpl
@@ -1,0 +1,23 @@
+package `in`.koreatech.koin.data.response.{{FEATURE_LOWER}}
+
+import com.google.gson.annotations.SerializedName
+
+data class {{FEATURE}}{{ACTION}}Response(
+{{FIELDS}}
+)
+
+// FIELDS — same conventions as Request.kt.tmpl. Nullability driven by OpenAPI `required`.
+//
+// Nested objects: if the response schema has nested objects (`properties.foo.type == "object"`),
+// declare them as inner data classes inside the same file:
+//
+//     data class FooResponse(
+//         @SerializedName("items") val items: List<ItemDto>
+//     ) {
+//         data class ItemDto(
+//             @SerializedName("post_id") val postId: Int,
+//             @SerializedName("title")   val title: String
+//         )
+//     }
+//
+// Match `feature/callvan` response files for visual style.

--- a/.agents/skills/create-feature-module/SKILL.md
+++ b/.agents/skills/create-feature-module/SKILL.md
@@ -21,9 +21,9 @@ The user's invocation typically looks like one of:
 - "feature/library 모듈 만들어줘" — Korean natural language with name embedded
 - "scaffold a new compose feature module called menu with orbit" — name + extras hinted
 
-Extract the **module name** in kebab-case (`a-z0-9-`, lowercase). If the user supplies PascalCase or camelCase, normalize it (`Library` → `library`, `lostAndFound` → `lostandfound`). Reject names that conflict with existing modules under `feature/` (run `ls feature/` first).
+Extract the **module name** in kebab-case (`a-z0-9-`, lowercase). If the user supplies PascalCase or camelCase, split on case boundaries first (`lostAndFound` → words `[lost, and, found]`), then join lowercase for the directory name (`lostandfound`). **Preserve the word boundaries** — you'll need them to derive PascalCase in Step 1. Reject names that conflict with existing modules under `feature/` (run `ls feature/` first).
 
-**Orbit MVI and `core.navigation` are always on** — every new KOIN feature module uses both, so the `koin.library.orbit` plugin, its test deps (`kotlinx.coroutines.test`, `turbine`), and `implementation(projects.core.navigation)` are baked into the template. Do not ask about them. Do not offer to skip them.
+**Orbit MVI and `core.navigation` are always on** — every new KOIN feature module uses both, so the `koin.library.orbit` plugin, its test dep (`kotlinx.coroutines.test`), and `implementation(projects.core.navigation)` are baked into the template. Do not ask about them. Do not offer to skip them.
 
 If the user has not signaled which extras they want, ask **one** consolidated multi-select question covering the two real opt-ins below. Do not bombard with separate questions.
 
@@ -41,9 +41,9 @@ If the user only says "make me a feature module called X" with no extras hint, t
 ## Step 1 — Validate the name and resolve options
 
 1. Run `ls feature/` (Bash) to confirm the name is not taken.
-2. Normalize to kebab-case lowercase. Derive:
-   - `<name>` — kebab-case, e.g. `lostandfound`
-   - `<NamePascal>` — PascalCase, e.g. `Lostandfound`. (KOIN treats compound names as a single token: `lostandfound` → `Lostandfound`, not `LostAndFound`. Confirm by checking `feature/lostandfound/` directory naming if the input is multi-word.)
+2. Derive the names. KOIN's convention is **asymmetric**: the directory uses lowercase concatenated (single token, no dashes), but class names use multi-word PascalCase. Confirm by inspecting `feature/lostandfound/` — directory is `lostandfound`, but files are `LostAndFoundActivity.kt`, `LostAndFoundNavType.kt`, etc.
+   - `<name>` — lowercase concatenated, e.g. `lostandfound` (used for directory, namespace, package)
+   - `<NamePascal>` — multi-word PascalCase from the original word boundaries, e.g. `LostAndFound` (used for class names like `<NamePascal>Activity`). If the user typed `lost-and-found` or `lostAndFound`, you have boundaries → produce `LostAndFound`. If they typed `lostandfound` with no boundaries, ask one short clarification ("PascalCase로 어떻게 표기할까요? `LostAndFound` / `Lostandfound`") rather than guessing.
    - Namespace: `in.koreatech.koin.feature.<name>`
    - Source dir: `feature/<name>/src/main/java/in/koreatech/koin/feature/<name>/`
 3. If the user has not specified extras, ask **one** AskUserQuestion with `multiSelect: true`, options: "kotlinx-serialization", "Deeplink Activity". Frame Orbit as already-included so the user knows it's not a choice. If the user already mentioned the extras inline (e.g. "with serialization", "with deeplink"), skip the question.
@@ -204,7 +204,6 @@ Adapt the list to whichever extras were actually selected.
 - Do NOT create `AGENTS.md` content beyond the template — concrete focus areas are the user's job to fill in. Do not invent feature responsibilities.
 - Do NOT modify any existing feature module to "match style". Other modules are out of scope.
 - Do NOT commit. Stop after `ktlintFormat`.
-- Do NOT create a `res/` directory pre-emptively. Let the implementer add `res/values/strings.xml` etc. when they have actual resources.
 - Do NOT add `tests/`, `build.gradle` (Groovy variant), or any pre-AGP-9 boilerplate.
 
 # Reference files

--- a/.agents/skills/create-feature-module/SKILL.md
+++ b/.agents/skills/create-feature-module/SKILL.md
@@ -9,7 +9,7 @@ You are the dedicated **KOIN feature-module scaffolder**. Given a feature name (
 
 # Philosophy
 
-KOIN already has 11 feature modules with a stable shape. Do not reinvent. Mirror the conventions of `feature/callvan/` (full-featured) — every new feature module in KOIN uses Orbit MVI and the shared `core.navigation` library, so both are **always** wired in. The user picks two opt-ins: kotlinx-serialization and a Deeplink Activity manifest block.
+KOIN already has 13 feature modules with a stable shape. Do not reinvent. Mirror the conventions of `feature/callvan/` (full-featured, the most recently added module). **Going forward, all new feature modules use Orbit MVI and the shared `core.navigation` library**, so both are wired in by default. (Older modules — `banner`, `bus`, `dining`, `timetable`, `user` — predate this convention and use a subset; do not match their shape for new work.) The user picks two opt-ins: kotlinx-serialization and a Deeplink Activity manifest block.
 
 The smallest correct scaffold beats a feature-rich one full of unused plugins. Add kotlinx-serialization or an Activity manifest entry **only when the user signals they're needed**.
 
@@ -23,7 +23,7 @@ The user's invocation typically looks like one of:
 
 Extract the **module name** in kebab-case (`a-z0-9-`, lowercase). If the user supplies PascalCase or camelCase, split on case boundaries first (`lostAndFound` → words `[lost, and, found]`), then join lowercase for the directory name (`lostandfound`). **Preserve the word boundaries** — you'll need them to derive PascalCase in Step 1. Reject names that conflict with existing modules under `feature/` (run `ls feature/` first).
 
-**Orbit MVI and `core.navigation` are always on** — every new KOIN feature module uses both, so the `koin.library.orbit` plugin, its test dep (`kotlinx.coroutines.test`), and `implementation(projects.core.navigation)` are baked into the template. Do not ask about them. Do not offer to skip them.
+**Orbit MVI and `core.navigation` are always on for new modules** — this is the going-forward convention, so the `koin.library.orbit` plugin, its test dep (`kotlinx.coroutines.test`), and `implementation(projects.core.navigation)` are baked into the template. Do not ask about them. Do not offer to skip them. (Older modules without one or both are grandfathered — see Philosophy.)
 
 If the user has not signaled which extras they want, ask **one** consolidated multi-select question covering the two real opt-ins below. Do not bombard with separate questions.
 
@@ -57,7 +57,7 @@ Issue all of the following Write/Bash calls in a single message — they have no
 |---|---|
 | `feature/<name>/build.gradle.kts` | Render `references/build.gradle.kts.tmpl` |
 | `feature/<name>/src/main/AndroidManifest.xml` | Render `references/AndroidManifest.xml.tmpl`. **The manifest lives under `src/main/`, NOT at the module root.** Every existing KOIN feature module follows this — putting it at the module root will be silently ignored by AGP and the module will fail at runtime. |
-| `feature/<name>/src/main/res/values/strings.xml` | Copy `references/strings.xml.tmpl` verbatim. Empty `<resources>` skeleton — every existing KOIN feature module has this file, even when minimal (`feature/banner` ships only 3 strings). The implementer adds string resources as features land. |
+| `feature/<name>/src/main/res/values/strings.xml` | Copy `references/strings.xml.tmpl` verbatim. Empty `<resources>` skeleton — strings.xml is the convention for new modules, even when minimal (e.g. `feature/banner` ships 3 strings, `feature/callvan` ships 164). A few older modules (`notification`, `setting`) skip the file; do not match their shape for new work. The implementer adds string resources as features land. |
 | `feature/<name>/proguard-rules.pro` | Copy `references/proguard-rules.pro.tmpl` verbatim |
 | `feature/<name>/consumer-rules.pro` | Empty file (`touch`) |
 | `feature/<name>/AGENTS.md` | Render `references/AGENTS.md.tmpl` |

--- a/.agents/skills/create-feature-module/SKILL.md
+++ b/.agents/skills/create-feature-module/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: create-feature-module
+description: Scaffold a brand-new KOIN Android feature module under `feature/<name>/` with Orbit MVI and `core.navigation` baked in — `build.gradle.kts` (koin.feature + koin.hilt + koin.library.orbit + projects.core.navigation), `AndroidManifest.xml`, `proguard-rules.pro`, `consumer-rules.pro`, `AGENTS.md`, the `in.koreatech.koin.feature.<name>` package directory — and wire it into `settings.gradle` and `koin/build.gradle.kts`. Orbit and core.navigation are always included; the only opt-ins are kotlinx-serialization and a Deeplink Activity manifest block. Use whenever the user asks to create a new feature module, scaffold one, bootstrap one, or "add `feature/<name>`" (e.g. "feature/library 모듈 만들어줘", "신규 feature 모듈 추가", "scaffold feature/menu", "/create-feature-module library"). Trigger this skill even when the user does not say "skill" or "scaffold" — any request that boils down to "make a new module under `feature/`" should use it. Do NOT use for `core/*` modules, `business/`, or modifications to existing feature modules.
+---
+
+# Role
+
+You are the dedicated **KOIN feature-module scaffolder**. Given a feature name (kebab-case, e.g. `library`, `menu`, `lostandfound`), produce a brand-new feature module that compiles cleanly with `./gradlew :feature:<name>:assembleDebug` on the first run, follows existing KOIN conventions exactly, and is wired into the build graph.
+
+# Philosophy
+
+KOIN already has 11 feature modules with a stable shape. Do not reinvent. Mirror the conventions of `feature/callvan/` (full-featured) — every new feature module in KOIN uses Orbit MVI and the shared `core.navigation` library, so both are **always** wired in. The user picks two opt-ins: kotlinx-serialization and a Deeplink Activity manifest block.
+
+The smallest correct scaffold beats a feature-rich one full of unused plugins. Add kotlinx-serialization or an Activity manifest entry **only when the user signals they're needed**.
+
+# Inputs
+
+The user's invocation typically looks like one of:
+
+- `/create-feature-module library` — name positional
+- "feature/library 모듈 만들어줘" — Korean natural language with name embedded
+- "scaffold a new compose feature module called menu with orbit" — name + extras hinted
+
+Extract the **module name** in kebab-case (`a-z0-9-`, lowercase). If the user supplies PascalCase or camelCase, normalize it (`Library` → `library`, `lostAndFound` → `lostandfound`). Reject names that conflict with existing modules under `feature/` (run `ls feature/` first).
+
+**Orbit MVI and `core.navigation` are always on** — every new KOIN feature module uses both, so the `koin.library.orbit` plugin, its test deps (`kotlinx.coroutines.test`, `turbine`), and `implementation(projects.core.navigation)` are baked into the template. Do not ask about them. Do not offer to skip them.
+
+If the user has not signaled which extras they want, ask **one** consolidated multi-select question covering the two real opt-ins below. Do not bombard with separate questions.
+
+## Decision matrix (the 2 real opt-ins)
+
+| Choice | When to enable | What it adds |
+|---|---|---|
+| **kotlinx-serialization** | Module needs `@Serializable` types for navigation arguments or JSON. | `alias(libs.plugins.kotlinx.serialization)` plugin + `implementation(libs.kotlinx.serialization.json)` dep |
+| **Deeplink Activity** | Module is the entry point for a `koin://<name>/navigation` deeplink (mirrors `feature/callvan` `CallvanActivity`). | An `<activity android:name=".<NamePascal>Activity">` block in `AndroidManifest.xml` with `intent-filter` for `koin://<name>/navigation`, plus a stub `<NamePascal>Activity.kt`. (No build.gradle change — `core.navigation` is already on.) |
+
+If the user only says "make me a feature module called X" with no extras hint, the **smart default is "both off"** — Orbit and core.navigation are already on, the rest stays minimal until needed.
+
+# Workflow
+
+## Step 1 — Validate the name and resolve options
+
+1. Run `ls feature/` (Bash) to confirm the name is not taken.
+2. Normalize to kebab-case lowercase. Derive:
+   - `<name>` — kebab-case, e.g. `lostandfound`
+   - `<NamePascal>` — PascalCase, e.g. `Lostandfound`. (KOIN treats compound names as a single token: `lostandfound` → `Lostandfound`, not `LostAndFound`. Confirm by checking `feature/lostandfound/` directory naming if the input is multi-word.)
+   - Namespace: `in.koreatech.koin.feature.<name>`
+   - Source dir: `feature/<name>/src/main/java/in/koreatech/koin/feature/<name>/`
+3. If the user has not specified extras, ask **one** AskUserQuestion with `multiSelect: true`, options: "kotlinx-serialization", "Deeplink Activity". Frame Orbit as already-included so the user knows it's not a choice. If the user already mentioned the extras inline (e.g. "with serialization", "with deeplink"), skip the question.
+4. Ask the user for a **one-line purpose** to put in `AGENTS.md` (e.g., "library reservations and seat-status display"). If the user is impatient, fill it with `TODO: describe the feature` and move on — they can edit later.
+
+## Step 2 — Generate files (parallelize all Writes)
+
+Issue all of the following Write/Bash calls in a single message — they have no inter-dependencies:
+
+| Path | Source |
+|---|---|
+| `feature/<name>/build.gradle.kts` | Render `references/build.gradle.kts.tmpl` |
+| `feature/<name>/src/main/AndroidManifest.xml` | Render `references/AndroidManifest.xml.tmpl`. **The manifest lives under `src/main/`, NOT at the module root.** Every existing KOIN feature module follows this — putting it at the module root will be silently ignored by AGP and the module will fail at runtime. |
+| `feature/<name>/src/main/res/values/strings.xml` | Copy `references/strings.xml.tmpl` verbatim. Empty `<resources>` skeleton — every existing KOIN feature module has this file, even when minimal (`feature/banner` ships only 3 strings). The implementer adds string resources as features land. |
+| `feature/<name>/proguard-rules.pro` | Copy `references/proguard-rules.pro.tmpl` verbatim |
+| `feature/<name>/consumer-rules.pro` | Empty file (`touch`) |
+| `feature/<name>/AGENTS.md` | Render `references/AGENTS.md.tmpl` |
+| `feature/<name>/src/main/java/in/koreatech/koin/feature/<name>/.gitkeep` | Empty file — keeps the package dir under git |
+
+The `.gitkeep` matters: KOIN puts no source file in a fresh module, so without it the empty package dir won't ship.
+
+### Template rendering rules
+
+**`build.gradle.kts.tmpl` placeholders** (Orbit and core.navigation are hardcoded in the template):
+
+- `{{NAME}}` → the kebab-case name (used in `namespace = "in.koreatech.koin.feature.<NAME>"`).
+- `{{SERIALIZATION_PLUGIN_LINE}}` and `{{SERIALIZATION_DEP_LINE}}` are **standalone-line** placeholders. They each occupy their own line in the template. Apply the line-rule below — do not use plain string-substitution that leaves stray blank lines.
+
+**Standalone-line placeholder rule:**
+
+If kotlinx-serialization is **selected**, replace each placeholder with one indented Kotlin line:
+- `{{SERIALIZATION_PLUGIN_LINE}}` → `    alias(libs.plugins.kotlinx.serialization)`
+- `{{SERIALIZATION_DEP_LINE}}` → `    implementation(libs.kotlinx.serialization.json)`
+
+If kotlinx-serialization is **not selected**, **delete the entire placeholder line including its trailing newline** — leave no blank line behind. The output should look exactly like `feature/banner/build.gradle.kts` (no kotlinx-serialization references at all, no orphan blank line where the placeholder used to be).
+
+After rendering, the file should have no orphan blank lines — visually as dense as `feature/banner/build.gradle.kts` (no-serialization case) or `feature/callvan/build.gradle.kts` (with-serialization case). If you see two consecutive blank lines anywhere except between the `plugins`, `android`, and `dependencies` blocks, the line-deletion rule was applied incorrectly.
+
+After rendering, **clean up double blank lines** so the final file has the same density as `feature/callvan/build.gradle.kts`. Compare your output against that file mentally before writing.
+
+**`AndroidManifest.xml.tmpl` placeholder:**
+
+- `{{ACTIVITY_BLOCK}}` →
+  - If **Deeplink Activity** is OFF: empty (the file becomes `<manifest><application/></manifest>`).
+  - If ON: indented Activity block (8-space indent inside `<application>`):
+    ```xml
+            <activity
+                android:name=".<NamePascal>Activity"
+                android:exported="true"
+                android:windowSoftInputMode="adjustResize">
+                <intent-filter>
+                    <action android:name="android.intent.action.VIEW" />
+
+                    <category android:name="android.intent.category.DEFAULT" />
+                    <category android:name="android.intent.category.BROWSABLE" />
+
+                    <data
+                        android:host="<name>"
+                        android:scheme="koin"
+                        android:pathPrefix="/navigation"/>
+                </intent-filter>
+            </activity>
+    ```
+  - If ON, you must ALSO produce a stub `feature/<name>/src/main/java/in/koreatech/koin/feature/<name>/<NamePascal>Activity.kt` (otherwise the manifest references a non-existent class and the build fails). Use this minimal body and let the implementer flesh it out:
+    ```kotlin
+    package `in`.koreatech.koin.feature.<name>
+
+    import android.os.Bundle
+    import androidx.activity.ComponentActivity
+    import androidx.activity.compose.setContent
+    import dagger.hilt.android.AndroidEntryPoint
+
+    @AndroidEntryPoint
+    class <NamePascal>Activity : ComponentActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            super.onCreate(savedInstanceState)
+            setContent {
+                // TODO: NavHost / start screen
+            }
+        }
+    }
+    ```
+
+**`AGENTS.md.tmpl` placeholders** (Orbit baked into template wording — no toggle):
+
+- `{{NAME}}` → kebab-case
+- `{{NAME_PASCAL}}` → PascalCase
+- `{{ONE_LINE_PURPOSE}}` → user-supplied one-liner
+- `{{FOCUS_AREAS}}` → bullet seed `TODO: list focus areas` if user did not supply, else their list
+
+## Step 3 — Wire into the build graph (Edit, not Write)
+
+Two surgical edits, **not** whole-file rewrites:
+
+1. `settings.gradle`: append `include ':feature:<name>'` after the last existing `include ':feature:...'` line. Preserve Groovy single-quote style (the file is `.gradle`, not `.gradle.kts`). Use Edit with the last existing `include ':feature:<existing>'` line as `old_string` to anchor the insertion.
+
+2. `koin/build.gradle.kts`: append `implementation(projects.feature.<name>)` after the last existing `implementation(projects.feature.<existing>)` line. Use Edit anchored to that block.
+
+Both edits are idempotent — before applying, Grep for the new line and skip if it already exists.
+
+## Step 4 — Verify
+
+Run a fast verification:
+
+```bash
+./gradlew :feature:<name>:tasks -q | head -5
+```
+
+`tasks` is dramatically faster than `assembleDebug` and proves the module is discoverable + plugin chain resolves. If it fails, report the error verbatim — do not silently retry.
+
+If the user explicitly asks for a full build, then `./gradlew :feature:<name>:assembleDebug`. Do not run that by default — it can take minutes.
+
+## Step 5 — Format
+
+After all writes, run:
+
+```bash
+./gradlew :feature:<name>:ktlintFormat
+```
+
+This is **mandatory** per `CLAUDE.md`'s "Run ./gradlew ktlintFormat before commit". If ktlintFormat fails, the scaffolding has a syntax issue — fix it.
+
+# Output to the user
+
+After everything succeeds, emit a concise checklist:
+
+```
+✅ feature/<name> 생성 완료
+
+생성된 파일:
+- feature/<name>/build.gradle.kts        (plugins: koin.feature, koin.hilt, ...)
+- feature/<name>/src/main/AndroidManifest.xml
+- feature/<name>/src/main/res/values/strings.xml
+- feature/<name>/proguard-rules.pro
+- feature/<name>/consumer-rules.pro
+- feature/<name>/AGENTS.md
+- feature/<name>/src/main/java/in/koreatech/koin/feature/<name>/.gitkeep
+  (+ <NamePascal>Activity.kt — Deeplink 옵션을 켰을 경우)
+
+연결:
+- settings.gradle  →  include ':feature:<name>' 추가
+- koin/build.gradle.kts  →  implementation(projects.feature.<name>) 추가
+
+검증:
+- :feature:<name>:tasks  ✅
+- :feature:<name>:ktlintFormat  ✅
+
+다음:
+- AGENTS.md 의 'Focus Areas' 와 'one-line purpose' 채우기
+- 첫 화면을 src/main/java/.../<name>/ui/<screen>/ 패키지에 추가
+```
+
+Adapt the list to whichever extras were actually selected.
+
+# What NOT to do
+
+- Do NOT add unused dependencies (e.g., `coil.compose` is in the template because every existing module uses it; that's the project convention. Do not add `retrofit`, `okhttp`, `kotlinx-datetime`, etc. — those belong in `data/` or are pulled in transitively.)
+- Do NOT create `AGENTS.md` content beyond the template — concrete focus areas are the user's job to fill in. Do not invent feature responsibilities.
+- Do NOT modify any existing feature module to "match style". Other modules are out of scope.
+- Do NOT commit. Stop after `ktlintFormat`.
+- Do NOT create a `res/` directory pre-emptively. Let the implementer add `res/values/strings.xml` etc. when they have actual resources.
+- Do NOT add `tests/`, `build.gradle` (Groovy variant), or any pre-AGP-9 boilerplate.
+
+# Reference files
+
+- `references/build.gradle.kts.tmpl` — module build script template
+- `references/AndroidManifest.xml.tmpl` — minimum manifest skeleton
+- `references/strings.xml.tmpl` — empty `<resources>` skeleton (verbatim copy)
+- `references/proguard-rules.pro.tmpl` — verbatim boilerplate (copy as-is)
+- `references/AGENTS.md.tmpl` — module AGENTS.md skeleton
+
+`consumer-rules.pro` is intentionally empty across all KOIN modules — just `touch` the file.

--- a/.agents/skills/create-feature-module/evals/evals.json
+++ b/.agents/skills/create-feature-module/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "create-feature-module",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "feature/library 모듈 만들어줘.",
+      "expected_output": "feature/library 가 생성되고 build.gradle.kts 에 koin.feature + koin.hilt + koin.library.orbit 3개 플러그인 포함 (kotlinx-serialization 없음). namespace 는 in.koreatech.koin.feature.library. dependencies 에 projects.core.navigation 포함 (필수). testImplementation kotlinx.coroutines.test + turbine 포함. settings.gradle 에 include ':feature:library' 추가. koin/build.gradle.kts 에 implementation(projects.feature.library) 추가. ./gradlew :feature:library:tasks 가 성공.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "scaffold a new compose feature module called menu. minimum dependencies, no serialization, no activity.",
+      "expected_output": "feature/menu 의 build.gradle.kts 에 koin.feature + koin.hilt + koin.library.orbit (Orbit 은 필수이므로 빠질 수 없음) + projects.core.navigation (필수). kotlinx-serialization 플러그인/의존성 없음. AndroidManifest 는 빈 application 태그. orbit 관련 testImplementation 포함.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "/create-feature-module reservation 만들어줘. 딥링크 Activity 도 필요하고, 화면 진입은 koin://reservation/navigation 로 받을 거야. serialization 도 켜.",
+      "expected_output": "feature/reservation 의 AndroidManifest.xml 에 .ReservationActivity intent-filter (host=reservation, scheme=koin, pathPrefix=/navigation) 포함. ReservationActivity.kt stub 이 src/main/java/.../reservation/ 에 생성. build.gradle.kts 에 4개 플러그인 (feature, hilt, orbit, kotlinx-serialization) + projects.core.navigation (필수) + kotlinx-serialization-json 포함.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "feature/callvan 모듈 새로 만들어줘",
+      "expected_output": "이미 존재하는 모듈이므로 거부 또는 명확한 안내. ls feature/ 결과를 근거로 제시. 기존 파일을 덮어쓰지 않음.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/create-feature-module/evals/evals.json
+++ b/.agents/skills/create-feature-module/evals/evals.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "prompt": "feature/library 모듈 만들어줘.",
-      "expected_output": "feature/library 가 생성되고 build.gradle.kts 에 koin.feature + koin.hilt + koin.library.orbit 3개 플러그인 포함 (kotlinx-serialization 없음). namespace 는 in.koreatech.koin.feature.library. dependencies 에 projects.core.navigation 포함 (필수). testImplementation kotlinx.coroutines.test + turbine 포함. settings.gradle 에 include ':feature:library' 추가. koin/build.gradle.kts 에 implementation(projects.feature.library) 추가. ./gradlew :feature:library:tasks 가 성공.",
+      "expected_output": "feature/library 가 생성되고 build.gradle.kts 에 koin.feature + koin.hilt + koin.library.orbit 3개 플러그인 포함 (kotlinx-serialization 없음). namespace 는 in.koreatech.koin.feature.library. dependencies 에 projects.core.navigation 포함 (필수). testImplementation kotlinx.coroutines.test 포함. settings.gradle 에 include ':feature:library' 추가. koin/build.gradle.kts 에 implementation(projects.feature.library) 추가. ./gradlew :feature:library:tasks 가 성공.",
       "files": []
     },
     {

--- a/.agents/skills/create-feature-module/references/AGENTS.md.tmpl
+++ b/.agents/skills/create-feature-module/references/AGENTS.md.tmpl
@@ -1,0 +1,23 @@
+# Feature {{NAME_PASCAL}} Module - AGENTS.md
+
+`feature/{{NAME}}` is a Compose-first Orbit module for {{ONE_LINE_PURPOSE}}.
+
+## Keep In Mind
+
+- Use the existing Compose + Orbit patterns for screens and ViewModels.
+- Keep {{NAME}}-specific flows inside this module.
+- Use `rememberNavigator()` and shared navigation helpers for hand-offs back to `koin` Activities.
+- Reuse shared onboarding, analytics, and design-system components before adding module-local alternatives.
+- Keep {{NAME_PASCAL}}-specific UI state and validation in the feature layer; ViewModels still call use cases rather than repositories directly.
+
+## Focus Areas
+
+- {{FOCUS_AREAS}}
+
+## Read First
+
+- Root `AGENTS.md`
+- `core/AGENTS.md`
+- `core/navigation/AGENTS.md`
+- `core/designsystem/AGENTS.md`
+- `core/onboarding/AGENTS.md`

--- a/.agents/skills/create-feature-module/references/AndroidManifest.xml.tmpl
+++ b/.agents/skills/create-feature-module/references/AndroidManifest.xml.tmpl
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+{{ACTIVITY_BLOCK}}
+    </application>
+
+</manifest>

--- a/.agents/skills/create-feature-module/references/build.gradle.kts.tmpl
+++ b/.agents/skills/create-feature-module/references/build.gradle.kts.tmpl
@@ -1,0 +1,29 @@
+plugins {
+    alias(libs.plugins.koin.feature)
+    alias(libs.plugins.koin.hilt)
+    alias(libs.plugins.koin.library.orbit)
+{{SERIALIZATION_PLUGIN_LINE}}
+}
+
+android {
+    namespace = "in.koreatech.koin.feature.{{NAME}}"
+}
+
+dependencies {
+    implementation(projects.core)
+    implementation(projects.domain)
+    implementation(projects.core.onboarding)
+    implementation(projects.core.designsystem)
+    implementation(projects.core.analytics)
+    implementation(projects.core.navigation)
+
+    implementation(libs.androidx.core.ktx)
+    implementation(libs.androidx.appcompat)
+    implementation(libs.material)
+    implementation(libs.kotlinx.collections.immutable)
+{{SERIALIZATION_DEP_LINE}}
+    implementation(libs.coil.compose)
+    implementation(libs.timber)
+
+    testImplementation(libs.kotlinx.coroutines.test)
+}

--- a/.agents/skills/create-feature-module/references/proguard-rules.pro.tmpl
+++ b/.agents/skills/create-feature-module/references/proguard-rules.pro.tmpl
@@ -1,0 +1,21 @@
+# Add project specific ProGuard rules here.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
+#
+# For more details, see
+#   http://developer.android.com/guide/developing/tools/proguard.html
+
+# If your project uses WebView with JS, uncomment the following
+# and specify the fully qualified class name to the JavaScript interface
+# class:
+#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
+#   public *;
+#}
+
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+#-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile

--- a/.agents/skills/create-feature-module/references/strings.xml.tmpl
+++ b/.agents/skills/create-feature-module/references/strings.xml.tmpl
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+</resources>

--- a/.agents/skills/create-repository/SKILL.md
+++ b/.agents/skills/create-repository/SKILL.md
@@ -81,7 +81,7 @@ Use Edit anchored on `import javax.inject.Singleton` so the placement is determi
 
 ### 3b. Add the `@Binds` method
 
-Anchor on the **last `@Binds` method's closing line** in the file and insert a new block immediately after it. The current file ends like:
+Anchor on the **last `@Binds` method's closing line** in the file and insert a new block immediately after it. **Read the file first to find the actual last method — do not assume `bindsCallvanRepository` is still last, since this skill itself appends new methods on each run.** As of writing the file ends like:
 
 ```kotlin
     @Binds

--- a/.agents/skills/create-repository/SKILL.md
+++ b/.agents/skills/create-repository/SKILL.md
@@ -30,7 +30,7 @@ Extract the **noun** as `<Name>`:
 
 - Strip a trailing `Repository` if the user typed it (`LibraryRepository` → `Library`).
 - Strip a leading `feature/` if the user typed it (`feature/library` → `library`).
-- Convert to **PascalCase**: `library` → `Library`, `reservation_v2` → `ReservationV2`, `lostandfound` → `Lostandfound` (KOIN treats compound names as single token — see `domain/repository/CoopShopRepository.kt` vs imaginary `Lostandfound...`). When unsure, look at neighbours in `domain/repository/` to confirm casing convention.
+- Convert to **multi-word PascalCase**: `library` → `Library`, `reservation_v2` → `ReservationV2`, `lost-and-found` / `lostAndFound` → `LostAndFound`, `coop-shop` → `CoopShop` (see `domain/repository/CoopShopRepository.kt`, `OwnerChangePasswordRepository.kt`). If the input is a single concatenated token like `lostandfound` with no word boundaries, ask one short clarification rather than guessing — KOIN repositories all use multi-word PascalCase, so `Lostandfound` would be wrong.
 
 If the resulting `<Name>` is ambiguous (e.g., user gives "owner change password"), state the proposed name and ask once before writing.
 

--- a/.agents/skills/create-repository/SKILL.md
+++ b/.agents/skills/create-repository/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: create-repository
+description: Scaffold a new KOIN Repository — domain `<Name>Repository` interface, data `<Name>RepositoryImpl` class with `@Inject constructor()`, and the corresponding `@Binds` entry in `data/.../di/repository/BindsRepositoryModule.kt`. Use whenever the user asks to add a Repository, create a Repository pair, "domain interface + data impl + Hilt 바인딩", or "repository 만들어줘" (e.g. "Library Repository 만들어줘", "create LibraryRepository", "/create-repository Library", "domain 에 인터페이스 + data 에 impl + Hilt 등록"). Trigger this skill even when the user does not say "skill" — any request that boils down to "new Repository in the KOIN clean-architecture stack" should use it. Defaults to the modern `@Binds` DI style (BindsRepositoryModule), not the legacy `@Provides` (RepositoryModule). Does NOT generate data sources, API services, mappers, domain models, or use cases — those are out of scope and require their own follow-up scaffolding.
+---
+
+# Role
+
+You are the dedicated **KOIN Repository scaffolder**. Given a feature noun (e.g. `Library`, `Reservation`, `Menu`), produce a three-piece change that compiles cleanly:
+
+1. `domain/src/main/java/in/koreatech/koin/domain/repository/<Name>Repository.kt` — interface
+2. `data/src/main/java/in/koreatech/koin/data/repository/<Name>RepositoryImpl.kt` — class
+3. One added `@Binds` method (plus 2 imports) in `data/src/main/java/in/koreatech/koin/data/di/repository/BindsRepositoryModule.kt`
+
+Do **not** create methods, data-source dependencies, mappers, request DTOs, response DTOs, domain models, or use cases. The user adds those separately (or via other skills) once the repository contract is being filled in.
+
+# Why this exists
+
+KOIN already has 35 domain repository interfaces and 30 data impls. Each new pair is a tiny but error-prone copy-paste: get the package backticks right, get the `@Inject constructor()` right, register the Hilt binding in the right module out of two competing modules, keep import order ktlint-clean. This skill removes the rote.
+
+# Inputs
+
+The user's invocation typically looks like:
+
+- `/create-repository Library` — name positional
+- "Library Repository 만들어줘"
+- "create LibraryRepository in domain and the impl in data with Hilt binding"
+- "신규 repository 추가: 이름은 reservation"
+
+Extract the **noun** as `<Name>`:
+
+- Strip a trailing `Repository` if the user typed it (`LibraryRepository` → `Library`).
+- Strip a leading `feature/` if the user typed it (`feature/library` → `library`).
+- Convert to **PascalCase**: `library` → `Library`, `reservation_v2` → `ReservationV2`, `lostandfound` → `Lostandfound` (KOIN treats compound names as single token — see `domain/repository/CoopShopRepository.kt` vs imaginary `Lostandfound...`). When unsure, look at neighbours in `domain/repository/` to confirm casing convention.
+
+If the resulting `<Name>` is ambiguous (e.g., user gives "owner change password"), state the proposed name and ask once before writing.
+
+# DI Style — always `@Binds`, never `@Provides`
+
+The repo has two co-existing DI modules:
+
+- `BindsRepositoryModule.kt` — modern `@Binds` style (37 lines, holds 4 newest repos: Callvan, Timetable, Bus, FirebaseMessaging).
+- `RepositoryModule.kt` — legacy `@Provides` style (308 lines, holds the bulk of historical repos).
+
+**New repositories MUST be added to `BindsRepositoryModule.kt`.** The `@Provides` form was historically used because the codebase predates `@Binds`-friendly impls; it is no longer the preferred path and produces noisier code. Do not even ask the user.
+
+# Workflow
+
+## Step 1 — Validate the name
+
+1. Compute `<Name>` in PascalCase.
+2. Run two parallel Greps to confirm uniqueness:
+   - `Grep` for `interface <Name>Repository` under `domain/src/main/java/in/koreatech/koin/domain/repository/`
+   - `Grep` for `class <Name>RepositoryImpl` under `data/src/main/java/in/koreatech/koin/data/repository/`
+3. If either exists, refuse and report which file already has it. Do not overwrite.
+
+## Step 2 — Write the interface and impl (parallel Writes)
+
+Render both files in a single message:
+
+| Path | Source |
+|---|---|
+| `domain/src/main/java/in/koreatech/koin/domain/repository/<Name>Repository.kt` | `references/Repository.kt.tmpl` with `{{NAME}}` substituted |
+| `data/src/main/java/in/koreatech/koin/data/repository/<Name>RepositoryImpl.kt` | `references/RepositoryImpl.kt.tmpl` with `{{NAME}}` substituted |
+
+Both files use backtick-escaped `in` in the package declaration (per CLAUDE.md). Do not skip the backticks — `in` is a Kotlin keyword.
+
+## Step 3 — Register the Hilt binding (Edit, not Write)
+
+Edit `data/src/main/java/in/koreatech/koin/data/di/repository/BindsRepositoryModule.kt` with **two surgical edits**, then let ktlint reorder imports.
+
+### 3a. Add two imports
+
+The existing import block is alphabetically ordered. Append both new lines anywhere in the import block (the simplest is right before `import javax.inject.Singleton`) — `:data:ktlintFormat` will reorder them later.
+
+```kotlin
+import `in`.koreatech.koin.data.repository.<Name>RepositoryImpl
+import `in`.koreatech.koin.domain.repository.<Name>Repository
+```
+
+Use Edit anchored on `import javax.inject.Singleton` so the placement is deterministic.
+
+### 3b. Add the `@Binds` method
+
+Anchor on the **last `@Binds` method's closing line** in the file and insert a new block immediately after it. The current file ends like:
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun bindsCallvanRepository(callvanRepositoryImpl: CallvanRepositoryImpl): CallvanRepository
+}
+```
+
+Insert before the final `}`:
+
+```kotlin
+
+    @Binds
+    @Singleton
+    abstract fun binds<Name>Repository(<name>RepositoryImpl: <Name>RepositoryImpl): <Name>Repository
+```
+
+Where `<name>` is `<Name>` with the **first letter lowercased** (parameter name convention in this file: `callvanRepositoryImpl`, `busV2RepositoryImpl`, `timetableRepositoryImpl`).
+
+The method format is **single-line signature** when it fits on one line (mirrors `bindsTimetableRepository`, `bindsBusV2Repository`, `bindsCallvanRepository`). If the line exceeds ktlint's max width, fall back to the multi-line form (mirrors `bindsFirebaseMessagingRepository`):
+
+```kotlin
+    @Binds
+    @Singleton
+    abstract fun binds<Name>Repository(
+        <name>RepositoryImpl: <Name>RepositoryImpl
+    ): <Name>Repository
+```
+
+### 3c. Idempotency
+
+Before applying 3a and 3b, Grep `BindsRepositoryModule.kt` for `binds<Name>Repository`. If present, skip both edits and report.
+
+## Step 4 — Format
+
+Run:
+
+```bash
+./gradlew :data:ktlintFormat -q
+```
+
+This fixes import order in `BindsRepositoryModule.kt` (your appended imports are inserted near `javax.inject.Singleton`; ktlint will move them into alphabetical position). It also formats the new files.
+
+If ktlintFormat fails, the scaffold has a syntax issue — fix it and rerun. Do not commit broken code.
+
+## Step 5 — Verify the build graph
+
+```bash
+./gradlew :data:assembleDebug -q
+```
+
+Hilt processes `@Binds` at compile time, so this proves the binding is well-formed (the impl is `@Inject`-able, return type matches the interface, no duplicate binding). If you see `[Dagger/DuplicateBindings]`, you accidentally registered a binding that already exists in `RepositoryModule.kt` — investigate the legacy module before retrying.
+
+# Output to the user
+
+Concise checklist after success:
+
+```
+✅ <Name>Repository 생성 완료
+
+생성된 파일:
+- domain/src/main/java/in/koreatech/koin/domain/repository/<Name>Repository.kt
+- data/src/main/java/in/koreatech/koin/data/repository/<Name>RepositoryImpl.kt
+
+수정된 파일:
+- data/.../di/repository/BindsRepositoryModule.kt
+  - import: <Name>RepositoryImpl, <Name>Repository
+  - @Binds: binds<Name>Repository(...)
+
+검증:
+- :data:ktlintFormat   ✅
+- :data:assembleDebug  ✅
+
+다음:
+- 인터페이스에 suspend fun 시그니처 추가 (실패 가능 호출은 Result<T>)
+- Impl 의 @Inject constructor() 에 RemoteDataSource / LocalDataSource 주입
+- mapper, request/response DTO, 도메인 모델은 별도 작업
+```
+
+# What NOT to do
+
+- Do NOT add methods to the interface. The TODO comment is the spec — user fills in.
+- Do NOT add constructor dependencies to the Impl. Empty constructor is the spec; user injects data sources after creating them.
+- Do NOT touch `RepositoryModule.kt`. Even if the user explicitly asks for `@Provides` style, refuse and explain `@Binds` is the chosen direction (mention all 4 recent repos used `@Binds`).
+- Do NOT create RemoteDataSource, LocalDataSource, API service, or any DTOs. Those are separate concerns with their own scaffolding paths.
+- Do NOT create domain models or use cases. Those are wired separately.
+- Do NOT commit. Stop after `assembleDebug`.
+
+# Reference files
+
+- `references/Repository.kt.tmpl` — domain interface skeleton
+- `references/RepositoryImpl.kt.tmpl` — data impl skeleton
+
+The `BindsRepositoryModule.kt` edit is described inline above (no separate template — it's a 2-import + 1-method surgical insert).

--- a/.agents/skills/create-repository/SKILL.md
+++ b/.agents/skills/create-repository/SKILL.md
@@ -15,7 +15,7 @@ Do **not** create methods, data-source dependencies, mappers, request DTOs, resp
 
 # Why this exists
 
-KOIN already has 35 domain repository interfaces and 30 data impls. Each new pair is a tiny but error-prone copy-paste: get the package backticks right, get the `@Inject constructor()` right, register the Hilt binding in the right module out of two competing modules, keep import order ktlint-clean. This skill removes the rote.
+KOIN already has 31 domain repository interfaces and 31 data impls. Each new pair is a tiny but error-prone copy-paste: get the package backticks right, get the `@Inject constructor()` right, register the Hilt binding in the right module out of two competing modules, keep import order ktlint-clean. This skill removes the rote.
 
 # Inputs
 
@@ -99,9 +99,9 @@ Insert before the final `}`:
     abstract fun binds<Name>Repository(<name>RepositoryImpl: <Name>RepositoryImpl): <Name>Repository
 ```
 
-Where `<name>` is `<Name>` with the **first letter lowercased** (parameter name convention in this file: `callvanRepositoryImpl`, `busV2RepositoryImpl`, `timetableRepositoryImpl`).
+Where `<name>` is `<Name>` with the **first letter lowercased** (parameter name convention in this file: `callvanRepositoryImpl`, `timetableRepositoryImpl`). Note: `bindsBusV2Repository` is an outlier — its parameter is named `busV2RepositoryImpl` even though the impl class is `BusRepositoryImpl` (a leftover from an incomplete `v2` → `Bus` rename). Do not mirror this anomaly; follow the rule against `<Name>`, not the bus example.
 
-The method format is **single-line signature** when it fits on one line (mirrors `bindsTimetableRepository`, `bindsBusV2Repository`, `bindsCallvanRepository`). If the line exceeds ktlint's max width, fall back to the multi-line form (mirrors `bindsFirebaseMessagingRepository`):
+The method format is **single-line signature** when it fits on one line (mirrors `bindsTimetableRepository`, `bindsCallvanRepository`). If the line exceeds ktlint's max width, fall back to the multi-line form (mirrors `bindsFirebaseMessagingRepository`):
 
 ```kotlin
     @Binds

--- a/.agents/skills/create-repository/evals/evals.json
+++ b/.agents/skills/create-repository/evals/evals.json
@@ -1,0 +1,29 @@
+{
+  "skill_name": "create-repository",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Library Repository 만들어줘",
+      "expected_output": "domain/src/main/java/in/koreatech/koin/domain/repository/LibraryRepository.kt 생성 (interface, TODO 주석만). data/src/main/java/in/koreatech/koin/data/repository/LibraryRepositoryImpl.kt 생성 (class @Inject constructor() : LibraryRepository). BindsRepositoryModule.kt 에 import 2줄 + @Binds @Singleton abstract fun bindsLibraryRepository(...) 추가. :data:assembleDebug 통과.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "/create-repository ReservationRepository",
+      "expected_output": "트레일링 'Repository' 자동 제거 → Reservation 으로 정규화. ReservationRepository / ReservationRepositoryImpl 생성. 동일 검증.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "callvan repository 새로 만들어줘",
+      "expected_output": "이미 CallvanRepository 가 domain 에 존재하므로 거부. Grep 결과 명시. 기존 파일 덮어쓰지 않음.",
+      "files": []
+    },
+    {
+      "id": 4,
+      "prompt": "MenuRepository 만들어줘. 그리고 RepositoryModule (Provides) 에 등록해. BindsRepositoryModule 말고.",
+      "expected_output": "사용자가 @Provides 를 명시 요청해도 거부. @Binds 가 KOIN 의 채택된 방향임을 설명 (callvan/timetable/bus/firebase 4개 최근 모두 @Binds). BindsRepositoryModule.kt 에 등록.",
+      "files": []
+    }
+  ]
+}

--- a/.agents/skills/create-repository/references/Repository.kt.tmpl
+++ b/.agents/skills/create-repository/references/Repository.kt.tmpl
@@ -1,0 +1,5 @@
+package `in`.koreatech.koin.domain.repository
+
+interface {{NAME}}Repository {
+    // TODO: declare suspend functions. Failable calls return Result<T>.
+}

--- a/.agents/skills/create-repository/references/RepositoryImpl.kt.tmpl
+++ b/.agents/skills/create-repository/references/RepositoryImpl.kt.tmpl
@@ -1,0 +1,6 @@
+package `in`.koreatech.koin.data.repository
+
+import `in`.koreatech.koin.domain.repository.{{NAME}}Repository
+import javax.inject.Inject
+
+class {{NAME}}RepositoryImpl @Inject constructor() : {{NAME}}Repository

--- a/.claude/skills/create-api-endpoint
+++ b/.claude/skills/create-api-endpoint
@@ -1,0 +1,1 @@
+../../.agents/skills/create-api-endpoint

--- a/.claude/skills/create-feature-module
+++ b/.claude/skills/create-feature-module
@@ -1,0 +1,1 @@
+../../.agents/skills/create-feature-module

--- a/.claude/skills/create-repository
+++ b/.claude/skills/create-repository
@@ -1,0 +1,1 @@
+../../.agents/skills/create-repository

--- a/.codex/skills/create-api-endpoint
+++ b/.codex/skills/create-api-endpoint
@@ -1,0 +1,1 @@
+../../.agents/skills/create-api-endpoint

--- a/.codex/skills/create-feature-module
+++ b/.codex/skills/create-feature-module
@@ -1,0 +1,1 @@
+../../.agents/skills/create-feature-module

--- a/.codex/skills/create-repository
+++ b/.codex/skills/create-repository
@@ -1,0 +1,1 @@
+../../.agents/skills/create-repository


### PR DESCRIPTION
## PR 개요
- closes: #1436 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
- create-feature-module skill을 추가했습니다.
    - 기본 템플릿에 맞춰 신규 feature 모듈을 생성합니다. kotlinx.serialization은 optional입니다.
- create-repository skill을 추가했습니다.
    - Repository, RepositoryImpl 및 Hilt Binds 등록까지 진행합니다.
- create-api-endpoint skill을 추가했습니다.
    - OpenAPI spec을 fetch해서 사용자가 요청한 API를 추가합니다.
    - RemoteDataSource, Repository에 함수를 추가하고, Repository가 없다면 create-repository skill을 호출합니다.
    - 문서화 이슈로 Auth/NoAuth 여부는 사용자에게 질문합니다.
- 모든 skills는 `.agents/skills` 경로에 있으며, `.claude` 및 `.codex` 경로는 symlink를 추가했습니다.

### 논의 사항
X
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Documentation**
  * API 엔드포인트 스캐폴딩 스킬 문서·템플릿·검증 케이스 추가 — Retrofit API, 요청/응답 DTO, 매퍼, 원격 데이터소스, 리포지토리 패턴, 예외 매핑 및 검증 워크플로우 포함
  * 기능 모듈 생성 스킬 문서·템플릿·검증 케이스 추가 — 모듈 구조·빌드/포맷 검증 및 가이드라인 포함
  * 리포지토리 생성 스킬 문서·템플릿·검증 케이스 추가 — 인터페이스/구현 및 DI 등록 규칙 문서화

* **Chores**
  * 스킬 참조 포인터 파일들 업데이트 및 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->