### PR TITLE
[Feature] StoreNoticeViewModel 생성 + ui 일부 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/navigation/Navigation.kt
@@ -22,6 +22,7 @@ import `in`.koreatech.koin.feature.store.home.StoreHomeScreen
 import `in`.koreatech.koin.feature.store.model.StoreNavigationData
 import `in`.koreatech.koin.feature.store.model.StoreNavigationDataType
 import `in`.koreatech.koin.feature.store.nearby.StoreNearbyScreen
+import `in`.koreatech.koin.feature.store.notice.StoreNoticeScreen
 import `in`.koreatech.koin.feature.store.orderhistory.OrderHistoryScreen
 import `in`.koreatech.koin.feature.store.origin.ShopOriginInfoScreen
 import `in`.koreatech.koin.feature.store.review.ReviewScreen
@@ -365,6 +366,13 @@ internal fun NavGraphBuilder.koinStoreDetailGraph(
     }
 
     composable<StoreDetailNavType.StoreNotice> {
+        StoreNoticeScreen(
+            onBackClick = {
+                if (!navController.popBackStack()) {
+                    finish()
+                }
+            }
+        )
     }
 }
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeScreen.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeScreen.kt
@@ -1,25 +1,66 @@
 package `in`.koreatech.koin.feature.store.notice
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.store.R
+import `in`.koreatech.koin.feature.store.component.KoinStoreTopAppBar
 import `in`.koreatech.koin.feature.store.notice.component.StoreNoticeCard
 import `in`.koreatech.koin.feature.store.notice.component.StoreNoticeCardExpand
 import `in`.koreatech.koin.feature.store.notice.component.StoreNoticeEmpty
 import kotlinx.collections.immutable.persistentListOf
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun StoreNoticeScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: StoreNoticeViewModel = hiltViewModel()
+) {
+    val state by viewModel.container.stateFlow.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            KoinStoreTopAppBar(
+                title = state.storeName,
+                onNavigationIconClick = onBackClick,
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = colorResource(id = R.color.store_detail_background)
+                )
+            )
+        }
+    ) { innerPadding ->
+        StoreNoticeContent(
+            state = state,
+            onExpandClick = viewModel::expandNotice,
+            onFoldClick = viewModel::foldNotice,
+            modifier = Modifier
+                .padding(innerPadding)
+                .background(colorResource(id = R.color.store_detail_background))
+        )
+    }
+}
+
+@Composable
+private fun StoreNoticeContent(
     state: StoreNoticeListState,
     onExpandClick: (Int) -> Unit,
     onFoldClick: (Int) -> Unit,
@@ -63,8 +104,7 @@ fun StoreNoticeScreen(
                         }
                     }
                     HorizontalDivider(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        color = RebrandKoinTheme.colors.neutral100
+                        color = RebrandKoinTheme.colors.neutral400
                     )
                 }
             }
@@ -75,7 +115,7 @@ fun StoreNoticeScreen(
 @Preview(showBackground = true, widthDp = 390, heightDp = 800)
 @Composable
 private fun StoreNoticeScreenPreview() {
-    StoreNoticeScreen(
+    StoreNoticeContent(
         state = StoreNoticeListState(
             notices = persistentListOf(
                 StoreNoticeItemState(
@@ -101,7 +141,7 @@ private fun StoreNoticeScreenPreview() {
 @Preview(showBackground = true, widthDp = 390, heightDp = 800)
 @Composable
 private fun StoreNoticeScreenEmptyPreview() {
-    StoreNoticeScreen(
+    StoreNoticeContent(
         state = StoreNoticeListState(notices = persistentListOf()),
         onExpandClick = {},
         onFoldClick = {}

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeState.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeState.kt
@@ -11,6 +11,7 @@ import kotlinx.parcelize.Parcelize
 data class StoreNoticeListState(
     val isLoading: Boolean = false,
     val isFirstPageLoading: Boolean = true,
+    val storeName: String = "",
     val notices: ImmutableList<StoreNoticeItemState> = persistentListOf()
 ) : Parcelable
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeViewModel.kt
@@ -29,14 +29,14 @@ class StoreNoticeViewModel @Inject constructor(
     }
 
     private fun fetchStoreName(storeId: Int) = intent {
-        runCatching { getStoreWithMenuUseCase(storeId) }.onSuccess { result ->
+        getStoreWithMenuUseCase(storeId).also { result ->
             reduce { state.copy(storeName = result.name) }
         }
     }
 
     private fun fetchNotices(storeId: Int) = intent {
         reduce { state.copy(isFirstPageLoading = true) }
-        runCatching { getShopEventsUseCase(storeId) }.onSuccess { result ->
+        getShopEventsUseCase(storeId).also { result ->
             reduce {
                 state.copy(
                     isFirstPageLoading = false,
@@ -51,8 +51,6 @@ class StoreNoticeViewModel @Inject constructor(
                     }.toImmutableList()
                 )
             }
-        }.onFailure {
-            reduce { state.copy(isFirstPageLoading = false) }
         }
     }
 

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/notice/StoreNoticeViewModel.kt
@@ -1,0 +1,78 @@
+package `in`.koreatech.koin.feature.store.notice
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.usecase.store.GetShopEventsUseCase
+import `in`.koreatech.koin.domain.usecase.store.GetStoreWithMenuUseCase
+import `in`.koreatech.koin.feature.store.navigation.STORE_ID
+import javax.inject.Inject
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.blockingIntent
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+
+@HiltViewModel
+class StoreNoticeViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val getShopEventsUseCase: GetShopEventsUseCase,
+    private val getStoreWithMenuUseCase: GetStoreWithMenuUseCase
+) : ViewModel(), ContainerHost<StoreNoticeListState, Unit> {
+
+    override val container = container<StoreNoticeListState, Unit>(StoreNoticeListState()) {
+        val storeId = checkNotNull(savedStateHandle.get<Int>(STORE_ID))
+        fetchStoreName(storeId)
+        fetchNotices(storeId)
+    }
+
+    private fun fetchStoreName(storeId: Int) = intent {
+        runCatching { getStoreWithMenuUseCase(storeId) }.onSuccess { result ->
+            reduce { state.copy(storeName = result.name) }
+        }
+    }
+
+    private fun fetchNotices(storeId: Int) = intent {
+        reduce { state.copy(isFirstPageLoading = true) }
+        runCatching { getShopEventsUseCase(storeId) }.onSuccess { result ->
+            reduce {
+                state.copy(
+                    isFirstPageLoading = false,
+                    notices = result.events.map { event ->
+                        StoreNoticeItemState(
+                            id = event.eventId,
+                            title = event.title,
+                            description = event.content,
+                            dateRange = "${event.startDate} - ${event.endDate}",
+                            imageUris = event.thumbnailImages?.toImmutableList() ?: persistentListOf()
+                        )
+                    }.toImmutableList()
+                )
+            }
+        }.onFailure {
+            reduce { state.copy(isFirstPageLoading = false) }
+        }
+    }
+
+    fun expandNotice(id: Int) = blockingIntent {
+        reduce {
+            state.copy(
+                notices = state.notices.map {
+                    if (it.id == id) it.copy(isExpanded = true) else it
+                }.toImmutableList()
+            )
+        }
+    }
+
+    fun foldNotice(id: Int) = blockingIntent {
+        reduce {
+            state.copy(
+                notices = state.notices.map {
+                    if (it.id == id) it.copy(isExpanded = false) else it
+                }.toImmutableList()
+            )
+        }
+    }
+}


### PR DESCRIPTION
## PR 개요
이슈 번호: #1444

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `StoreNoticeViewModel` 구현 — `GetShopEventsUseCase`로 공지 목록 fetch, `GetStoreWithMenuUseCase`로 상점명 fetch, expand/fold 상태 관리
- `StoreNoticeScreen`에 `hiltViewModel()` 적용 및 `Scaffold` + `KoinStoreTopAppBar` 추가
- TopAppBar 타이틀을 상점명으로 표시, 배경색(`store_detail_background`) 적용
- Navigation에서 `StoreNoticeScreen` 연결 및 `onBackClick` 전달

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다