### PR TITLE
[Fix] Android P에서 발생하는 시간표 이미지 저장 실패 수정

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/utils/BitmapUtils.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/utils/BitmapUtils.kt
@@ -58,37 +58,36 @@ class BitmapUtils(
                     Timber.e("Failed save : ${e.message}")
                     return false
                 }
-            } else {
-                val imageFileFolder =
-                    File(Environment.getExternalStorageDirectory().toString() + "/" + "koin")
-                if (!imageFileFolder.exists()) {
-                    imageFileFolder.mkdirs()
-                }
-                val mImageName = "$timeStamp.png"
-                val imageFile = File(imageFileFolder, mImageName)
-                try {
-                    val outputStream: OutputStream = FileOutputStream(imageFile)
-                    try {
-                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
-                        outputStream.close()
-                    } catch (e: Exception) {
-                        e.message
-                    }
-                    values.put(MediaStore.Images.Media.DATA, imageFile.absolutePath)
-                    context.contentResolver.insert(
-                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                        values
-                    )
-
-                    Timber.e("Saved...")
-                    return true
-                } catch (e: Exception) {
-                    Timber.e("Failed save : ${e.message}")
-                    return false
-                }
             }
         }
-        return false
+
+        val imageFileFolder =
+            File(Environment.getExternalStorageDirectory().toString() + "/" + "koin")
+        if (!imageFileFolder.exists()) {
+            imageFileFolder.mkdirs()
+        }
+        val mImageName = "$timeStamp.png"
+        val imageFile = File(imageFileFolder, mImageName)
+        try {
+            val outputStream: OutputStream = FileOutputStream(imageFile)
+            try {
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+                outputStream.close()
+            } catch (e: Exception) {
+                e.message
+            }
+            values.put(MediaStore.Images.Media.DATA, imageFile.absolutePath)
+            context.contentResolver.insert(
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                values
+            )
+
+            Timber.e("Saved...")
+            return true
+        } catch (e: Exception) {
+            Timber.e("Failed save : ${e.message}")
+            return false
+        }
     }
 
     private fun generateBitmap(view: View): Bitmap {

--- a/feature/timetable/src/main/res/values/strings.xml
+++ b/feature/timetable/src/main/res/values/strings.xml
@@ -98,4 +98,5 @@
     <string name="download">다운로드</string>
     <string name="download_description">다운로드 하시겠어요?</string>
 
+    <string name="timetable_save_permission_needed">시간표를 저장하기 위해서는 권한이 필요해요.</string>
 </resources>

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -1,8 +1,13 @@
 package `in`.koreatech.koin.ui.timetablev2
 
+import android.Manifest
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.activity.result.contract.ActivityResultContracts
@@ -20,6 +25,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.asAndroidBitmap
 import androidx.compose.ui.graphics.rememberGraphicsLayer
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import dagger.hilt.android.AndroidEntryPoint
@@ -81,6 +87,24 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
 
             if (it.resultCode == TimetableSemesterActivity.REQUEST_CODE_LOGIN_ACTIVITY) {
                 startToLoginActivity()
+            }
+        }
+
+    private val writeStoragePermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                viewModel.updateIsDownloadDialogVisible(true)
+            } else {
+                viewModel.updateSideEffect(
+                    TimetableSideEffect.SnackBar(
+                        getString(R.string.timetable_save_permission_needed)
+                    )
+                )
+                if (!shouldShowRequestPermissionRationale(Manifest.permission.WRITE_EXTERNAL_STORAGE)) {
+                    Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                        data = Uri.fromParts("package", this@TimetableActivity.packageName, null)
+                    }.let(::startActivity)
+                }
             }
         }
 
@@ -268,7 +292,19 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
                         startToTimetableSemesterActivity()
                     },
                     onClickDownloadTimetable = {
-                        viewModel.updateIsDownloadDialogVisible(true)
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            viewModel.updateIsDownloadDialogVisible(true)
+                        } else {
+                            if (ContextCompat.checkSelfPermission(
+                                    this,
+                                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                                ) == PackageManager.PERMISSION_GRANTED
+                            ) {
+                                viewModel.updateIsDownloadDialogVisible(true)
+                            } else {
+                                writeStoragePermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                            }
+                        }
                     },
                     onClickAddLectureMode = viewModel::updateTimetableBottomSheetMode,
                     onClickAddCustomLectureMode = {


### PR DESCRIPTION
## PR 개요
- close: #1484 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- Android P에서 발생하는 시간표 이미지 저장 실패를 수정했습니다.
- Android Q 미만 기기에서는 `WRITE_EXTERNAL_STORAGE` 로 이미지를 저장하기 때문에, 권한 요청을 추가했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다