### PR TITLE
[Refactor] Coopshop 유스케이스 및 에러 처리 마이그레이션

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/repository/CoopShopRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/CoopShopRepositoryImpl.kt
@@ -3,6 +3,9 @@ package `in`.koreatech.koin.data.repository
 import `in`.koreatech.koin.data.mapper.toCoopShop
 import `in`.koreatech.koin.data.response.coopshop.CoopShopResponse
 import `in`.koreatech.koin.data.source.remote.CoopShopRemoteDataSource
+import `in`.koreatech.koin.data.util.mapHttpFailure
+import `in`.koreatech.koin.data.util.suspendRunCatching
+import `in`.koreatech.koin.domain.error.coopshop.KoinCoopShopException
 import `in`.koreatech.koin.domain.model.coopshop.CoopShop
 import `in`.koreatech.koin.domain.repository.CoopShopRepository
 import javax.inject.Inject
@@ -10,11 +13,17 @@ import javax.inject.Inject
 class CoopShopRepositoryImpl @Inject constructor(
     private val coopShopRemoteDataSource: CoopShopRemoteDataSource
 ) : CoopShopRepository {
-    override suspend fun getCoopShopAll(): List<CoopShop> {
-        return coopShopRemoteDataSource.getCoopShopAll().map(CoopShopResponse::toCoopShop)
+    override suspend fun getCoopShopAll(): Result<List<CoopShop>> {
+        return suspendRunCatching {
+            coopShopRemoteDataSource.getCoopShopAll().map(CoopShopResponse::toCoopShop)
+        }.mapHttpFailure { }
     }
 
-    override suspend fun getCoopShopById(id: Int): CoopShop {
-        return coopShopRemoteDataSource.getCoopShopById(id).toCoopShop()
+    override suspend fun getCoopShopById(id: Int): Result<CoopShop> {
+        return suspendRunCatching {
+            coopShopRemoteDataSource.getCoopShopById(id).toCoopShop()
+        }.mapHttpFailure {
+            on(404) throws KoinCoopShopException.CoopShopNotFoundException()
+        }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/error/coopshop/KoinCoopShopException.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/error/coopshop/KoinCoopShopException.kt
@@ -1,0 +1,15 @@
+package `in`.koreatech.koin.domain.error.coopshop
+
+import `in`.koreatech.koin.domain.error.KoinErrorException
+
+/**
+ * Exceptions related to coopshop APIs.
+ * Don't add CoopShop prefix because we using sealed class to group exceptions.
+ * Every exceptions should ends with Exception.
+ */
+sealed class KoinCoopShopException : KoinErrorException() {
+    /*
+     * Exceptions for 404 Not Found
+     */
+    class CoopShopNotFoundException : KoinCoopShopException()
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/CoopShopRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/CoopShopRepository.kt
@@ -3,7 +3,7 @@ package `in`.koreatech.koin.domain.repository
 import `in`.koreatech.koin.domain.model.coopshop.CoopShop
 
 interface CoopShopRepository {
-    suspend fun getCoopShopAll(): List<CoopShop>
+    suspend fun getCoopShopAll(): Result<List<CoopShop>>
 
-    suspend fun getCoopShopById(id: Int): CoopShop
+    suspend fun getCoopShopById(id: Int): Result<CoopShop>
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/coopshop/GetCoopShopAllUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/coopshop/GetCoopShopAllUseCase.kt
@@ -1,20 +1,13 @@
 package `in`.koreatech.koin.domain.usecase.coopshop
 
-import `in`.koreatech.koin.domain.error.coopshop.CoopShopErrorHandler
 import `in`.koreatech.koin.domain.model.coopshop.CoopShop
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.CoopShopRepository
 import javax.inject.Inject
 
 class GetCoopShopAllUseCase @Inject constructor(
-    private val coopShopRepository: CoopShopRepository,
-    private val coopShopErrorHandler: CoopShopErrorHandler
+    private val coopShopRepository: CoopShopRepository
 ) {
-    suspend operator fun invoke(): Pair<List<CoopShop>?, ErrorHandler?> {
-        return try {
-            coopShopRepository.getCoopShopAll() to null
-        } catch (t: Throwable) {
-            null to coopShopErrorHandler.handleGetCoopShopAllError(t)
-        }
+    suspend operator fun invoke(): Result<List<CoopShop>> {
+        return coopShopRepository.getCoopShopAll()
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/coopshop/GetCoopShopUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/coopshop/GetCoopShopUseCase.kt
@@ -1,21 +1,14 @@
 package `in`.koreatech.koin.domain.usecase.coopshop
 
-import `in`.koreatech.koin.domain.error.coopshop.CoopShopErrorHandler
 import `in`.koreatech.koin.domain.model.coopshop.CoopShop
 import `in`.koreatech.koin.domain.model.coopshop.CoopShopType
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.CoopShopRepository
 import javax.inject.Inject
 
 class GetCoopShopUseCase @Inject constructor(
-    private val coopShopRepository: CoopShopRepository,
-    private val coopShopErrorHandler: CoopShopErrorHandler
+    private val coopShopRepository: CoopShopRepository
 ) {
-    suspend operator fun invoke(type: CoopShopType): Pair<CoopShop?, ErrorHandler?> {
-        return try {
-            coopShopRepository.getCoopShopById(type.id) to null
-        } catch (t: Throwable) {
-            null to coopShopErrorHandler.handleGetCoopShopError(t)
-        }
+    suspend operator fun invoke(type: CoopShopType): Result<CoopShop> {
+        return coopShopRepository.getCoopShopById(type.id)
     }
 }

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningnotice/DiningNoticeViewModel.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningnotice/DiningNoticeViewModel.kt
@@ -6,7 +6,6 @@ import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import `in`.koreatech.koin.domain.model.coopshop.CoopShop
 import `in`.koreatech.koin.domain.model.coopshop.CoopShopType
 import `in`.koreatech.koin.domain.usecase.coopshop.GetCoopShopUseCase
-import `in`.koreatech.koin.domain.util.onSuccess
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -39,6 +38,7 @@ class DiningNoticeViewModel @Inject constructor(
                 .onSuccess {
                     _diningNotice.value = it
                 }
+                .onFailure { /* keep silent fail, preserve existing behavior */ }
         }
     }
 }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1467

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `coopshop` 도메인 내 유스케이스 2개(`GetCoopShopUseCase`, `GetCoopShopAllUseCase`)를 레거시 `Pair<T?, ErrorHandler?>` 패턴에서 `kotlin.Result<T>` 패턴으로 마이그레이션했습니다.
- `CoopShopRepository` 인터페이스 및 `CoopShopRepositoryImpl`의 반환 타입을 `Result<T>`로 변경하고, 에러를 도메인 레벨에서 처리하기 위해 `KoinCoopShopException` sealed class를 신규 생성했습니다.
- `CoopShopRepositoryImpl`에 `suspendRunCatching`과 `mapHttpFailure` DSL을 적용하여 데이터 레이어의 에러 처리를 표준화하였습니다.
- `DiningNoticeViewModel`의 에러 처리 로직을 `kotlin.Result` API(`onSuccess`, `onFailure`)로 전환하였으며, 기존의 silent fail 동작을 그대로 유지하여 사용자에게 기능적 변경이 발생하지 않도록 했습니다.
- 레거시 `CoopShopErrorHandler` 및 관련 바인딩은 이번 이슈의 스코프 외 작업이므로 삭제하지 않고 유지했습니다.

### 논의 사항
(없음)

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 에러 처리 방식을 개선하여 더 명확한 오류 관리 체계로 변경했습니다.
  * 협동샵 관련 기능에서 요청 실패(404 등) 시 더 정확한 오류 정보를 제공하도록 업데이트했습니다.
  * 식사 공지 기능에서 협동샵 정보 조회 실패 시 이전 값을 유지하도록 개선했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->