### PR TITLE
[Fix] assembleDebug sonar 환경에서 Java 분석 제외로 SonarCloud 실패 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,6 +99,7 @@ sonar {
         property("sonar.kotlin.detekt.reportPaths", detektReports)
         property("sonar.kotlin.ktlint.reportPaths", ktlintReports)
         property("sonar.coverage.exclusions", sonarCoverageExclusions)
+        property("sonar.exclusions", "**/*.java")
     }
 }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1452

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
OOM 회피를 위해 CI sonar 명령을 `./gradlew build sonar` → `./gradlew assembleDebug sonar` 로 변경(`d2909cc37`)한 이후, SonarCloud 스캔이 다음 예외로 실패하고 있습니다.

```
org.sonar.java.AnalysisException: Your project contains .java files, please provide
compiled classes with sonar.java.binaries property, or exclude them from the
analysis with sonar.exclusions property.
```

`assembleDebug` 는 Java 센서가 요구하는 `sonar.java.binaries` 를 생성하지 않아 발생하는 문제입니다. 현재 열려 있는 모든 PR의 CI(sonarcloud job)가 이 회귀로 실패 중입니다.

본 프로젝트의 모든 Java 코드는 레거시로 분석 대상이 아니므로(`CLAUDE.md`), 에러 메시지가 직접 안내하는 대로 `sonar.exclusions` 에 `**/*.java` 를 추가하여 Java 파일을 분석에서 제외합니다. 이로써 OOM 회피용 `assembleDebug sonar` 명령을 유지하면서 스캔 실패를 해소합니다.

- `build.gradle.kts` 의 `sonar { properties { ... } }` 블록에 `property("sonar.exclusions", "**/*.java")` 한 줄 추가

### 논의 사항
- 대안으로 `sonar.java.binaries` 를 직접 지정하는 방법이 있으나, 다수 모듈 × `assembleDebug` 조합에서 경로가 깨지기 쉬워 더 취약합니다. 제외 방식이 더 단순하고 "Java는 레거시/무시" 정책과도 일치합니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다
