### PR TITLE
[Feature] 분실물 키워드 관리 화면에 비로그인 사용자용 로그인 유도 다이얼로그 추가

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LoginDialog.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/component/LoginDialog.kt
@@ -1,4 +1,4 @@
-package `in`.koreatech.koin.feature.lostandfound.ui.list.component
+package `in`.koreatech.koin.feature.lostandfound.component
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -146,9 +146,19 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     }
 
     composable<LostAndFoundNavType.LostAndFoundKeywordRoute> {
+        val navigator = rememberNavigator()
+        val context = LocalContext.current
         LostAndFoundKeyword(
             viewModel = hiltViewModel(),
-            onBackClick = { navController.popBackStack() }
+            onBackClick = { navController.popBackStack() },
+            navigateToLogin = {
+                navigator.navigateToSignIn(
+                    context = context,
+                    redirectUrl = DEEP_LINK_LOST_AND_FOUND_BASE
+                ).apply {
+                    context.startActivity(this)
+                }
+            }
         )
     }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -57,6 +57,7 @@ import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundAddableChipFlowGroup
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundDeletableChipFlowGroup
+import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LoginDialog
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -69,6 +70,7 @@ private val ButtonShape = RoundedCornerShape(4.dp)
 @Composable
 fun LostAndFoundKeyword(
     onBackClick: () -> Unit,
+    navigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: LostAndFoundKeywordViewModel = hiltViewModel()
 ) {
@@ -90,6 +92,19 @@ fun LostAndFoundKeyword(
 
     BackHandler {
         onBackClick()
+    }
+
+    // 비로그인 다이얼로그
+    if (uiState.showLoginDialog) {
+        LoginDialog(
+            title = stringResource(R.string.recommend_login_to_get_keyword_notification_title),
+            description = stringResource(R.string.recommend_login_to_get_keyword_notification_message),
+            onPositive = {
+                navigateToLogin()
+                viewModel.dismissLoginDialog()
+            },
+            onNegative = viewModel::dismissLoginDialog
+        )
     }
 
     // Article keyword 화면처럼, 이미 등록된 키워드는 추천 키워드에서 제거

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeyword.kt
@@ -55,9 +55,9 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
+import `in`.koreatech.koin.feature.lostandfound.component.LoginDialog
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundAddableChipFlowGroup
 import `in`.koreatech.koin.feature.lostandfound.component.LostAndFoundDeletableChipFlowGroup
-import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LoginDialog
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
@@ -11,6 +11,7 @@ data class LostAndFoundKeywordState(
     val isNotificationEnabled: Boolean = false,
     val isLoading: Boolean = false,
     val suggestedKeywords: ImmutableList<String> = persistentListOf(),
+    val isLoginStatusLoaded: Boolean = false,
     val isLoggedIn: Boolean = false,
     val showLoginDialog: Boolean = false
 )

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordState.kt
@@ -10,5 +10,7 @@ data class LostAndFoundKeywordState(
     val keywordInput: String = "",
     val isNotificationEnabled: Boolean = false,
     val isLoading: Boolean = false,
-    val suggestedKeywords: ImmutableList<String> = persistentListOf()
+    val suggestedKeywords: ImmutableList<String> = persistentListOf(),
+    val isLoggedIn: Boolean = false,
+    val showLoginDialog: Boolean = false
 )

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
@@ -52,9 +52,12 @@ class LostAndFoundKeywordViewModel @Inject constructor(
     private fun observeUserStatus() = intent {
         repeatOnSubscription {
             getUserStatusUseCase()
-                .catch { reduce { state.copy(isLoggedIn = false) } }
+                .catch { e ->
+                    Timber.e(e, "로그인 상태 관찰 실패")
+                    reduce { state.copy(isLoggedIn = false, isLoginStatusLoaded = true) }
+                }
                 .collect { user ->
-                    reduce { state.copy(isLoggedIn = !user.isAnonymous) }
+                    reduce { state.copy(isLoggedIn = !user.isAnonymous, isLoginStatusLoaded = true) }
                 }
         }
     }
@@ -99,6 +102,7 @@ class LostAndFoundKeywordViewModel @Inject constructor(
 
     fun addKeyword(keyword: String) {
         intent {
+            if (!state.isLoginStatusLoaded) return@intent
             if (!state.isLoggedIn) {
                 reduce { state.copy(showLoginDialog = true) }
                 return@intent
@@ -149,6 +153,7 @@ class LostAndFoundKeywordViewModel @Inject constructor(
 
     fun toggleNotification(isEnabled: Boolean) {
         intent {
+            if (!state.isLoginStatusLoaded) return@intent
             if (!state.isLoggedIn) {
                 reduce { state.copy(showLoginDialog = true) }
                 return@intent

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/keyword/LostAndFoundKeywordViewModel.kt
@@ -10,6 +10,7 @@ import `in`.koreatech.koin.domain.usecase.article.lostandfound.SaveLostItemKeywo
 import `in`.koreatech.koin.domain.usecase.notification.DeleteNotificationSubscriptionUseCase
 import `in`.koreatech.koin.domain.usecase.notification.GetNotificationPermissionInfoUseCase
 import `in`.koreatech.koin.domain.usecase.notification.UpdateNotificationSubscriptionUseCase
+import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.lostandfound.R
 import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
@@ -24,7 +25,7 @@ import org.orbitmvi.orbit.syntax.simple.repeatOnSubscription
 import org.orbitmvi.orbit.viewmodel.container
 import timber.log.Timber
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "TooManyFunctions")
 @HiltViewModel
 class LostAndFoundKeywordViewModel @Inject constructor(
     private val fetchLostItemKeywordUseCase: FetchLostItemKeywordUseCase,
@@ -33,7 +34,8 @@ class LostAndFoundKeywordViewModel @Inject constructor(
     private val fetchLostItemKeywordSuggestionsUseCase: FetchLostItemKeywordSuggestionsUseCase,
     private val updateNotificationSubscriptionUseCase: UpdateNotificationSubscriptionUseCase,
     private val deleteNotificationSubscriptionUseCase: DeleteNotificationSubscriptionUseCase,
-    private val getNotificationPermissionInfoUseCase: GetNotificationPermissionInfoUseCase
+    private val getNotificationPermissionInfoUseCase: GetNotificationPermissionInfoUseCase,
+    private val getUserStatusUseCase: GetUserStatusUseCase
 ) : ViewModel(), ContainerHost<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect> {
 
     override val container = container<LostAndFoundKeywordState, LostAndFoundKeywordSideEffect>(
@@ -41,9 +43,20 @@ class LostAndFoundKeywordViewModel @Inject constructor(
     )
 
     init {
+        observeUserStatus()
         observeKeywords()
         fetchSuggestedKeywords()
         loadNotificationState()
+    }
+
+    private fun observeUserStatus() = intent {
+        repeatOnSubscription {
+            getUserStatusUseCase()
+                .catch { reduce { state.copy(isLoggedIn = false) } }
+                .collect { user ->
+                    reduce { state.copy(isLoggedIn = !user.isAnonymous) }
+                }
+        }
     }
 
     private fun observeKeywords() = intent {
@@ -86,6 +99,10 @@ class LostAndFoundKeywordViewModel @Inject constructor(
 
     fun addKeyword(keyword: String) {
         intent {
+            if (!state.isLoggedIn) {
+                reduce { state.copy(showLoginDialog = true) }
+                return@intent
+            }
             if (state.isLoading) return@intent
 
             val validationError = validateKeyword(keyword)
@@ -132,6 +149,10 @@ class LostAndFoundKeywordViewModel @Inject constructor(
 
     fun toggleNotification(isEnabled: Boolean) {
         intent {
+            if (!state.isLoggedIn) {
+                reduce { state.copy(showLoginDialog = true) }
+                return@intent
+            }
             if (state.isLoading) return@intent
 
             reduce { state.copy(isLoading = true, isNotificationEnabled = isEnabled) }
@@ -147,6 +168,10 @@ class LostAndFoundKeywordViewModel @Inject constructor(
                 reduce { state.copy(isLoading = false) }
             }
         }
+    }
+
+    fun dismissLoginDialog() = intent {
+        reduce { state.copy(showLoginDialog = false) }
     }
 
     private fun validateKeyword(keyword: String): Int? = when {

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/list/LostAndFoundList.kt
@@ -28,11 +28,11 @@ import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.lostandfound.R
+import `in`.koreatech.koin.feature.lostandfound.component.LoginDialog
 import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.ItemSearchTextField
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.KeywordNotificationRow
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.ListColumn
-import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LoginDialog
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundChip
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFAB
 import `in`.koreatech.koin.feature.lostandfound.ui.list.component.LostAndFoundFABBottomSheet

--- a/feature/lostandfound/src/main/res/values/strings.xml
+++ b/feature/lostandfound/src/main/res/values/strings.xml
@@ -182,7 +182,7 @@
     <string name="downloading">다운로드 중</string>
     <string name="start_download">파일을 다운로드합니다.</string>
     <string name="recommend_login_to_get_keyword_notification_title">키워드 알림을 받으려면\n로그인이 필요해요.</string>
-    <string name="recommend_login_to_get_keyword_notification_message">로그인 후 간편하게 공지사항 키워드\n알림을 받아보세요!</string>
+    <string name="recommend_login_to_get_keyword_notification_message">로그인 후 간편하게 분실물 키워드\n알림을 받아보세요!</string>
     <string name="title_article">게시판</string>
     <string name="navigation_title_article">공지사항</string>
     <string name="navigation_title_article_search">공지글 검색</string>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1442

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 신규 기능
- [ ] 버그 수정
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 분실물 키워드 관리 화면(`LostAndFoundKeyword`)에서 비로그인 상태일 때 키워드 관련 기능(알림 토글, 키워드 추가) 사용 시 로그인 유도 다이얼로그를 표시하도록 구현했습니다.
- `LostAndFoundKeywordViewModel`에 `GetUserStatusUseCase`를 주입하여 로그인 상태를 감시하고, `LostAndFoundKeywordState`에 `isLoggedIn`, `showLoginDialog` 상태 필드를 추가했습니다.
- `addKeyword` 및 `toggleNotification` 함수에 비로그인 사용자 체크 로직을 추가하여, 비로그인 시 `LoginDialog`를 표시하고 `dismissLoginDialog()` 함수로 상태를 관리합니다.
- `LostAndFoundKeyword` composable에 `LoginDialog` 렌더링 로직을 추가했으며, `Navigation.kt`의 `LostAndFoundKeywordRoute`에서 로그인 화면으로 이동하는 `navigateToLogin` 콜백을 전달하도록 수정했습니다.
- `feature/lostandfound/src/main/res/values/strings.xml` 파일의 `recommend_login_to_get_keyword_notification_message` 문자열을 "분실물"에 맞게 수정했습니다.
- 코드 리뷰 피드백을 반영하여 detekt `TooManyFunctions` 이슈를 `@Suppress`로 해결하고, 로그인 상태 체크 로직을 간결하게 개선했습니다.

### 논의 사항
- 기존 `LoginDialog` 컴포넌트와 `GetUserStatusUseCase`를 재사용하여 효율적으로 기능을 구현했습니다.
- Orbit MVI 패턴의 `repeatOnSubscription`을 사용하여 Flow 구독 로직을 생명주기 안전하게 처리했습니다.

### 스크린샷
비로그인 사용자가 키워드 관련 기능을 사용하려고 할 때 로그인 유도 다이얼로그가 표시됩니다.

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 분실물 키워드 관련 동작에서 로그인 상태를 확인하고, 미로그인 시 로그인 화면으로 이동하는 흐름을 추가
  * 로그인 유도 다이얼로그의 확인 동작으로 로그인 이동을 트리거하도록 연결

* **개선사항**
  * 로그인 권장 문구를 '분실물 키워드 알림'으로 정확하게 변경
  * 로그인 상태 로딩 및 표시 제어로 사용자 경험 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1443)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->