### PR TITLE
[Feature] 앱 공통 알림 설정에 분실물 키워드 알림 항목 추가

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -150,7 +150,7 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
         val context = LocalContext.current
         LostAndFoundKeyword(
             viewModel = hiltViewModel(),
-            onBackClick = { navController.popBackStack() },
+            onBackClick = { if (!navController.popBackStack()) onBackPressed() },
             navigateToLogin = {
                 navigator.navigateToSignIn(
                     context = context,

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/LostAndFoundActivity.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/LostAndFoundActivity.kt
@@ -30,15 +30,20 @@ class LostAndFoundActivity : ComponentActivity() {
         }
 
         val id = intent.data?.getQueryParameter("id")
+        val screen = intent.data?.getQueryParameter("screen")
 
         setContent {
             KoinTheme {
-                var startDestination by remember { mutableStateOf<LostAndFoundNavType>(LostAndFoundNavType.LostAndFoundListRoute) }
-                val navController = rememberNavController()
-
-                id?.let {
-                    startDestination = LostAndFoundNavType.LostAndFoundDetailRoute(it.toInt())
+                var startDestination by remember {
+                    mutableStateOf<LostAndFoundNavType>(
+                        when {
+                            screen == "keyword" -> LostAndFoundNavType.LostAndFoundKeywordRoute
+                            id != null -> LostAndFoundNavType.LostAndFoundDetailRoute(id.toInt())
+                            else -> LostAndFoundNavType.LostAndFoundListRoute
+                        }
+                    )
                 }
+                val navController = rememberNavController()
 
                 val dispatcher = LocalOnBackPressedDispatcherOwner.current?.onBackPressedDispatcher
 

--- a/koin/src/main/java/in/koreatech/koin/ui/notification/NotificationActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/notification/NotificationActivity.kt
@@ -93,6 +93,13 @@ class NotificationActivity : ActivityBase() {
             intent.`package` = packageName
             startActivity(intent)
         }
+        binding.clGotoLostAndFoundKeyword.setOnClickListener {
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                data = Uri.parse("koin://lost-item/navigation?screen=keyword")
+            }
+            intent.`package` = packageName
+            startActivity(intent)
+        }
     }
 
     override fun onResume() {

--- a/koin/src/main/res/layout/activity_notification.xml
+++ b/koin/src/main/res/layout/activity_notification.xml
@@ -261,13 +261,20 @@
 
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
+                        <View
+                            android:id="@+id/view_article_keyword_divider"
+                            android:layout_width="match_parent"
+                            android:layout_height="1dp"
+                            android:background="@color/gray2"
+                            app:layout_constraintTop_toBottomOf="@+id/cl_goto_article_keyword" />
+
                         <androidx.constraintlayout.widget.ConstraintLayout
                             android:id="@+id/cl_goto_lost_and_found_keyword"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:paddingHorizontal="24dp"
                             android:paddingVertical="16dp"
-                            app:layout_constraintTop_toBottomOf="@+id/cl_goto_article_keyword">
+                            app:layout_constraintTop_toBottomOf="@+id/view_article_keyword_divider">
 
                             <androidx.appcompat.widget.AppCompatTextView
                                 android:id="@+id/tv_laf_keyword_title"

--- a/koin/src/main/res/layout/activity_notification.xml
+++ b/koin/src/main/res/layout/activity_notification.xml
@@ -261,12 +261,54 @@
 
                         </androidx.constraintlayout.widget.ConstraintLayout>
 
+                        <androidx.constraintlayout.widget.ConstraintLayout
+                            android:id="@+id/cl_goto_lost_and_found_keyword"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:paddingHorizontal="24dp"
+                            android:paddingVertical="16dp"
+                            app:layout_constraintTop_toBottomOf="@+id/cl_goto_article_keyword">
+
+                            <androidx.appcompat.widget.AppCompatTextView
+                                android:id="@+id/tv_laf_keyword_title"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:text="@string/notification_lost_and_found_keyword"
+                                android:textAppearance="@style/TextAppearance.Koin.Medium.18"
+                                android:textColor="@color/neutral_800"
+                                app:layout_constraintEnd_toStartOf="@id/image_laf_arrow"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                            <androidx.appcompat.widget.AppCompatTextView
+                                android:id="@+id/tv_laf_keyword_description"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_marginTop="8dp"
+                                android:maxLines="1"
+                                android:text="@string/notification_lost_and_found_keyword_description"
+                                android:textAppearance="@style/TextAppearance.Koin.Regular.16"
+                                android:textColor="@color/neutral_500"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintStart_toStartOf="parent"
+                                app:layout_constraintTop_toBottomOf="@id/tv_laf_keyword_title" />
+
+                            <ImageView
+                                android:id="@+id/image_laf_arrow"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:src="@drawable/ic_arrow_right"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="@id/tv_laf_keyword_title" />
+
+                        </androidx.constraintlayout.widget.ConstraintLayout>
+
                         <View
                             android:id="@+id/view4"
                             android:layout_width="match_parent"
                             android:layout_height="1dp"
                             android:background="@color/gray2"
-                            app:layout_constraintTop_toBottomOf="@id/cl_goto_article_keyword" />
+                            app:layout_constraintTop_toBottomOf="@+id/cl_goto_lost_and_found_keyword" />
 
                         <in.koreatech.koin.core.view.notificaiton.NotificationHeader
                             android:id="@+id/notification_chat"
@@ -275,7 +317,7 @@
                             app:description="@string/notification_chat_description"
                             app:layout_constraintEnd_toEndOf="parent"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toBottomOf="@id/cl_goto_article_keyword"
+                            app:layout_constraintTop_toBottomOf="@id/view4"
                             app:text="@string/notification_chat" />
 
                         <androidx.appcompat.widget.AppCompatTextView

--- a/koin/src/main/res/values/strings.xml
+++ b/koin/src/main/res/values/strings.xml
@@ -349,6 +349,8 @@
     <string name="notification_article_keyword_description">키워드가 포함된 글이 게시될 경우 알림을 받습니다.</string>
     <string name="notification_dining_photo_upload">식단 사진 업로드 알림</string>
     <string name="notification_article_keyword">공지사항 키워드 알림</string>
+    <string name="notification_lost_and_found_keyword">분실물 키워드 알림</string>
+    <string name="notification_lost_and_found_keyword_description">키워드가 포함된 분실물 게시글의 알림을 받습니다.</string>
     <string name="notification_dining_photo_upload_description">식단 사진이 업로드 될 경우 알림을 받습니다.</string>
 
     <string name="notification_marketing_term_switch">마케팅 정보 수신 동의</string>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1458

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 앱 공통 알림 설정 화면(`NotificationActivity`)의 게시판 섹션에 "분실물 키워드 알림" 항목을 추가하였습니다.
- 해당 항목 클릭 시 `koin://lost-item/navigation?screen=keyword` 딥링크를 사용하여 `LostAndFoundActivity`의 `LostAndFoundKeywordRoute`로 직접 진입하도록 구현하였습니다.
- `activity_notification.xml`의 레이아웃 constraint 체인을 올바르게 수정하였습니다 (기존 체인 오류 수정 및 새 항목 연결).
- `LostAndFoundActivity`에서 `screen` 쿼리 파라미터를 파싱하여 초기 목적지를 결정하도록 로직을 개선하였습니다.
- 딥링크로 직접 진입 시 백 스택이 비어있는 경우를 대비하여 `onBackClick` 로직을 개선하였습니다 (`popBackStack` 실패 시 Activity 종료).

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음 - 기존 설정 UI 스타일 유지)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다