### PR TITLE
[Refactor] Maestro QA Build로 전환 및 auth flow 작성

### DIFF
--- a/.github/scripts/run_maestro_suite.sh
+++ b/.github/scripts/run_maestro_suite.sh
@@ -11,7 +11,7 @@ suite_path="$1"
 suite_name="$2"
 app_id="$3"
 
-if [[ "$suite_name" == *auth* && -z "${USER_PASSWORD:-}" ]]; then
+if [[ -z "${USER_PASSWORD:-}" ]]; then
   echo "USER_PASSWORD is required for auth Maestro suites. Set MAESTRO_USER_PASSWORD secret in GitHub Actions." >&2
   exit 1
 fi

--- a/.github/scripts/run_maestro_suite.sh
+++ b/.github/scripts/run_maestro_suite.sh
@@ -11,6 +11,11 @@ suite_path="$1"
 suite_name="$2"
 app_id="$3"
 
+if [[ "$suite_name" == *auth* && -z "${USER_PASSWORD:-}" ]]; then
+  echo "USER_PASSWORD is required for auth Maestro suites. Set MAESTRO_USER_PASSWORD secret in GitHub Actions." >&2
+  exit 1
+fi
+
 mkdir -p recordings debug-output .maestro/.generated
 
 wrapper_flow=".maestro/.generated/${suite_name}_recorded.yaml"
@@ -44,6 +49,7 @@ record_args=(
   --local
   --debug-output "$debug_output"
   -e "APP_ID=$app_id"
+  -e "USER_PASSWORD=${USER_PASSWORD:-}"
   "$wrapper_flow"
   "$video_output"
 )

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -99,6 +99,9 @@ jobs:
             adb install -r koin/build/outputs/apk/qa/koin-qa.apk
             chmod +x .github/scripts/run_maestro_suite.sh
             bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_guest_smoke.yaml" "student_guest_smoke" "$APP_ID"
+            bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_auth_smoke.yaml" "student_auth_smoke" "$APP_ID"
+        env:
+          USER_PASSWORD: ${{ secrets.MAESTRO_USER_PASSWORD }}
 
       - name: Upload Maestro test results
         if: always()

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -36,6 +36,7 @@ jobs:
           FIREBASE_STAGE: ${{ secrets.FIREBASE_STAGE }}
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
         run: |
+          mkdir -p ./koin/src/qa
           echo "$FIREBASE" | base64 -di > ./koin/google-services.json
           echo "$FIREBASE_STAGE" | base64 -di > ./koin/src/qa/google-services.json
           echo "$GOOGLE_CREDENTIALS" | base64 -di > ./google-credentials.json 

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     env:
-      APP_ID: in.koreatech.koin
+      APP_ID: in.koreatech.koin.dev
 
     steps:
       - uses: actions/checkout@v4
@@ -33,9 +33,11 @@ jobs:
       - name: Update Firebase
         env:
           FIREBASE: ${{ secrets.FIREBASE }}
+          FIREBASE_STAGE: ${{ secrets.FIREBASE_STAGE }}
           GOOGLE_CREDENTIALS: ${{ secrets.GOOGLE_CREDENTIALS }}
         run: |
-          echo "$FIREBASE" | base64 -di > ./koin/google-services.json  
+          echo "$FIREBASE" | base64 -di > ./koin/google-services.json
+          echo "$FIREBASE_STAGE" | base64 -di > ./koin/src/qa/google-services.json
           echo "$GOOGLE_CREDENTIALS" | base64 -di > ./google-credentials.json 
           for file in $(find . -name 'google-services.json')
           do
@@ -46,8 +48,8 @@ jobs:
            echo $file
           done
 
-      - name: Build release APK with Gradle
-        run: ./gradlew koin:assembleRelease
+      - name: Build QA APK with Gradle
+        run: ./gradlew koin:assembleQa
 
       - name: Enable KVM group perms
         run: |
@@ -94,7 +96,7 @@ jobs:
             mkdir -p recordings debug-output
             adb uninstall in.koreatech.koin || true
             adb uninstall in.koreatech.koin.dev || true
-            adb install -r koin/build/outputs/apk/release/koin-release.apk
+            adb install -r koin/build/outputs/apk/qa/koin-qa.apk
             chmod +x .github/scripts/run_maestro_suite.sh
             bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_guest_smoke.yaml" "student_guest_smoke" "$APP_ID"
 

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   maestro-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     env:
       APP_ID: in.koreatech.koin.dev
 

--- a/.github/workflows/maestro.yml
+++ b/.github/workflows/maestro.yml
@@ -99,8 +99,7 @@ jobs:
             adb uninstall in.koreatech.koin.dev || true
             adb install -r koin/build/outputs/apk/qa/koin-qa.apk
             chmod +x .github/scripts/run_maestro_suite.sh
-            bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_guest_smoke.yaml" "student_guest_smoke" "$APP_ID"
-            bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_auth_smoke.yaml" "student_auth_smoke" "$APP_ID"
+            bash .github/scripts/run_maestro_suite.sh ".maestro/suites/student_smoke.yaml" "student_smoke" "$APP_ID"
         env:
           USER_PASSWORD: ${{ secrets.MAESTRO_USER_PASSWORD }}
 

--- a/.maestro/common/dismiss_banner.yaml
+++ b/.maestro/common/dismiss_banner.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow:
+    when:
+      visible:
+        text: "닫기"
+    commands:
+      - tapOn:
+          text: "일주일 동안 그만 보기"
+          optional: true
+      - tapOn:
+          text: "닫기"
+          optional: true

--- a/.maestro/common/launch_app.yaml
+++ b/.maestro/common/launch_app.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - stopApp
 - openLink: "koin://main/navigation"

--- a/.maestro/common/launch_app.yaml
+++ b/.maestro/common/launch_app.yaml
@@ -7,5 +7,8 @@ env:
 - waitForAnimationToEnd:
     timeout: 15000
 - tapOn:
+    text: "허용"
+    optional: true
+- tapOn:
     text: "닫기"
     optional: true

--- a/.maestro/common/launch_app.yaml
+++ b/.maestro/common/launch_app.yaml
@@ -2,13 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- stopApp
+- launchApp:
+    permissions:
+      notifications: allow
+- waitForAnimationToEnd:
+    timeout: 5000
 - openLink: "koin://main/navigation"
 - waitForAnimationToEnd:
-    timeout: 15000
-- tapOn:
-    text: "허용"
-    optional: true
-- tapOn:
-    text: "닫기"
-    optional: true
+    timeout: 5000
+- runFlow: dismiss_banner.yaml

--- a/.maestro/common/login.yaml
+++ b/.maestro/common/login.yaml
@@ -1,0 +1,25 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- stopApp
+- openLink: "koin://login/navigation"
+- extendedWaitUntil:
+    visible: "로그인"
+    timeout: 15000
+- tapOn: "아이디(Koreatech ID/전화번호)"
+- inputText: "androidqa"
+- hideKeyboard
+- tapOn: "비밀번호"
+- inputText: "${USER_PASSWORD}"
+- hideKeyboard
+- tapOn: "로그인"
+- tapOn:
+    text: "허용"
+    optional: true
+- tapOn:
+    text: "닫기"
+    optional: true
+- extendedWaitUntil:
+    visible: "게시판"
+    timeout: 20000

--- a/.maestro/common/login.yaml
+++ b/.maestro/common/login.yaml
@@ -2,7 +2,13 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- stopApp
+- launchApp:
+    clearState: true
+    permissions:
+      notifications: allow
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow: dismiss_banner.yaml
 - openLink: "koin://login/navigation"
 - extendedWaitUntil:
     visible: "로그인"
@@ -14,12 +20,10 @@ env:
 - inputText: "${USER_PASSWORD}"
 - hideKeyboard
 - tapOn: "로그인"
-- tapOn:
-    text: "허용"
-    optional: true
-- tapOn:
-    text: "닫기"
-    optional: true
+- waitForAnimationToEnd:
+    timeout: 5000
+- runFlow: dismiss_banner.yaml
 - extendedWaitUntil:
     visible: "게시판"
     timeout: 20000
+- assertVisible: "게시판"

--- a/.maestro/common/logout.yaml
+++ b/.maestro/common/logout.yaml
@@ -1,0 +1,11 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_login_or_logout"
+- extendedWaitUntil:
+    visible: "로그인"
+    timeout: 10000
+- assertVisible: "로그인"

--- a/.maestro/common/open_drawer.yaml
+++ b/.maestro/common/open_drawer.yaml
@@ -3,7 +3,13 @@ env:
   APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: launch_app.yaml
+- extendedWaitUntil:
+    visible:
+      id: "${APP_ID}:id/button_category"
+    timeout: 15000
 - tapOn:
     id: "${APP_ID}:id/button_category"
-- waitForAnimationToEnd:
-    timeout: 5000
+- extendedWaitUntil:
+    visible:
+      id: "${APP_ID}:id/navi_item_setting"
+    timeout: 10000

--- a/.maestro/common/open_drawer.yaml
+++ b/.maestro/common/open_drawer.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: launch_app.yaml
 - tapOn:

--- a/.maestro/guest/article.yaml
+++ b/.maestro/guest/article.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://article/navigation"

--- a/.maestro/guest/auth_find_id.yaml
+++ b/.maestro/guest/auth_find_id.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://findid/navigation"

--- a/.maestro/guest/auth_find_password.yaml
+++ b/.maestro/guest/auth_find_password.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://findpassword/navigation"

--- a/.maestro/guest/auth_sign_in.yaml
+++ b/.maestro/guest/auth_sign_in.yaml
@@ -7,12 +7,19 @@ env:
 - extendedWaitUntil:
     visible: "로그인"
     timeout: 15000
+
+- assertVisible: "아이디(Koreatech ID/전화번호)"
+- assertVisible: "비밀번호"
 - assertVisible: "로그인"
 - assertVisible: "회원가입"
 - assertVisible: "아이디 찾기"
 - assertVisible: "비밀번호 찾기"
+- assertVisible: "둘러보기"
+- assertVisible: "사장님이신가요?"
+
 - tapOn: "아이디(Koreatech ID/전화번호)"
 - inputText: "invalid-user"
+- hideKeyboard
 - tapOn: "비밀번호"
 - inputText: "wrong-password"
 - hideKeyboard
@@ -21,3 +28,35 @@ env:
     visible: "아이디 또는 비밀번호가 올바르지 않습니다."
     timeout: 15000
 - assertVisible: "아이디 또는 비밀번호가 올바르지 않습니다."
+
+- tapOn: "invalid-user"
+- eraseText
+
+- tapOn: "아이디(Koreatech ID/전화번호)"
+- inputText: "01012345678"
+- assertVisible: "010-1234-5678"
+- hideKeyboard
+
+- tapOn: "회원가입"
+- waitForAnimationToEnd:
+    timeout: 5000
+- openLink: "koin://login/navigation"
+- extendedWaitUntil:
+    visible: "로그인"
+    timeout: 10000
+
+- tapOn: "아이디 찾기"
+- waitForAnimationToEnd:
+    timeout: 5000
+- openLink: "koin://login/navigation"
+- extendedWaitUntil:
+    visible: "로그인"
+    timeout: 10000
+
+- tapOn: "비밀번호 찾기"
+- waitForAnimationToEnd:
+    timeout: 5000
+- openLink: "koin://login/navigation"
+- extendedWaitUntil:
+    visible: "로그인"
+    timeout: 10000

--- a/.maestro/guest/auth_sign_in.yaml
+++ b/.maestro/guest/auth_sign_in.yaml
@@ -29,18 +29,11 @@ env:
     timeout: 15000
 - assertVisible: "아이디 또는 비밀번호가 올바르지 않습니다."
 
-- tapOn: "invalid-user"
-- eraseText
-
-- tapOn: "아이디(Koreatech ID/전화번호)"
-- inputText: "01012345678"
-- assertVisible: "010-1234-5678"
-- hideKeyboard
-
 - tapOn: "회원가입"
 - waitForAnimationToEnd:
     timeout: 5000
 - openLink: "koin://login/navigation"
+- hideKeyboard
 - extendedWaitUntil:
     visible: "로그인"
     timeout: 10000
@@ -49,6 +42,7 @@ env:
 - waitForAnimationToEnd:
     timeout: 5000
 - openLink: "koin://login/navigation"
+- hideKeyboard
 - extendedWaitUntil:
     visible: "로그인"
     timeout: 10000
@@ -57,6 +51,7 @@ env:
 - waitForAnimationToEnd:
     timeout: 5000
 - openLink: "koin://login/navigation"
+- hideKeyboard
 - extendedWaitUntil:
     visible: "로그인"
     timeout: 10000

--- a/.maestro/guest/auth_sign_in.yaml
+++ b/.maestro/guest/auth_sign_in.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://login/navigation"

--- a/.maestro/guest/auth_sign_up.yaml
+++ b/.maestro/guest/auth_sign_up.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://signup/navigation"

--- a/.maestro/guest/banner.yaml
+++ b/.maestro/guest/banner.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - assertVisible: "게시판"

--- a/.maestro/guest/bus.yaml
+++ b/.maestro/guest/bus.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - tapOn:

--- a/.maestro/guest/callvan.yaml
+++ b/.maestro/guest/callvan.yaml
@@ -1,9 +1,12 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - tapOn:
     id: "${APP_ID}:id/navi_item_callvan"
+- tapOn:
+    text: "알림 켜기"
+    optional: true
 - waitForAnimationToEnd:
     timeout: 10000

--- a/.maestro/guest/club.yaml
+++ b/.maestro/guest/club.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - scrollUntilVisible:

--- a/.maestro/guest/dining.yaml
+++ b/.maestro/guest/dining.yaml
@@ -7,7 +7,7 @@ env:
     id: "${APP_ID}:id/navi_item_dining"
 - runFlow:
     when:
-      visible: "알림 설정을 허용하고"
+      visible: "알림 설정 바로가기"
     commands:
       - pressKey: BACK
 - extendedWaitUntil:

--- a/.maestro/guest/dining.yaml
+++ b/.maestro/guest/dining.yaml
@@ -1,10 +1,15 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - tapOn:
     id: "${APP_ID}:id/navi_item_dining"
+- runFlow:
+    when:
+      visible: "알림 설정을 허용하고"
+    commands:
+      - pressKey: BACK
 - extendedWaitUntil:
     visible: "식단"
     timeout: 15000

--- a/.maestro/guest/home.yaml
+++ b/.maestro/guest/home.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - extendedWaitUntil:

--- a/.maestro/guest/land.yaml
+++ b/.maestro/guest/land.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - scrollUntilVisible:

--- a/.maestro/guest/lost_and_found.yaml
+++ b/.maestro/guest/lost_and_found.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - tapOn:

--- a/.maestro/guest/operating_info.yaml
+++ b/.maestro/guest/operating_info.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - scrollUntilVisible:

--- a/.maestro/guest/settings.yaml
+++ b/.maestro/guest/settings.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - tapOn:

--- a/.maestro/guest/store.yaml
+++ b/.maestro/guest/store.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/launch_app.yaml
 - openLink: "koin://store"

--- a/.maestro/guest/timetable.yaml
+++ b/.maestro/guest/timetable.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../common/open_drawer.yaml
 - scrollUntilVisible:

--- a/.maestro/student/article_keyword.yaml
+++ b/.maestro/student/article_keyword.yaml
@@ -28,9 +28,3 @@ env:
     visible: "maestroarticle"
     timeout: 5000
 - assertVisible: "maestroarticle"
-
-- tapOn: "maestroarticle"
-- extendedWaitUntil:
-    notVisible: "maestroarticle"
-    timeout: 5000
-- assertNotVisible: "maestroarticle"

--- a/.maestro/student/article_keyword.yaml
+++ b/.maestro/student/article_keyword.yaml
@@ -28,3 +28,10 @@ env:
     visible: "maestroarticle"
     timeout: 5000
 - assertVisible: "maestroarticle"
+
+# 키워드 삭제 테스트: Material Chip 닫기 아이콘(접근성 라벨 "<키워드> 삭제")을 탭하면 제거
+- tapOn: "maestroarticle 삭제"
+- extendedWaitUntil:
+    notVisible: "maestroarticle"
+    timeout: 5000
+- assertNotVisible: "maestroarticle"

--- a/.maestro/student/article_keyword.yaml
+++ b/.maestro/student/article_keyword.yaml
@@ -29,7 +29,6 @@ env:
     timeout: 5000
 - assertVisible: "maestroarticle"
 
-# 키워드 삭제 테스트: Material Chip 닫기 아이콘(접근성 라벨 "<키워드> 삭제")을 탭하면 제거
 - tapOn: "maestroarticle 삭제"
 - extendedWaitUntil:
     notVisible: "maestroarticle"

--- a/.maestro/student/article_keyword.yaml
+++ b/.maestro/student/article_keyword.yaml
@@ -29,7 +29,7 @@ env:
     timeout: 5000
 - assertVisible: "maestroarticle"
 
-- tapOn: "maestroarticle 삭제"
+- tapOn: "maestroarticle"
 - extendedWaitUntil:
     notVisible: "maestroarticle"
     timeout: 5000

--- a/.maestro/student/article_keyword.yaml
+++ b/.maestro/student/article_keyword.yaml
@@ -1,0 +1,30 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- openLink: "koin://article/navigation"
+- extendedWaitUntil:
+    visible: "공지사항"
+    timeout: 15000
+
+- tapOn:
+    id: "${APP_ID}:id/image_view_to_keyword_add_page"
+- extendedWaitUntil:
+    visible: "키워드 관리"
+    timeout: 10000
+
+- assertNotVisible: "키워드 알림을 받으려면"
+- assertVisible: "키워드 관리"
+- assertVisible: "내 키워드"
+- assertVisible: "추천 키워드"
+- assertVisible: "알림받을 키워드를 입력해 주세요."
+
+- tapOn: "알림받을 키워드를 입력해 주세요."
+- inputText: "maestroarticle"
+- hideKeyboard
+- tapOn: "추가"
+- extendedWaitUntil:
+    visible: "maestroarticle"
+    timeout: 5000
+- assertVisible: "maestroarticle"

--- a/.maestro/student/callvan_create.yaml
+++ b/.maestro/student/callvan_create.yaml
@@ -2,8 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
+- scrollUntilVisible:
+    element:
+      id: "${APP_ID}:id/navi_item_callvan"
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "${APP_ID}:id/navi_item_callvan"
 - tapOn:

--- a/.maestro/student/callvan_create.yaml
+++ b/.maestro/student/callvan_create.yaml
@@ -1,0 +1,44 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_callvan"
+- tapOn:
+    text: "알림 켜기"
+    optional: true
+- extendedWaitUntil:
+    visible: "모집하기"
+    timeout: 10000
+
+- tapOn: "모집하기"
+- extendedWaitUntil:
+    visible: "출발지 선택"
+    timeout: 10000
+- assertVisible: "출발"
+- assertVisible: "도착"
+- assertVisible: "출발일"
+- assertVisible: "출발 시각"
+- assertVisible: "참여 인원"
+- assertVisible: "작성 완료"
+
+- tapOn: "출발지 선택"
+- extendedWaitUntil:
+    visible: "출발지가 어디인가요?"
+    timeout: 5000
+- tapOn: "천안역"
+- tapOn: "선택하기"
+
+- tapOn: "도착지 선택"
+- extendedWaitUntil:
+    visible: "도착지가 어디인가요?"
+    timeout: 5000
+- tapOn: "정문"
+- tapOn: "선택하기"
+
+- pressKey: BACK
+- extendedWaitUntil:
+    visible: "모집하기"
+    timeout: 10000

--- a/.maestro/student/callvan_detail.yaml
+++ b/.maestro/student/callvan_detail.yaml
@@ -2,8 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
+- scrollUntilVisible:
+    element:
+      id: "${APP_ID}:id/navi_item_callvan"
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "${APP_ID}:id/navi_item_callvan"
 - tapOn:

--- a/.maestro/student/callvan_detail.yaml
+++ b/.maestro/student/callvan_detail.yaml
@@ -1,0 +1,19 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_callvan"
+- tapOn:
+    text: "알림 켜기"
+    optional: true
+- extendedWaitUntil:
+    visible: "모집하기"
+    timeout: 10000
+
+- assertNotVisible: "콜밴팟에 참여하려면 로그인이 필요해요."
+- assertVisible: "검색어를 입력해주세요."
+
+- assertVisible: "모집하기"

--- a/.maestro/student/callvan_notifications.yaml
+++ b/.maestro/student/callvan_notifications.yaml
@@ -2,8 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
+- scrollUntilVisible:
+    element:
+      id: "${APP_ID}:id/navi_item_callvan"
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "${APP_ID}:id/navi_item_callvan"
 - tapOn:

--- a/.maestro/student/callvan_notifications.yaml
+++ b/.maestro/student/callvan_notifications.yaml
@@ -1,0 +1,20 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_callvan"
+- tapOn:
+    text: "알림 켜기"
+    optional: true
+- extendedWaitUntil:
+    visible: "모집하기"
+    timeout: 10000
+
+- tapOn: "알림"
+- extendedWaitUntil:
+    visible: "알림"
+    timeout: 10000
+- assertVisible: "알림"

--- a/.maestro/student/chat_list.yaml
+++ b/.maestro/student/chat_list.yaml
@@ -1,0 +1,11 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_chat"
+- extendedWaitUntil:
+    visible: "쪽지"
+    timeout: 15000
+- assertVisible: "쪽지"

--- a/.maestro/student/lostandfound_keyword.yaml
+++ b/.maestro/student/lostandfound_keyword.yaml
@@ -35,7 +35,6 @@ env:
     timeout: 5000
 - assertVisible: "maestrotest"
 
-# 키워드 삭제 테스트: 내 키워드 칩은 전체가 클릭 = 삭제 동작
 - tapOn: "maestrotest"
 - extendedWaitUntil:
     notVisible: "maestrotest"

--- a/.maestro/student/lostandfound_keyword.yaml
+++ b/.maestro/student/lostandfound_keyword.yaml
@@ -2,8 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
+- scrollUntilVisible:
+    element:
+      id: "${APP_ID}:id/navi_item_lost_and_found"
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "${APP_ID}:id/navi_item_lost_and_found"
 - extendedWaitUntil:
@@ -30,3 +34,10 @@ env:
     visible: "maestrotest"
     timeout: 5000
 - assertVisible: "maestrotest"
+
+# 키워드 삭제 테스트: 내 키워드 칩은 전체가 클릭 = 삭제 동작
+- tapOn: "maestrotest"
+- extendedWaitUntil:
+    notVisible: "maestrotest"
+    timeout: 5000
+- assertNotVisible: "maestrotest"

--- a/.maestro/student/lostandfound_keyword.yaml
+++ b/.maestro/student/lostandfound_keyword.yaml
@@ -1,0 +1,32 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_lost_and_found"
+- extendedWaitUntil:
+    visible: "분실물"
+    timeout: 15000
+
+- assertNotVisible: "키워드 알림을 받으려면"
+
+- tapOn: "키워드 알림 설정"
+- extendedWaitUntil:
+    visible: "분실물 키워드 관리"
+    timeout: 10000
+
+- assertVisible: "분실물 키워드 관리"
+- assertVisible: "내 키워드"
+- assertVisible: "추천 키워드"
+- assertVisible: "잃어버린 물건을 입력해 주세요."
+
+- tapOn: "잃어버린 물건을 입력해 주세요."
+- inputText: "maestrotest"
+- hideKeyboard
+- tapOn: "추가"
+- extendedWaitUntil:
+    visible: "maestrotest"
+    timeout: 5000
+- assertVisible: "maestrotest"

--- a/.maestro/student/lostandfound_keyword.yaml
+++ b/.maestro/student/lostandfound_keyword.yaml
@@ -34,9 +34,3 @@ env:
     visible: "maestrotest"
     timeout: 5000
 - assertVisible: "maestrotest"
-
-- tapOn: "maestrotest"
-- extendedWaitUntil:
-    notVisible: "maestrotest"
-    timeout: 5000
-- assertNotVisible: "maestrotest"

--- a/.maestro/student/lostandfound_write.yaml
+++ b/.maestro/student/lostandfound_write.yaml
@@ -1,0 +1,31 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_lost_and_found"
+- extendedWaitUntil:
+    visible: "분실물"
+    timeout: 15000
+
+- tapOn: "글쓰기"
+- extendedWaitUntil:
+    visible: "잃어버렸어요"
+    timeout: 5000
+- tapOn: "잃어버렸어요"
+- extendedWaitUntil:
+    visible: "분실물 신고"
+    timeout: 10000
+
+- assertVisible: "분실물 신고"
+- assertVisible: "분실 일자.*"
+- assertVisible: "분실 장소"
+- assertVisible: "작성 완료"
+
+- tapOn: "작성 완료"
+- extendedWaitUntil:
+    visible: "분실일자가 입력되지 않았습니다."
+    timeout: 5000
+- assertVisible: "분실일자가 입력되지 않았습니다."

--- a/.maestro/student/lostandfound_write.yaml
+++ b/.maestro/student/lostandfound_write.yaml
@@ -2,8 +2,12 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
+- scrollUntilVisible:
+    element:
+      id: "${APP_ID}:id/navi_item_lost_and_found"
+    direction: DOWN
+    timeout: 10000
 - tapOn:
     id: "${APP_ID}:id/navi_item_lost_and_found"
 - extendedWaitUntil:
@@ -20,10 +24,21 @@ env:
     timeout: 10000
 
 - assertVisible: "분실물 신고"
-- assertVisible: "분실 일자.*"
-- assertVisible: "분실 장소"
-- assertVisible: "작성 완료"
 
+- scrollUntilVisible:
+    element:
+      text: "분실 일자.*"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "분실 일자.*"
+- scrollUntilVisible:
+    element:
+      text: "분실 장소"
+    direction: DOWN
+    timeout: 10000
+- assertVisible: "분실 장소"
+
+- assertVisible: "작성 완료"
 - tapOn: "작성 완료"
 - extendedWaitUntil:
     visible: "분실일자가 입력되지 않았습니다."

--- a/.maestro/student/settings_logged_in.yaml
+++ b/.maestro/student/settings_logged_in.yaml
@@ -1,0 +1,24 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/launch_app.yaml
+- runFlow: ../common/open_drawer.yaml
+- tapOn:
+    id: "${APP_ID}:id/navi_item_setting"
+- extendedWaitUntil:
+    visible: "설정"
+    timeout: 10000
+
+- assertVisible: "프로필"
+- assertVisible: "비밀번호 변경"
+- assertVisible: "알림"
+
+- tapOn: "프로필"
+- extendedWaitUntil:
+    visible: "내 프로필"
+    timeout: 10000
+- assertVisible: "내 프로필"
+- assertVisible: "기본 정보"
+- assertVisible: "아이디"
+- assertVisible: "androidqa"

--- a/.maestro/student/settings_logged_in.yaml
+++ b/.maestro/student/settings_logged_in.yaml
@@ -2,7 +2,6 @@ appId: ${APP_ID}
 env:
   APP_ID: in.koreatech.koin.dev
 ---
-- runFlow: ../common/launch_app.yaml
 - runFlow: ../common/open_drawer.yaml
 - tapOn:
     id: "${APP_ID}:id/navi_item_setting"

--- a/.maestro/suites/student_auth_smoke.yaml
+++ b/.maestro/suites/student_auth_smoke.yaml
@@ -1,0 +1,14 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../common/login.yaml
+- runFlow: ../student/settings_logged_in.yaml
+- runFlow: ../student/callvan_create.yaml
+- runFlow: ../student/callvan_notifications.yaml
+- runFlow: ../student/callvan_detail.yaml
+- runFlow: ../student/chat_list.yaml
+- runFlow: ../student/lostandfound_write.yaml
+- runFlow: ../student/lostandfound_keyword.yaml
+- runFlow: ../student/article_keyword.yaml
+- runFlow: ../common/logout.yaml

--- a/.maestro/suites/student_guest_smoke.yaml
+++ b/.maestro/suites/student_guest_smoke.yaml
@@ -1,6 +1,6 @@
 appId: ${APP_ID}
 env:
-  APP_ID: in.koreatech.koin
+  APP_ID: in.koreatech.koin.dev
 ---
 - runFlow: ../guest/home.yaml
 - runFlow: ../guest/auth_sign_in.yaml

--- a/.maestro/suites/student_smoke.yaml
+++ b/.maestro/suites/student_smoke.yaml
@@ -1,0 +1,31 @@
+appId: ${APP_ID}
+env:
+  APP_ID: in.koreatech.koin.dev
+---
+- runFlow: ../guest/home.yaml
+- runFlow: ../guest/auth_sign_in.yaml
+- runFlow: ../guest/auth_find_id.yaml
+- runFlow: ../guest/auth_find_password.yaml
+- runFlow: ../guest/auth_sign_up.yaml
+- runFlow: ../guest/article.yaml
+- runFlow: ../guest/lost_and_found.yaml
+- runFlow: ../guest/store.yaml
+- runFlow: ../guest/bus.yaml
+- runFlow: ../guest/dining.yaml
+- runFlow: ../guest/timetable.yaml
+- runFlow: ../guest/club.yaml
+- runFlow: ../guest/callvan.yaml
+- runFlow: ../guest/land.yaml
+- runFlow: ../guest/settings.yaml
+- runFlow: ../guest/operating_info.yaml
+- runFlow: ../guest/banner.yaml
+- runFlow: ../common/login.yaml
+- runFlow: ../student/settings_logged_in.yaml
+- runFlow: ../student/callvan_create.yaml
+- runFlow: ../student/callvan_notifications.yaml
+- runFlow: ../student/callvan_detail.yaml
+- runFlow: ../student/chat_list.yaml
+- runFlow: ../student/lostandfound_write.yaml
+- runFlow: ../student/lostandfound_keyword.yaml
+- runFlow: ../student/article_keyword.yaml
+- runFlow: ../common/logout.yaml

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/detail/CallvanDetailScreen.kt
@@ -119,7 +119,10 @@ fun CallvanDetailScreenImpl(
                 onNavigationIconClick = onTopbarBackClick,
                 actions = {
                     IconButton(onClick = onNotificationClick) {
-                        CallvanNotificationIcon(hasNewNotification = hasNewNotification)
+                        CallvanNotificationIcon(
+                            hasNewNotification = hasNewNotification,
+                            contentDescription = stringResource(R.string.callvan_notification_top_bar)
+                        )
                     }
                 }
             )

--- a/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
+++ b/feature/callvan/src/main/java/in/koreatech/koin/feature/callvan/ui/list/CallvanListScreen.kt
@@ -289,7 +289,10 @@ fun CallvanListScreenImpl(
                     },
                     actions = {
                         IconButton(onClick = onNotificationClick) {
-                            CallvanNotificationIcon(hasNewNotification = hasNewNotification)
+                            CallvanNotificationIcon(
+                                hasNewNotification = hasNewNotification,
+                                contentDescription = stringResource(R.string.callvan_notification_top_bar)
+                            )
                         }
                     }
                 )

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserPasswordTextField.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserPasswordTextField.kt
@@ -19,6 +19,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setText
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -55,7 +58,12 @@ fun KoinUserPasswordTextField(
     onShowPasswordChange: (Boolean) -> Unit = {}
 ) {
     BasicTextField(
-        modifier = modifier,
+        modifier = modifier.semantics {
+            setText { text ->
+                onValueChange(text.text)
+                true
+            }
+        },
         value = value,
         onValueChange = {
             if (it.length < maxLength) {
@@ -113,7 +121,9 @@ fun KoinUserPasswordTextField(
                                 onShowPasswordChange(!showPassword)
                             },
                         painter = painterResource(id = if (showPassword) R.drawable.ic_user_hide_password else R.drawable.ic_user_show_password),
-                        contentDescription = null
+                        contentDescription = stringResource(
+                            if (showPassword) R.string.sign_in_hide_password else R.string.sign_in_show_password
+                        )
                     )
                 }
                 HorizontalDivider(

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserPasswordTextField.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/component/KoinUserPasswordTextField.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.BuildConfig
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.user.R
@@ -58,11 +59,15 @@ fun KoinUserPasswordTextField(
     onShowPasswordChange: (Boolean) -> Unit = {}
 ) {
     BasicTextField(
-        modifier = modifier.semantics {
-            setText { text ->
-                onValueChange(text.text)
-                true
+        modifier = if (BuildConfig.IS_QA) {
+            modifier.semantics {
+                setText { text ->
+                    onValueChange(text.text)
+                    true
+                }
             }
+        } else {
+            modifier
         },
         value = value,
         onValueChange = {

--- a/feature/user/src/main/res/values/strings.xml
+++ b/feature/user/src/main/res/values/strings.xml
@@ -80,6 +80,8 @@
     <string name="sign_in_sign_up">회원가입</string>
     <string name="sign_in_login_id_hint">아이디(Koreatech ID/전화번호)</string>
     <string name="sign_in_password_hint">비밀번호</string>
+    <string name="sign_in_show_password">비밀번호 표시</string>
+    <string name="sign_in_hide_password">비밀번호 숨기기</string>
     <string name="sign_in_error">아이디 또는 비밀번호가 올바르지 않습니다.</string>
     <string name="sign_in_find_login_id">아이디 찾기</string>
     <string name="sign_in_find_password">비밀번호 찾기</string>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1503 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- Maestro Github Actions를 QA Build로 교체했습니다.
- auth flow를 추가했습니다.
- 일부 semantics 및 contentDescription를 추가했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **Tests**
  * CI에서 QA 빌드 기반 Maestro 실행으로 전환하고, 학생 인증을 포함한 스모크 스위트 범위를 확장했습니다.
  * 분실물/쪽지/콜밴(생성·알림·상세)/키워드/기사 키워드 E2E 시나리오를 추가·보강했습니다.

* **Chores**
  * 테스트 실행 전 비밀번호 값 사전 검증 및 환경 변수 주입을 추가했습니다.
  * QA 환경용 앱 식별자 전환 및 배너/로그인 실행 흐름을 정리했습니다.

* **Accessibility**
  * 비밀번호 표시/숨김 문구와 콜밴 알림 아이콘의 접근성 설명을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->