### PR TITLE
[Fix] Race condition으로 인한 상점 목록 fetch 실패 수정

### DIFF
--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
@@ -176,6 +176,9 @@ class StoreNearbyViewModel @Inject constructor(
             )
         }
         postSideEffect(StoreNearbySideEffect.FetchData)
-        postSideEffect(StoreNearbySideEffect.ScrollCategory(state.storeCategories.indexOfFirst { it.id == categoryId }))
+        if (state.storeCategories.isNotEmpty()) {
+            // If category not fetched, `indexOfFirst` will return -1 and it'll cause Exception
+            postSideEffect(StoreNearbySideEffect.ScrollCategory(state.storeCategories.indexOfFirst { it.id == categoryId }))
+        }
     }
 }

--- a/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
+++ b/feature/store/src/main/java/in/koreatech/koin/feature/store/nearby/StoreNearbyViewModel.kt
@@ -33,7 +33,6 @@ class StoreNearbyViewModel @Inject constructor(
     override val container = container<StoreNearbyState, StoreNearbySideEffect>(StoreNearbyState())
 
     init {
-        fetchData()
         intent {
             getStoreCategoriesUseCase().let {
                 reduce {


### PR DESCRIPTION
## PR 개요
- close: #1486 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `init()`에서 `fetchData()`를 제거했습니다.
- `storeCategories`가 fetch 되지 않은 경우, scroll을 막았습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* 근처 상점 목록의 초기 데이터 로딩 흐름을 개선했습니다.
* 카테고리 필터 적용 시 카테고리 데이터가 완전히 로드되지 않은 상태에서 발생하는 불안정한 스크롤 동작을 방지했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BCSDLab/KOIN_ANDROID/pull/1487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->