### PR TITLE
[Feature] 콜벤 모집글 연속 클릭 시 중복 생성 방지

### DIFF
--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
@@ -160,7 +160,7 @@ class CallvanCreateViewModel @Inject constructor(
     @Suppress("CognitiveComplexMethod")
     fun submit() = intent {
         val currentState = state
-        if (!currentState.isFormComplete || currentState.isSubmitting) return@intent
+        if (!currentState.isFormComplete) return@intent
         if (currentState.departureLocation == null || currentState.arrivalLocation == null) return@intent
 
         if (currentState.restriction.isRestricted) {
@@ -176,7 +176,17 @@ class CallvanCreateViewModel @Inject constructor(
             return@intent
         }
 
-        reduce { state.copy(isSubmitting = true) }
+        // check와 set을 하나의 reduce 로 처리해 중복 호출 방지 보장
+        var canProceed = false
+        reduce {
+            if (state.isSubmitting) {
+                state
+            } else {
+                canProceed = true
+                state.copy(isSubmitting = true)
+            }
+        }
+        if (!canProceed) return@intent
         createCallvanPostUseCase(
             departureType = currentState.departureLocation.name,
             departureCustomName = if (currentState.departureLocation == CallvanLocationOption.CUSTOM) {

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/create/CallvanCreateViewModel.kt
@@ -14,6 +14,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import javax.inject.Inject
+import kotlinx.coroutines.sync.Mutex
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
@@ -32,6 +33,8 @@ class CallvanCreateViewModel @Inject constructor(
     override val container: Container<CallvanCreateState, CallvanCreateSideEffect> = container(
         CallvanCreateState()
     )
+
+    private val submitMutex = Mutex()
 
     fun openDepartureLocationPicker() = blockingIntent {
         reduce { state.copy(isLocationPickerVisible = true, isPickingDeparture = true) }
@@ -176,45 +179,39 @@ class CallvanCreateViewModel @Inject constructor(
             return@intent
         }
 
-        // check와 set을 하나의 reduce 로 처리해 중복 호출 방지 보장
-        var canProceed = false
-        reduce {
-            if (state.isSubmitting) {
-                state
-            } else {
-                canProceed = true
-                state.copy(isSubmitting = true)
+        if (!submitMutex.tryLock()) return@intent
+        reduce { state.copy(isSubmitting = true) }
+        try {
+            createCallvanPostUseCase(
+                departureType = currentState.departureLocation.name,
+                departureCustomName = if (currentState.departureLocation == CallvanLocationOption.CUSTOM) {
+                    currentState.departureCustomText
+                } else {
+                    null
+                },
+                arrivalType = currentState.arrivalLocation.name,
+                arrivalCustomName = if (currentState.arrivalLocation == CallvanLocationOption.CUSTOM) {
+                    currentState.arrivalCustomText
+                } else {
+                    null
+                },
+                departureDate = currentState.apiDepartureDate,
+                departureTime = currentState.apiDepartureTime,
+                maxParticipants = currentState.maxParticipants
+            ).onSuccess {
+                postSideEffect(CallvanCreateSideEffect.NavigateToMain)
+            }.onFailure { error ->
+                val errorType = when (error) {
+                    is KoinCallvanException.InvalidRequestBodyException -> SubmitErrorType.INVALID_REQUEST_BODY
+                    is KoinCallvanException.InvalidCustomLocationNameException -> SubmitErrorType.INVALID_CUSTOM_LOCATION_NAME
+                    is KoinCallvanException.NotFoundUserException -> SubmitErrorType.NOT_FOUND_USER
+                    else -> SubmitErrorType.UNKNOWN
+                }
+                postSideEffect(CallvanCreateSideEffect.ShowSubmitError(errorType))
             }
-        }
-        if (!canProceed) return@intent
-        createCallvanPostUseCase(
-            departureType = currentState.departureLocation.name,
-            departureCustomName = if (currentState.departureLocation == CallvanLocationOption.CUSTOM) {
-                currentState.departureCustomText
-            } else {
-                null
-            },
-            arrivalType = currentState.arrivalLocation.name,
-            arrivalCustomName = if (currentState.arrivalLocation == CallvanLocationOption.CUSTOM) {
-                currentState.arrivalCustomText
-            } else {
-                null
-            },
-            departureDate = currentState.apiDepartureDate,
-            departureTime = currentState.apiDepartureTime,
-            maxParticipants = currentState.maxParticipants
-        ).onSuccess {
+        } finally {
+            submitMutex.unlock()
             reduce { state.copy(isSubmitting = false) }
-            postSideEffect(CallvanCreateSideEffect.NavigateToMain)
-        }.onFailure { error ->
-            reduce { state.copy(isSubmitting = false) }
-            val errorType = when (error) {
-                is KoinCallvanException.InvalidRequestBodyException -> SubmitErrorType.INVALID_REQUEST_BODY
-                is KoinCallvanException.InvalidCustomLocationNameException -> SubmitErrorType.INVALID_CUSTOM_LOCATION_NAME
-                is KoinCallvanException.NotFoundUserException -> SubmitErrorType.NOT_FOUND_USER
-                else -> SubmitErrorType.UNKNOWN
-            }
-            postSideEffect(CallvanCreateSideEffect.ShowSubmitError(errorType))
         }
     }
 }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1445

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
`submit()` 을 연속으로 클릭하면 Orbit MVI `intent {}` 가 동시에 여러 개 실행될 수 있어, 두 번째 intent 가 첫 번째 intent 의 `reduce { isSubmitting = true }` 실행 전에 state 를 읽어 중복 API 호출이 발생하는 race condition 을 수정했습니다.

`isSubmitting` 의 check 와 set 을 단일 `reduce {}` 블록 안으로 이동해 원자적으로 처리합니다. `reduce` 는 순차 실행이 보장되므로 첫 번째 intent 만 `canProceed = true` 를 얻고, 이후 중복 호출은 즉시 return 합니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 제출 동작의 중복 실행을 근본 차단하도록 개선해 안정성이 향상되었습니다.
  * 제출 중 상태 관리가 정교화되어 완료 후 상태가 올바르게 해제됩니다.
  * 제출 성공 시 정상 네비게이션 및 실패 시 오류 처리가 보다 일관되게 동작하도록 보완했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->