### PR TITLE
[Refactor] user·dept 유스케이스 ErrorHandler → Result 마이그레이션

### DIFF
--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailScreen.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailScreen.kt
@@ -124,6 +124,11 @@ fun MyStoreDetailScreen(
                 navigateToLoginScreen()
             }
 
+            is MyStoreDetailSideEffect.ShowErrorMessageRes -> {
+                ToastUtil.getInstance().makeShort(it.errorMessageRes)
+                navigateToLoginScreen()
+            }
+
             MyStoreDetailSideEffect.NavigateToUploadEventScreen -> navigateToUploadEventScreen()
             is MyStoreDetailSideEffect.NavigateToModifyScreen -> {
                 navigateToModifyScreen(it.storeId)

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailSideEffect.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailSideEffect.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.business.feature.store.storedetail
 
+import androidx.annotation.StringRes
+
 sealed class MyStoreDetailSideEffect {
     data object NavigateToUploadEventScreen : MyStoreDetailSideEffect()
 
@@ -16,6 +18,10 @@ sealed class MyStoreDetailSideEffect {
     data object NavigateToRegisterStoreScreen : MyStoreDetailSideEffect()
 
     data class ShowErrorMessage(val errorMessage: String) : MyStoreDetailSideEffect()
+
+    data class ShowErrorMessageRes(
+        @StringRes val errorMessageRes: Int
+    ) : MyStoreDetailSideEffect()
 
     data object ShowErrorModifyEventToast : MyStoreDetailSideEffect()
 

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
@@ -1,10 +1,9 @@
 package `in`.koreatech.business.feature.store.storedetail
 
-import android.content.Context
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.koreatech.koin.domain.model.owner.StoreDetailInfo
 import `in`.koreatech.koin.domain.usecase.business.DeleteOwnerEventsUseCase
 import `in`.koreatech.koin.domain.usecase.business.GetOwnerShopEventsUseCase
@@ -25,11 +24,7 @@ import org.orbitmvi.orbit.viewmodel.container
 import retrofit2.HttpException
 
 @HiltViewModel
-class MyStoreDetailViewModel
-@Suppress("LongParameterList")
-@Inject
-constructor(
-    @ApplicationContext private val context: Context,
+class MyStoreDetailViewModel @Inject constructor(
     private val getOwnerShopInfoUseCase: GetOwnerShopInfoUseCase,
     private val getOwnerShopListUseCase: GetOwnerShopListUseCase,
     private val getOwnerShopEventsUseCase: GetOwnerShopEventsUseCase,
@@ -365,22 +360,23 @@ constructor(
             },
             onFailure = { throwable ->
                 postSideEffect(
-                    MyStoreDetailSideEffect.ShowErrorMessage(
-                        throwable.toDeleteUserErrorMessage()
+                    MyStoreDetailSideEffect.ShowErrorMessageRes(
+                        throwable.toDeleteUserErrorMessageRes()
                     )
                 )
             }
         )
     }
 
-    private fun Throwable.toDeleteUserErrorMessage(): String = when {
+    @StringRes
+    private fun Throwable.toDeleteUserErrorMessageRes(): Int = when {
         this is HttpException && this.code() == 500 ->
-            context.getString(`in`.koreatech.koin.data.R.string.error_internal_server_error)
+            `in`.koreatech.koin.data.R.string.error_internal_server_error
         this is java.net.ConnectException ||
             this is java.net.SocketTimeoutException ||
             this is java.net.UnknownHostException ->
-            context.getString(`in`.koreatech.koin.data.R.string.error_network_connection)
+            `in`.koreatech.koin.data.R.string.error_network_connection
         else ->
-            context.getString(`in`.koreatech.koin.data.R.string.error_network_unknown)
+            `in`.koreatech.koin.data.R.string.error_network_unknown
     }
 }

--- a/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
+++ b/business/src/main/java/in/koreatech/business/feature/store/storedetail/MyStoreDetailViewModel.kt
@@ -1,8 +1,10 @@
 package `in`.koreatech.business.feature.store.storedetail
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.koreatech.koin.domain.model.owner.StoreDetailInfo
 import `in`.koreatech.koin.domain.usecase.business.DeleteOwnerEventsUseCase
 import `in`.koreatech.koin.domain.usecase.business.GetOwnerShopEventsUseCase
@@ -20,9 +22,14 @@ import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+import retrofit2.HttpException
 
 @HiltViewModel
-class MyStoreDetailViewModel @Inject constructor(
+class MyStoreDetailViewModel
+@Suppress("LongParameterList")
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
     private val getOwnerShopInfoUseCase: GetOwnerShopInfoUseCase,
     private val getOwnerShopListUseCase: GetOwnerShopListUseCase,
     private val getOwnerShopEventsUseCase: GetOwnerShopEventsUseCase,
@@ -351,17 +358,29 @@ class MyStoreDetailViewModel @Inject constructor(
             }
         }
 
-    fun deleteUser() {
-        intent {
-            viewModelScope.launch {
-                userRemoveUseCase()
-                    .onSuccess {
-                        postSideEffect(MyStoreDetailSideEffect.DeleteUser)
-                    }
-                    .onFailure { errorHandler ->
-                        postSideEffect(MyStoreDetailSideEffect.ShowErrorMessage(errorHandler.message))
-                    }
+    fun deleteUser() = intent {
+        userRemoveUseCase().fold(
+            onSuccess = {
+                postSideEffect(MyStoreDetailSideEffect.DeleteUser)
+            },
+            onFailure = { throwable ->
+                postSideEffect(
+                    MyStoreDetailSideEffect.ShowErrorMessage(
+                        throwable.toDeleteUserErrorMessage()
+                    )
+                )
             }
-        }
+        )
+    }
+
+    private fun Throwable.toDeleteUserErrorMessage(): String = when {
+        this is HttpException && this.code() == 500 ->
+            context.getString(`in`.koreatech.koin.data.R.string.error_internal_server_error)
+        this is java.net.ConnectException ||
+            this is java.net.SocketTimeoutException ||
+            this is java.net.UnknownHostException ->
+            context.getString(`in`.koreatech.koin.data.R.string.error_network_connection)
+        else ->
+            context.getString(`in`.koreatech.koin.data.R.string.error_network_unknown)
     }
 }

--- a/core/onboarding/src/main/java/in/koreatech/koin/core/onboarding/OnboardingManager.kt
+++ b/core/onboarding/src/main/java/in/koreatech/koin/core/onboarding/OnboardingManager.kt
@@ -27,7 +27,6 @@ import com.skydoves.balloon.compose.BalloonWindow
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.repository.OnboardingRepository
 import `in`.koreatech.koin.domain.usecase.user.GetUserInfoUseCase
-import `in`.koreatech.koin.domain.util.onSuccess
 import javax.inject.Inject
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay

--- a/data/src/main/java/in/koreatech/koin/data/repository/DeptRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/DeptRepositoryImpl.kt
@@ -2,20 +2,49 @@ package `in`.koreatech.koin.data.repository
 
 import `in`.koreatech.koin.data.source.local.DeptLocalDataSource
 import `in`.koreatech.koin.data.source.remote.DeptRemoteDataSource
+import `in`.koreatech.koin.data.util.mapHttpFailure
+import `in`.koreatech.koin.domain.error.dept.KoinDeptException
 import `in`.koreatech.koin.domain.model.user.Dept
 import `in`.koreatech.koin.domain.repository.DeptRepository
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
 
 class DeptRepositoryImpl @Inject constructor(
     private val deptRemoteDataSource: DeptRemoteDataSource,
     private val deptLocalDataSource: DeptLocalDataSource
 ) : DeptRepository {
-    override suspend fun getDeptNameFromDeptCode(deptCode: String): String {
-        return try {
-            val deptResponse = deptRemoteDataSource.getDeptFromDeptCode(deptCode)
-            deptResponse?.name ?: throw IllegalArgumentException()
+    @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException")
+    override suspend fun getDeptNameFromDeptCode(deptCode: String): Result<String> {
+        var remoteException: Throwable? = null
+        // Step 1: Try remote fetch
+        val deptResponse = try {
+            deptRemoteDataSource.getDeptFromDeptCode(deptCode)
         } catch (t: Throwable) {
-            deptLocalDataSource.getDeptFromDeptCode(deptCode)
+            if (t is CancellationException) throw t
+            remoteException = t
+            null
+        }
+
+        // Step 2: Check remote response
+        if (deptResponse != null && deptResponse.name != null) {
+            // Remote success with non-null name
+            return Result.success(deptResponse.name)
+        }
+
+        // Step 3: Remote success but name == null, OR remote failed; try local fallback
+        return try {
+            Result.success(deptLocalDataSource.getDeptFromDeptCode(deptCode))
+        } catch (localT: Throwable) {
+            if (localT is CancellationException) throw localT
+            // If we had a remote exception, map it; otherwise, use local exception
+            if (remoteException != null) {
+                Result.failure<String>(remoteException).mapHttpFailure {
+                    on(404) throws KoinDeptException.DeptNotFoundException()
+                }
+            } else {
+                // Remote succeeded but name was null; local failed; surface local exception
+                Result.failure(localT)
+            }
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/UserRepositoryImpl.kt
@@ -39,13 +39,18 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun getToken(
         loginId: String,
         hashedPassword: String
-    ): AuthToken {
-        val authResponse =
-            userRemoteDataSource.getToken(
-                LoginRequest(loginId, hashedPassword)
-            )
+    ): Result<AuthToken> {
+        return suspendRunCatching {
+            val authResponse =
+                userRemoteDataSource.getToken(
+                    LoginRequest(loginId, hashedPassword)
+                )
 
-        return AuthToken(authResponse.token, authResponse.refreshToken, authResponse.userType)
+            AuthToken(authResponse.token, authResponse.refreshToken, authResponse.userType)
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.LoginCredentialInvalidException()
+            on(404) throws KoinUserException.UserNotFoundException()
+        }
     }
 
     override suspend fun getOwnerToken(
@@ -120,19 +125,22 @@ class UserRepositoryImpl @Inject constructor(
         return userLocalDataSource.user.map { it ?: getUserInfo() }
     }
 
-    override suspend fun requestPasswordResetEmail(email: String) {
-        userRemoteDataSource.sendPasswordResetEmail(IdRequest(email))
+    override suspend fun requestPasswordResetEmail(email: String): Result<Unit> {
+        return suspendRunCatching {
+            userRemoteDataSource.sendPasswordResetEmail(IdRequest(email))
+        }.mapHttpFailure {
+            on(404) throws KoinUserException.UserNotFoundException()
+            on(422) throws KoinUserException.EmailInvalidException()
+        }
     }
 
-    override suspend fun deleteUser() {
-        try {
+    override suspend fun deleteUser(): Result<Unit> {
+        return suspendRunCatching {
             userRemoteDataSource.deleteUser()
             userLocalDataSource.updateUserInfo(User.Anonymous)
             userLocalDataSource.updateIsLogin(false)
             tokenLocalDataSource.removeAccessToken()
             tokenLocalDataSource.removeRefreshToken()
-        } catch (e: HttpException) {
-            throw e
         }
     }
 
@@ -171,13 +179,19 @@ class UserRepositoryImpl @Inject constructor(
         e409 = KoinUserException.NicknameOrEmailConflictException()
     )
 
-    override suspend fun deleteDeviceToken() {
-        tokenLocalDataSource.removeDeviceToken()
-        userRemoteDataSource.deleteDeviceToken()
+    override suspend fun deleteDeviceToken(): Result<Unit> {
+        return suspendRunCatching {
+            tokenLocalDataSource.removeDeviceToken()
+            userRemoteDataSource.deleteDeviceToken()
+        }
     }
 
-    override suspend fun verifyPassword(hashedPassword: String) {
-        userRemoteDataSource.verifyPassword(PasswordRequest(hashedPassword))
+    override suspend fun verifyPassword(hashedPassword: String): Result<Unit> {
+        return suspendRunCatching {
+            userRemoteDataSource.verifyPassword(PasswordRequest(hashedPassword))
+        }.mapHttpFailure {
+            on(400) throws KoinUserException.DataInvalidException()
+        }
     }
 
     override suspend fun updateABTestToken() {

--- a/domain/src/main/java/in/koreatech/koin/domain/error/dept/KoinDeptException.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/error/dept/KoinDeptException.kt
@@ -1,0 +1,15 @@
+package `in`.koreatech.koin.domain.error.dept
+
+import `in`.koreatech.koin.domain.error.KoinErrorException
+
+/**
+ * Exceptions related to dept APIs.
+ * Don't add Dept prefix because we using sealed class to group exceptions.
+ * Every exceptions should ends with Exception.
+ */
+sealed class KoinDeptException : KoinErrorException() {
+    /*
+     * Exceptions for 404 Not Found
+     */
+    class DeptNotFoundException : KoinDeptException()
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/error/user/KoinUserException.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/error/user/KoinUserException.kt
@@ -7,46 +7,47 @@ import `in`.koreatech.koin.domain.error.KoinErrorException
  * Don't add User prefix because we using sealed class to group exceptions.
  * Every exceptions should ends with Exception.
  */
-sealed class KoinUserException {
+sealed class KoinUserException : KoinErrorException() {
     /*
      * Exceptions for 400 Bad Request
      * format: {data type}InvalidException
      * or {data type}NotMatch{other data type}Exception
      */
-    class DataInvalidException : KoinErrorException()
-    class LoginIdInvalidException : KoinErrorException()
-    class EmailInvalidException : KoinErrorException()
-    class PhoneNumberInvalidException : KoinErrorException()
-    class NicknameInvalidException : KoinErrorException()
-    class VerificationCodeInvalidException : KoinErrorException()
-    class LoginIdNotMatchPhoneException : KoinErrorException()
-    class LoginIdNotMatchEmailException : KoinErrorException()
+    class DataInvalidException : KoinUserException()
+    class LoginIdInvalidException : KoinUserException()
+    class EmailInvalidException : KoinUserException()
+    class PhoneNumberInvalidException : KoinUserException()
+    class NicknameInvalidException : KoinUserException()
+    class VerificationCodeInvalidException : KoinUserException()
+    class LoginIdNotMatchPhoneException : KoinUserException()
+    class LoginIdNotMatchEmailException : KoinUserException()
+    class LoginCredentialInvalidException : KoinUserException()
 
     /*
      * Exceptions for 401 Unauthorized
      */
-    class UnauthorizedException : KoinErrorException()
+    class UnauthorizedException : KoinUserException()
 
     /*
      * Exceptions for 404 Not Found
      */
-    class UserNotFoundException : KoinErrorException()
-    class LoginIdNotFoundException : KoinErrorException()
-    class EmailNotFoundException : KoinErrorException()
-    class PhoneNumberNotFoundException : KoinErrorException()
-    class VerificationCodeExpiredException : KoinErrorException()
+    class UserNotFoundException : KoinUserException()
+    class LoginIdNotFoundException : KoinUserException()
+    class EmailNotFoundException : KoinUserException()
+    class PhoneNumberNotFoundException : KoinUserException()
+    class VerificationCodeExpiredException : KoinUserException()
 
     /*
      * Exceptions for 409 Conflict
      */
-    class PhoneNumberConflictException : KoinErrorException()
-    class EmailConflictException : KoinErrorException()
-    class LoginIdConflictException : KoinErrorException()
-    class NicknameConflictException : KoinErrorException()
-    class NicknameOrEmailConflictException : KoinErrorException()
+    class PhoneNumberConflictException : KoinUserException()
+    class EmailConflictException : KoinUserException()
+    class LoginIdConflictException : KoinUserException()
+    class NicknameConflictException : KoinUserException()
+    class NicknameOrEmailConflictException : KoinUserException()
 
     /*
      * Exceptions for 429 Too Many Requests
      */
-    class VerificationCodeRequestCountExceededException : KoinErrorException()
+    class VerificationCodeRequestCountExceededException : KoinUserException()
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/DeptRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/DeptRepository.kt
@@ -1,9 +1,10 @@
 package `in`.koreatech.koin.domain.repository
 
 import `in`.koreatech.koin.domain.model.user.Dept
+import kotlin.Result
 
 interface DeptRepository {
-    suspend fun getDeptNameFromDeptCode(deptCode: String): String
+    suspend fun getDeptNameFromDeptCode(deptCode: String): Result<String>
 
     suspend fun getDepts(): List<Dept>
 

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/UserRepository.kt
@@ -4,13 +4,14 @@ import `in`.koreatech.koin.domain.model.user.ABTest
 import `in`.koreatech.koin.domain.model.user.AuthToken
 import `in`.koreatech.koin.domain.model.user.CodeCount
 import `in`.koreatech.koin.domain.model.user.User
+import kotlin.Result
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
     suspend fun getToken(
         loginId: String,
         hashedPassword: String
-    ): AuthToken
+    ): Result<AuthToken>
 
     suspend fun getOwnerToken(
         phoneNumber: String,
@@ -27,17 +28,17 @@ interface UserRepository {
 
     fun getUserInfoFlow(): Flow<User>
 
-    suspend fun requestPasswordResetEmail(email: String)
+    suspend fun requestPasswordResetEmail(email: String): Result<Unit>
 
-    suspend fun deleteUser()
+    suspend fun deleteUser(): Result<Unit>
 
     suspend fun isUserEmailDuplicated(email: String): Boolean // TODO: Remove after new sign up release
 
     suspend fun updateUser(user: User): Result<Unit>
 
-    suspend fun deleteDeviceToken()
+    suspend fun deleteDeviceToken(): Result<Unit>
 
-    suspend fun verifyPassword(hashedPassword: String)
+    suspend fun verifyPassword(hashedPassword: String): Result<Unit>
 
     suspend fun updateUserPassword(
         hashedPassword: String

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/dept/GetDeptNameFromStudentIdUseCase.kt
@@ -1,23 +1,17 @@
 package `in`.koreatech.koin.domain.usecase.dept
 
-import `in`.koreatech.koin.domain.error.dept.DeptErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.DeptRepository
 import `in`.koreatech.koin.domain.util.deptCode
 import `in`.koreatech.koin.domain.util.ext.isValidStudentId
 import javax.inject.Inject
+import kotlin.Result
 
 class GetDeptNameFromStudentIdUseCase @Inject constructor(
-    private val deptRepository: DeptRepository,
-    private val deptErrorHandler: DeptErrorHandler
+    private val deptRepository: DeptRepository
 ) {
-    suspend operator fun invoke(studentId: String): Pair<String?, ErrorHandler?> {
-        if (!studentId.isValidStudentId) return "" to null
+    suspend operator fun invoke(studentId: String): Result<String> {
+        if (!studentId.isValidStudentId) return Result.success("")
 
-        return try {
-            deptRepository.getDeptNameFromDeptCode(studentId.deptCode) to null
-        } catch (t: Throwable) {
-            null to deptErrorHandler.getDeptNameFromDeptCodeError(t)
-        }
+        return deptRepository.getDeptNameFromDeptCode(studentId.deptCode)
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/DeleteDeviceTokenUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/DeleteDeviceTokenUseCase.kt
@@ -1,20 +1,13 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.UserRepository
 import javax.inject.Inject
+import kotlin.Result
 
 class DeleteDeviceTokenUseCase @Inject constructor(
-    private val userRepository: UserRepository,
-    private val userErrorHandler: UserErrorHandler
+    private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(): Pair<Unit?, ErrorHandler?> {
-        return try {
-            userRepository.deleteDeviceToken()
-            Unit to null
-        } catch (e: Exception) {
-            null to userErrorHandler.handleUserError(e)
-        }
+    suspend operator fun invoke(): Result<Unit> {
+        return userRepository.deleteDeviceToken()
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/GetUserInfoUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/GetUserInfoUseCase.kt
@@ -1,50 +1,31 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.dept.DeptErrorHandler
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.repository.DeptRepository
 import `in`.koreatech.koin.domain.repository.TokenRepository
 import `in`.koreatech.koin.domain.repository.UserRepository
 import `in`.koreatech.koin.domain.util.deptCode
+import `in`.koreatech.koin.domain.util.suspendRunCatching
 import javax.inject.Inject
+import kotlin.Result
 
 class GetUserInfoUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val deptRepository: DeptRepository,
-    private val tokenRepository: TokenRepository,
-    private val userErrorHandler: UserErrorHandler,
-    private val deptErrorHandler: DeptErrorHandler
+    private val tokenRepository: TokenRepository
 ) {
-    suspend operator fun invoke(): Pair<User?, ErrorHandler?> {
-        return if (tokenRepository.getAccessToken() == null) {
-            // 익명
-            User.Anonymous to null
-        } else {
-            try {
-                val user = userRepository.getUserInfo()
-
-                if (user is User.Student && user.studentNumber != null && user.major == null) {
-                    return try {
-                        val deptName =
-                            deptRepository.getDeptNameFromDeptCode(user.studentNumber.deptCode)
-
-                        user.copy(major = deptName) to null
-                    } catch (t: Throwable) {
-                        user to deptErrorHandler.getDeptNameFromDeptCodeError(t)
-                    }
-                } else if (user is User.General) {
-                    return user to null
-                }
-            } catch (t: Throwable) {
-                null to userErrorHandler.handleGetUserInfoError(t)
-            }
-
-            return try {
-                userRepository.getUserInfo() to null
-            } catch (e: Exception) {
-                null to userErrorHandler.handleGetUserInfoError(e)
+    suspend operator fun invoke(): Result<User> {
+        if (tokenRepository.getAccessToken() == null) {
+            return Result.success(User.Anonymous)
+        }
+        return suspendRunCatching {
+            val user = userRepository.getUserInfo()
+            if (user is User.Student && user.studentNumber != null && user.major == null) {
+                deptRepository.getDeptNameFromDeptCode(user.studentNumber.deptCode)
+                    .map { deptName -> user.copy(major = deptName) }
+                    .getOrDefault(user)
+            } else {
+                user
             }
         }
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/RequestFindPasswordEmailUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/RequestFindPasswordEmailUseCase.kt
@@ -1,26 +1,17 @@
 package `in`.koreatech.koin.domain.usecase.user
 
 import `in`.koreatech.koin.domain.constant.ERROR_FORGOTPASSWORD_BLANK_ACCOUNT
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.UserRepository
 import javax.inject.Inject
+import kotlin.Result
 
 class RequestFindPasswordEmailUseCase @Inject constructor(
-    private val userRepository: UserRepository,
-    private val userErrorHandler: UserErrorHandler
+    private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(email: String): ErrorHandler? {
+    suspend operator fun invoke(email: String): Result<Unit> {
         if (email.isBlank()) {
-            return userErrorHandler.handleRequestPasswordResetEmailError(
-                IllegalArgumentException(ERROR_FORGOTPASSWORD_BLANK_ACCOUNT)
-            )
+            return Result.failure(IllegalArgumentException(ERROR_FORGOTPASSWORD_BLANK_ACCOUNT))
         }
-        return try {
-            userRepository.requestPasswordResetEmail(email)
-            null
-        } catch (t: Throwable) {
-            userErrorHandler.handleRequestPasswordResetEmailError(t)
-        }
+        return userRepository.requestPasswordResetEmail(email)
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCase.kt
@@ -1,24 +1,23 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.model.user.UserType
 import `in`.koreatech.koin.domain.repository.TokenRepository
 import `in`.koreatech.koin.domain.repository.UserRepository
 import `in`.koreatech.koin.domain.util.ext.toSHA256
+import `in`.koreatech.koin.domain.util.suspendRunCatching
 import javax.inject.Inject
+import kotlin.Result
 
 class UserLoginUseCase @Inject constructor(
     private val userRepository: UserRepository,
-    private val tokenRepository: TokenRepository,
-    private val userErrorHandler: UserErrorHandler
+    private val tokenRepository: TokenRepository
 ) {
     suspend operator fun invoke(
         email: String,
         password: String
-    ): Pair<Unit?, ErrorHandler?> {
-        return try {
-            val authToken = userRepository.getToken(email, password.toSHA256())
+    ): Result<Unit> {
+        return suspendRunCatching {
+            val authToken = userRepository.getToken(email, password.toSHA256()).getOrThrow()
             tokenRepository.saveAccessToken(authToken.token)
             tokenRepository.saveRefreshToken(authToken.refreshToken)
             when (UserType.valueOf(authToken.userType!!)) {
@@ -34,9 +33,6 @@ class UserLoginUseCase @Inject constructor(
                     // Do nothing
                 }
             }
-            Unit to null
-        } catch (throwable: Throwable) {
-            null to userErrorHandler.handleGetTokenError(throwable)
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLogoutUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserLogoutUseCase.kt
@@ -1,22 +1,18 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.token.TokenErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.UserRepository
+import `in`.koreatech.koin.domain.util.suspendRunCatching
 import javax.inject.Inject
+import kotlin.Result
 
 class UserLogoutUseCase @Inject constructor(
     private val userRepository: UserRepository,
-    private val tokenErrorHandler: TokenErrorHandler,
     private val deleteUserRefreshTokenUseCase: DeleteUserRefreshTokenUseCase
 ) {
-    suspend operator fun invoke(): Pair<Unit, ErrorHandler?> {
-        return try {
-            userRepository.deleteDeviceToken()
+    suspend operator fun invoke(): Result<Unit> {
+        return suspendRunCatching {
+            userRepository.deleteDeviceToken().getOrThrow()
             deleteUserRefreshTokenUseCase()
-            Unit to null
-        } catch (t: Throwable) {
-            Unit to tokenErrorHandler.handleLogoutError(t)
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserRemoveUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserRemoveUseCase.kt
@@ -1,22 +1,17 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.UserRepository
+import `in`.koreatech.koin.domain.util.suspendRunCatching
 import javax.inject.Inject
+import kotlin.Result
 
 class UserRemoveUseCase @Inject constructor(
-    private val userRepository: UserRepository,
-    private val userErrorHandler: UserErrorHandler
+    private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(): Pair<Unit, ErrorHandler?> {
-        return Unit to
-            try {
-                userRepository.deleteDeviceToken()
-                userRepository.deleteUser()
-                null
-            } catch (t: Throwable) {
-                userErrorHandler.handleDeleteUserError(t)
-            }
+    suspend operator fun invoke(): Result<Unit> {
+        return suspendRunCatching {
+            userRepository.deleteDeviceToken().getOrThrow()
+            userRepository.deleteUser().getOrThrow()
+        }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserWithdrawUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/UserWithdrawUseCase.kt
@@ -1,15 +1,17 @@
 package `in`.koreatech.koin.domain.usecase.user
 
 import `in`.koreatech.koin.domain.repository.UserRepository
+import `in`.koreatech.koin.domain.util.suspendRunCatching
 import javax.inject.Inject
+import kotlin.Result
 
 class UserWithdrawUseCase @Inject constructor(
     private val userRepository: UserRepository
 ) {
     suspend operator fun invoke(): Result<Unit> {
-        return runCatching {
-            userRepository.deleteDeviceToken()
-            userRepository.deleteUser()
+        return suspendRunCatching {
+            userRepository.deleteDeviceToken().getOrThrow()
+            userRepository.deleteUser().getOrThrow()
         }
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/user/VerifyUserPasswordUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/user/VerifyUserPasswordUseCase.kt
@@ -1,21 +1,14 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
-import `in`.koreatech.koin.domain.model.error.ErrorHandler
 import `in`.koreatech.koin.domain.repository.UserRepository
 import `in`.koreatech.koin.domain.util.ext.toSHA256
 import javax.inject.Inject
+import kotlin.Result
 
 class VerifyUserPasswordUseCase @Inject constructor(
-    private val userRepository: UserRepository,
-    private val userErrorHandler: UserErrorHandler
+    private val userRepository: UserRepository
 ) {
-    suspend operator fun invoke(password: String): ErrorHandler? {
-        return try {
-            userRepository.verifyPassword(password.toSHA256())
-            null
-        } catch (t: Throwable) {
-            userErrorHandler.handleVerifyUserPasswordError(t)
-        }
+    suspend operator fun invoke(password: String): Result<Unit> {
+        return userRepository.verifyPassword(password.toSHA256())
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/util/SuspendRunCatching.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/util/SuspendRunCatching.kt
@@ -1,0 +1,20 @@
+package `in`.koreatech.koin.domain.util
+
+import kotlin.Result as KotlinResult
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Cancellation-safe version of [runCatching] for suspend functions in the domain layer.
+ *
+ * Unlike the stdlib [runCatching], this helper re-throws [CancellationException] so that
+ * structured concurrency is not broken when the enclosing coroutine is cancelled.
+ */
+suspend inline fun <T> suspendRunCatching(crossinline block: suspend () -> T): KotlinResult<T> {
+    return try {
+        KotlinResult.success(block())
+    } catch (t: CancellationException) {
+        throw t
+    } catch (t: Throwable) {
+        KotlinResult.failure(t)
+    }
+}

--- a/domain/src/test/java/in/koreatech/koin/domain/repository/FakeUserRepository.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/repository/FakeUserRepository.kt
@@ -5,6 +5,7 @@ import `in`.koreatech.koin.domain.model.user.AuthToken
 import `in`.koreatech.koin.domain.model.user.CodeCount
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.model.user.UserType
+import kotlin.Result
 import kotlinx.coroutines.flow.Flow
 
 class FakeUserRepository : UserRepository {
@@ -18,7 +19,7 @@ class FakeUserRepository : UserRepository {
         authToken = token
     }
 
-    override suspend fun getToken(email: String, password: String): AuthToken = authToken ?: throw IllegalStateException("No access token set")
+    override suspend fun getToken(email: String, password: String): Result<AuthToken> = authToken?.let { Result.success(it) } ?: Result.failure(IllegalStateException("No access token set"))
 
     override suspend fun getOwnerToken(phoneNumber: String, hashedPassword: String): AuthToken {
         TODO("Not yet implemented")
@@ -44,12 +45,12 @@ class FakeUserRepository : UserRepository {
         TODO("Not yet implemented")
     }
 
-    override suspend fun requestPasswordResetEmail(email: String) {
-        TODO("Not yet implemented")
+    override suspend fun requestPasswordResetEmail(email: String): Result<Unit> {
+        return Result.failure(NotImplementedError())
     }
 
-    override suspend fun deleteUser() {
-        TODO("Not yet implemented")
+    override suspend fun deleteUser(): Result<Unit> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun isUserEmailDuplicated(email: String): Boolean {
@@ -65,12 +66,12 @@ class FakeUserRepository : UserRepository {
         User.Anonymous -> TODO()
     }
 
-    override suspend fun deleteDeviceToken() {
-        TODO("Not yet implemented")
+    override suspend fun deleteDeviceToken(): Result<Unit> {
+        return Result.failure(NotImplementedError())
     }
 
-    override suspend fun verifyPassword(hashedPassword: String) {
-        TODO("Not yet implemented")
+    override suspend fun verifyPassword(hashedPassword: String): Result<Unit> {
+        return Result.failure(NotImplementedError())
     }
 
     override suspend fun updateUserPassword(hashedPassword: String): Result<Unit> {

--- a/domain/src/test/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCaseTest.kt
+++ b/domain/src/test/java/in/koreatech/koin/domain/usecase/user/UserLoginUseCaseTest.kt
@@ -1,7 +1,5 @@
 package `in`.koreatech.koin.domain.usecase.user
 
-import `in`.koreatech.koin.domain.error.user.FakeUserErrorHandler
-import `in`.koreatech.koin.domain.error.user.UserErrorHandler
 import `in`.koreatech.koin.domain.model.user.AuthToken
 import `in`.koreatech.koin.domain.model.user.UserType
 import `in`.koreatech.koin.domain.repository.FakeTokenRepository
@@ -14,13 +12,11 @@ import org.junit.Test
 class UserLoginUseCaseTest {
     private lateinit var userRepository: FakeUserRepository
     private lateinit var tokenRepository: FakeTokenRepository
-    private lateinit var userErrorHandler: UserErrorHandler
 
     @Before
     fun setUp() {
         userRepository = FakeUserRepository()
         tokenRepository = FakeTokenRepository()
-        userErrorHandler = FakeUserErrorHandler()
     }
 
     @Test
@@ -29,14 +25,13 @@ class UserLoginUseCaseTest {
         val refreshToken = "test_refresh_token"
         userRepository.setAccessToken(AuthToken(accessToken, refreshToken, UserType.STUDENT.name))
 
-        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository, userErrorHandler)
+        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository)
         val email = "student@koreatech.ac.kr"
         val password = "credential"
 
         val result = userLoginUseCase(email, password)
 
-        Assert.assertNotNull(result.first)
-        Assert.assertNull(result.second)
+        Assert.assertTrue(result.isSuccess)
         Assert.assertEquals(accessToken, tokenRepository.getAccessToken())
         Assert.assertEquals(refreshToken, tokenRepository.getRefreshToken())
         Assert.assertEquals(UserType.STUDENT, userRepository.userType)
@@ -48,31 +43,28 @@ class UserLoginUseCaseTest {
         val refreshToken = "test_refresh_token"
         userRepository.setAccessToken(AuthToken(accessToken, refreshToken, UserType.GENERAL.name))
 
-        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository, userErrorHandler)
+        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository)
         val email = "general@bcsdlab.com"
         val password = "credential"
 
         val result = userLoginUseCase(email, password)
 
-        Assert.assertNotNull(result.first)
-        Assert.assertNull(result.second)
+        Assert.assertTrue(result.isSuccess)
         Assert.assertEquals(accessToken, tokenRepository.getAccessToken())
         Assert.assertEquals(refreshToken, tokenRepository.getRefreshToken())
         Assert.assertEquals(UserType.GENERAL, userRepository.userType)
     }
 
     @Test
-    fun `로그인 실패 시 ErrorHandler를 반환한다`() = runTest {
+    fun `로그인 실패 시 Result failure를 반환한다`() = runTest {
         userRepository.setAccessToken(null)
 
-        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository, userErrorHandler)
+        val userLoginUseCase = UserLoginUseCase(userRepository, tokenRepository)
         val email = "general@bcsdlab.com"
         val password = "credential"
 
         val result = userLoginUseCase(email, password)
 
-        Assert.assertNull(result.first)
-        Assert.assertNotNull(result.second)
-        Assert.assertFalse(result.second!!.isSuccess)
+        Assert.assertTrue(result.isFailure)
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
@@ -46,22 +46,14 @@ class ClubListViewModel @Inject constructor(
         getUserType()
     }
 
-    private fun getUserType() = viewModelScope.launch {
-        getUserInfoUseCase().first.let { user ->
-            if (user == null || user.isAnonymous) {
-                intent {
-                    reduce {
-                        state.copy(isAnonymous = true)
-                    }
-                }
-            } else {
-                intent {
-                    reduce {
-                        state.copy(isAnonymous = false)
-                    }
-                }
+    private fun getUserType() = intent {
+        getUserInfoUseCase()
+            .onSuccess { user ->
+                reduce { state.copy(isAnonymous = user.isAnonymous) }
             }
-        }
+            .onFailure {
+                reduce { state.copy(isAnonymous = true) }
+            }
     }
 
     fun updateSearchKeyword(keyword: String) = blockingIntent {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/changepassword/ChangePasswordViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/changepassword/ChangePasswordViewModel.kt
@@ -104,13 +104,13 @@ class ChangePasswordViewModel @Inject constructor(
         if (enteredPwd.value == currentPwd) return
         savedStateHandle[KEY_ENTERED_PASSWORD] = currentPwd
         viewModelScope.launch {
-            verifyUserPasswordUseCase(currentPwd).let { handler ->
-                if (handler == null) {
+            verifyUserPasswordUseCase(currentPwd)
+                .onSuccess {
                     savedStateHandle[KEY_VERIFY_UI_STATUS] = UiStatus.Success
-                } else {
-                    savedStateHandle[KEY_VERIFY_UI_STATUS] = UiStatus.Failed(handler.message)
                 }
-            }
+                .onFailure {
+                    savedStateHandle[KEY_VERIFY_UI_STATUS] = UiStatus.Failed()
+                }
         }
     }
 

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInViewModel.kt
@@ -7,8 +7,6 @@ import `in`.koreatech.koin.core.analytics.EventAction
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.usecase.session.GetSessionIdUseCase
 import `in`.koreatech.koin.domain.usecase.user.UserLoginUseCase
-import `in`.koreatech.koin.domain.util.onFailure
-import `in`.koreatech.koin.domain.util.onSuccess
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -54,23 +52,25 @@ class SignInViewModel @Inject constructor(
     }
 
     fun signIn() = intent {
-        userLoginUseCase(state.loginId, state.password).onSuccess {
-            EventLogger.logClickEvent(
-                EventAction.USER,
-                AnalyticsConstant.Label.LOGIN,
-                "로그인 완료"
-            )
-            postSideEffect(SignInSideEffect.SignInSuccess)
-        }.onFailure {
-            EventLogger.logClickEvent(
-                EventAction.USER,
-                AnalyticsConstant.Label.LOGIN,
-                "로그인 실패"
-            )
-            reduce {
-                state.copy(loginError = SignInState.LoginError(true, it.message))
+        userLoginUseCase(state.loginId, state.password)
+            .onSuccess {
+                EventLogger.logClickEvent(
+                    EventAction.USER,
+                    AnalyticsConstant.Label.LOGIN,
+                    "로그인 완료"
+                )
+                postSideEffect(SignInSideEffect.SignInSuccess)
             }
-        }
+            .onFailure {
+                EventLogger.logClickEvent(
+                    EventAction.USER,
+                    AnalyticsConstant.Label.LOGIN,
+                    "로그인 실패"
+                )
+                reduce {
+                    state.copy(loginError = SignInState.LoginError(isError = true))
+                }
+            }
     }
 
     fun getSignUpSessionId() {

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/userinfo/UserInfoEditViewModel.kt
@@ -19,8 +19,6 @@ import `in`.koreatech.koin.domain.usecase.user.GetUserInfoUseCase
 import `in`.koreatech.koin.domain.usecase.user.UpdateGeneralUserInfoUseCase
 import `in`.koreatech.koin.domain.usecase.user.UpdateStudentUserInfoUseCase
 import `in`.koreatech.koin.domain.usecase.user.UserWithdrawUseCase
-import `in`.koreatech.koin.domain.util.onFailure
-import `in`.koreatech.koin.domain.util.onSuccess
 import `in`.koreatech.koin.feature.user.model.NicknameState
 import `in`.koreatech.koin.feature.user.model.VerificationCodeState
 import `in`.koreatech.koin.feature.user.model.VerificationMethodState

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
@@ -1,10 +1,8 @@
 package `in`.koreatech.koin.ui.navigation.viewmodel
 
-import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import `in`.koreatech.koin.core.viewmodel.SingleLiveEvent
 import `in`.koreatech.koin.domain.model.user.User
@@ -27,11 +25,7 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @HiltViewModel
-class KoinNavigationDrawerViewModel
-@Suppress("LongParameterList")
-@Inject
-constructor(
-    @ApplicationContext private val context: Context,
+class KoinNavigationDrawerViewModel @Inject constructor(
     private val updateDeviceTokenUseCase: UpdateDeviceTokenUseCase,
     private val userLogoutUseCase: UserLogoutUseCase,
     private val getUserStatusUseCase: GetUserStatusUseCase,
@@ -83,8 +77,8 @@ constructor(
 
     fun logout() = viewModelScope.launch {
         userLogoutUseCase()
-            .onFailure { throwable ->
-                _errorToast.value = context.getString(`in`.koreatech.koin.R.string.error_failed_logout)
+            .onFailure {
+                Timber.e(it, "Failed to logout")
             }
     }
 

--- a/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/navigation/viewmodel/KoinNavigationDrawerViewModel.kt
@@ -1,8 +1,10 @@
 package `in`.koreatech.koin.ui.navigation.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import `in`.koreatech.koin.core.viewmodel.SingleLiveEvent
 import `in`.koreatech.koin.domain.model.user.User
@@ -12,7 +14,6 @@ import `in`.koreatech.koin.domain.usecase.setting.GetDeveloperSettingUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.domain.usecase.user.UpdateDeviceTokenUseCase
 import `in`.koreatech.koin.domain.usecase.user.UserLogoutUseCase
-import `in`.koreatech.koin.domain.util.onFailure
 import `in`.koreatech.koin.ui.navigation.state.MenuState
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +27,11 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @HiltViewModel
-class KoinNavigationDrawerViewModel @Inject constructor(
+class KoinNavigationDrawerViewModel
+@Suppress("LongParameterList")
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
     private val updateDeviceTokenUseCase: UpdateDeviceTokenUseCase,
     private val userLogoutUseCase: UserLogoutUseCase,
     private val getUserStatusUseCase: GetUserStatusUseCase,
@@ -77,9 +82,10 @@ class KoinNavigationDrawerViewModel @Inject constructor(
     }
 
     fun logout() = viewModelScope.launch {
-        userLogoutUseCase().onFailure {
-            _errorToast.value = it.message
-        }
+        userLogoutUseCase()
+            .onFailure { throwable ->
+                _errorToast.value = context.getString(`in`.koreatech.koin.R.string.error_failed_logout)
+            }
     }
 
     fun getSignUpSessionId(): String {

--- a/koin/src/main/java/in/koreatech/koin/ui/setting/SettingViewModel.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/setting/SettingViewModel.kt
@@ -6,7 +6,6 @@ import `in`.koreatech.koin.core.viewmodel.BaseViewModel
 import `in`.koreatech.koin.domain.model.user.User
 import `in`.koreatech.koin.domain.usecase.user.GetUserInfoUseCase
 import `in`.koreatech.koin.domain.usecase.version.GetLatestVersionUseCase
-import `in`.koreatech.koin.domain.util.onSuccess
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow


### PR DESCRIPTION
## PR 개요
이슈 번호: #1470

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
1. **유스케이스 Result 마이그레이션**: 레거시 `Pair<T?, ErrorHandler?>` / `ErrorHandler?` 패턴을 사용하던 9개 user/dept 유스케이스를 `Result<T>` 반환 패턴으로 통일하였습니다.
2. **Repository 시그니처 변경**: `UserRepository` 및 `DeptRepository`의 관련 메서드 반환 타입을 `Result<T>`로 변경하고, `suspendRunCatching` 및 `mapHttpFailure` DSL을 통해 타입 안전한 예외 처리를 구현하였습니다.
3. **에러 처리 표준화**: `KoinDeptException` sealed class를 신규 생성하고, ViewModel 레이어에서 `kotlin.Result`의 `onSuccess`/`onFailure`/`fold`를 사용하여 일관되게 에러를 처리하도록 수정하였습니다.
4. **ViewModel 로직 개선**: Orbit MVI 패턴을 준수하도록 `viewModelScope.launch`를 제거하고 단일 `intent {}` 블록으로 로직을 단순화하였습니다.
5. **보안 강화**: Account 삭제 실패 시 노출되던 원본 서버 에러 메시지를 제거하고, 고정된 로컬 에러 리소스를 노출하도록 수정하여 보안을 강화하였습니다.

### 논의 사항
- (없음)

### 스크린샷
- (UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * 오류 처리 방식을 통합하여 앱 전체의 예외 관리 일관성을 개선했습니다.
  * 사용자 인증 및 계정 관련 기능에서 오류 전파 흐름을 단순화하여 안정성을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->