### PR TITLE
[Feature] Notification DB 값 추가

### DIFF
--- a/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/4.json
+++ b/data/schemas/debug/in.koreatech.koin.data.db.AppDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "2e2b9257bdabb1ca4d6f0f7800fe4f4f",
+    "identityHash": "dd12f144e279a3baf9af39855f09b3a0",
     "entities": [
       {
         "tableName": "cache_metadata",
@@ -97,7 +97,7 @@
       },
       {
         "tableName": "notification",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `datetime` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `datetime` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `originUrl` TEXT NOT NULL, `isRead` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -128,6 +128,18 @@
             "columnName": "content",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "originUrl",
+            "columnName": "originUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -135,12 +147,23 @@
           "columnNames": [
             "id"
           ]
-        }
+        },
+        "indices": [
+          {
+            "name": "index_notification_originUrl",
+            "unique": true,
+            "columnNames": [
+              "originUrl"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_notification_originUrl` ON `${TABLE_NAME}` (`originUrl`)"
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2e2b9257bdabb1ca4d6f0f7800fe4f4f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dd12f144e279a3baf9af39855f09b3a0')"
     ]
   }
 }

--- a/data/schemas/in.koreatech.koin.data.db.AppDatabase/4.json
+++ b/data/schemas/in.koreatech.koin.data.db.AppDatabase/4.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 4,
-    "identityHash": "2e2b9257bdabb1ca4d6f0f7800fe4f4f",
+    "identityHash": "dd12f144e279a3baf9af39855f09b3a0",
     "entities": [
       {
         "tableName": "cache_metadata",
@@ -97,7 +97,7 @@
       },
       {
         "tableName": "notification",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `datetime` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL)",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `datetime` TEXT NOT NULL, `title` TEXT NOT NULL, `content` TEXT NOT NULL, `originUrl` TEXT NOT NULL, `isRead` INTEGER NOT NULL)",
         "fields": [
           {
             "fieldPath": "id",
@@ -128,6 +128,18 @@
             "columnName": "content",
             "affinity": "TEXT",
             "notNull": true
+          },
+          {
+            "fieldPath": "originUrl",
+            "columnName": "originUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
           }
         ],
         "primaryKey": {
@@ -135,12 +147,23 @@
           "columnNames": [
             "id"
           ]
-        }
+        },
+        "indices": [
+          {
+            "name": "index_notification_originUrl",
+            "unique": true,
+            "columnNames": [
+              "originUrl"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_notification_originUrl` ON `${TABLE_NAME}` (`originUrl`)"
+          }
+        ]
       }
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2e2b9257bdabb1ca4d6f0f7800fe4f4f')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dd12f144e279a3baf9af39855f09b3a0')"
     ]
   }
 }

--- a/data/src/main/java/in/koreatech/koin/data/dao/NotificationDao.kt
+++ b/data/src/main/java/in/koreatech/koin/data/dao/NotificationDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import `in`.koreatech.koin.data.constant.DBConstant
 import `in`.koreatech.koin.data.entity.NotificationEntity
 import java.time.LocalDateTime
@@ -18,6 +19,30 @@ interface NotificationDao {
 
     @Query("SELECT * FROM ${DBConstant.NOTIFICATION}")
     suspend fun getNotifications(): List<NotificationEntity>
+
+    @Query("SELECT * FROM ${DBConstant.NOTIFICATION} WHERE originUrl = :url")
+    suspend fun getNotificationByUrl(url: String): NotificationEntity
+
+    @Query("SELECT * FROM ${DBConstant.NOTIFICATION} WHERE id = :id")
+    suspend fun getNotificationById(id: Int): NotificationEntity
+
+    @Query("UPDATE ${DBConstant.NOTIFICATION} SET isRead = :isRead WHERE originUrl = :url")
+    suspend fun updateReadByUrl(url: String, isRead: Boolean)
+
+    @Query("UPDATE ${DBConstant.NOTIFICATION} SET isRead = :isRead WHERE id = :id")
+    suspend fun updateReadById(id: Int, isRead: Boolean)
+
+    @Transaction
+    suspend fun updateReadByUrlAndReturn(url: String, isRead: Boolean): NotificationEntity {
+        updateReadByUrl(url, isRead)
+        return getNotificationByUrl(url)
+    }
+
+    @Transaction
+    suspend fun updateReadByIdAndReturn(id: Int, isRead: Boolean): NotificationEntity {
+        updateReadById(id, isRead)
+        return getNotificationById(id)
+    }
 
     @Query("DELETE FROM ${DBConstant.NOTIFICATION} WHERE datetime < :datetime")
     suspend fun deleteOldNotifications(datetime: LocalDateTime)

--- a/data/src/main/java/in/koreatech/koin/data/dao/NotificationDao.kt
+++ b/data/src/main/java/in/koreatech/koin/data/dao/NotificationDao.kt
@@ -9,6 +9,7 @@ import `in`.koreatech.koin.data.constant.DBConstant
 import `in`.koreatech.koin.data.entity.NotificationEntity
 import java.time.LocalDateTime
 
+@Suppress("Detekt.TooManyFunctions")
 @Dao
 interface NotificationDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)

--- a/data/src/main/java/in/koreatech/koin/data/entity/NotificationEntity.kt
+++ b/data/src/main/java/in/koreatech/koin/data/entity/NotificationEntity.kt
@@ -12,5 +12,7 @@ data class NotificationEntity(
     @ColumnInfo val type: String,
     @ColumnInfo val datetime: LocalDateTime,
     @ColumnInfo val title: String,
-    @ColumnInfo val content: String
+    @ColumnInfo val content: String,
+    @ColumnInfo val originUrl: String,
+    @ColumnInfo val isRead: Boolean
 )

--- a/data/src/main/java/in/koreatech/koin/data/entity/NotificationEntity.kt
+++ b/data/src/main/java/in/koreatech/koin/data/entity/NotificationEntity.kt
@@ -2,11 +2,15 @@ package `in`.koreatech.koin.data.entity
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import `in`.koreatech.koin.data.constant.DBConstant
 import java.time.LocalDateTime
 
-@Entity(tableName = DBConstant.NOTIFICATION)
+@Entity(
+    tableName = DBConstant.NOTIFICATION,
+    indices = [Index(value = ["originUrl"], unique = true)]
+)
 data class NotificationEntity(
     @PrimaryKey(autoGenerate = true) val id: Int = 0,
     @ColumnInfo val type: String,

--- a/data/src/main/java/in/koreatech/koin/data/mapper/NotificationMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/NotificationMapper.kt
@@ -56,7 +56,9 @@ fun Notification.toNotificationEntity(): NotificationEntity = NotificationEntity
     type = type,
     datetime = datetime,
     title = title,
-    content = content
+    content = content,
+    originUrl = originUrl,
+    isRead = isRead
 )
 
 fun NotificationEntity.toNotification(): Notification = Notification(
@@ -64,5 +66,7 @@ fun NotificationEntity.toNotification(): Notification = Notification(
     type = type,
     datetime = datetime,
     title = title,
-    content = content
+    content = content,
+    originUrl = originUrl,
+    isRead = isRead
 )

--- a/data/src/main/java/in/koreatech/koin/data/repository/NotificationRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/NotificationRepositoryImpl.kt
@@ -104,6 +104,18 @@ class NotificationRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateNotificationReadByUrl(url: String, isRead: Boolean): Result<Notification> {
+        return suspendRunCatching {
+            notificationLocalDataSource.updateNotificationReadByUrl(url, isRead).toNotification()
+        }
+    }
+
+    override suspend fun updateNotificationReadById(id: Int, isRead: Boolean): Result<Notification> {
+        return suspendRunCatching {
+            notificationLocalDataSource.updateNotificationReadById(id, isRead).toNotification()
+        }
+    }
+
     override suspend fun getNotificationsFromLocal(): Result<List<Notification>> {
         return suspendRunCatching {
             notificationLocalDataSource.getNotifications().map { it.toNotification() }

--- a/data/src/main/java/in/koreatech/koin/data/source/local/NotificationLocalDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/local/NotificationLocalDataSource.kt
@@ -20,6 +20,14 @@ class NotificationLocalDataSource @Inject constructor(
         return notificationDao.getNotifications()
     }
 
+    suspend fun updateNotificationReadByUrl(url: String, isRead: Boolean): NotificationEntity {
+        return notificationDao.updateReadByUrlAndReturn(url, isRead)
+    }
+
+    suspend fun updateNotificationReadById(id: Int, isRead: Boolean): NotificationEntity {
+        return notificationDao.updateReadByIdAndReturn(id, isRead)
+    }
+
     suspend fun deleteOldNotifications(dateTime: LocalDateTime) {
         notificationDao.deleteOldNotifications(dateTime)
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/notification/Notification.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/notification/Notification.kt
@@ -7,5 +7,7 @@ data class Notification(
     val type: String,
     val datetime: LocalDateTime,
     val title: String,
-    val content: String
+    val content: String,
+    val originUrl: String,
+    val isRead: Boolean
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/NotificationRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/NotificationRepository.kt
@@ -5,6 +5,7 @@ import `in`.koreatech.koin.domain.model.notification.NotificationPermissionInfo
 import `in`.koreatech.koin.domain.model.notification.SubscribesDetailType
 import `in`.koreatech.koin.domain.model.notification.SubscribesType
 
+@Suppress("Detekt.TooManyFunctions")
 interface NotificationRepository {
     suspend fun getPermissionInfo(): Result<NotificationPermissionInfo>
 

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/NotificationRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/NotificationRepository.kt
@@ -22,6 +22,10 @@ interface NotificationRepository {
 
     suspend fun insertNotificationsToLocal(notifications: List<Notification>): Result<Unit>
 
+    suspend fun updateNotificationReadByUrl(url: String, isRead: Boolean): Result<Notification>
+
+    suspend fun updateNotificationReadById(id: Int, isRead: Boolean): Result<Notification>
+
     suspend fun getNotificationsFromLocal(): Result<List<Notification>>
 
     suspend fun deleteNotificationFromLocal(id: Int): Result<Unit>

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/SaveNotificationUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/SaveNotificationUseCase.kt
@@ -12,6 +12,8 @@ class SaveNotificationUseCase @Inject constructor(
         type: String,
         title: String,
         content: String,
+        originUrl: String,
+        isRead: Boolean = false,
         datetime: LocalDateTime = LocalDateTime.now()
     ): Result<Unit> {
         return notificationRepository.insertNotificationToLocal(
@@ -19,7 +21,9 @@ class SaveNotificationUseCase @Inject constructor(
                 type = type,
                 title = title,
                 content = content,
-                datetime = datetime
+                datetime = datetime,
+                originUrl = originUrl,
+                isRead = isRead
             )
         )
     }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/UpdateNotificationReadByIdUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/UpdateNotificationReadByIdUseCase.kt
@@ -1,0 +1,19 @@
+package `in`.koreatech.koin.domain.usecase.notification
+
+import `in`.koreatech.koin.domain.model.notification.Notification
+import `in`.koreatech.koin.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class UpdateNotificationReadByIdUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository
+) {
+    suspend operator fun invoke(
+        id: Int,
+        isRead: Boolean
+    ): Result<Notification> {
+        return notificationRepository.updateNotificationReadById(
+            id = id,
+            isRead = isRead
+        )
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/UpdateNotificationReadByUrlUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/notification/UpdateNotificationReadByUrlUseCase.kt
@@ -1,0 +1,19 @@
+package `in`.koreatech.koin.domain.usecase.notification
+
+import `in`.koreatech.koin.domain.model.notification.Notification
+import `in`.koreatech.koin.domain.repository.NotificationRepository
+import javax.inject.Inject
+
+class UpdateNotificationReadByUrlUseCase @Inject constructor(
+    private val notificationRepository: NotificationRepository
+) {
+    suspend operator fun invoke(
+        originUrl: String,
+        isRead: Boolean
+    ): Result<Notification> {
+        return notificationRepository.updateNotificationReadByUrl(
+            url = originUrl,
+            isRead = isRead
+        )
+    }
+}

--- a/koin/src/main/java/in/koreatech/koin/firebase/KoinFirebaseMessagingService.kt
+++ b/koin/src/main/java/in/koreatech/koin/firebase/KoinFirebaseMessagingService.kt
@@ -70,7 +70,8 @@ class KoinFirebaseMessagingService : FirebaseMessagingService() {
                         saveNotificationUseCase(
                             type = url.schemeToNotificationType(),
                             title = title,
-                            content = content
+                            content = content,
+                            originUrl = url
                         ).onFailure {
                             Timber.e("Notification save failed: $it")
                         }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1507 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- Notification DB에 `isRead` 및 `originUrl` 필드 두개를 추가했습니다.
- `isRead` update query 및 usecase를 추가했습니다.
### 논의 사항
- 아직 배포는 안되었기 때문에, DB 버전은 안 올렸습니다.
### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 알림에 원본 URL(`originUrl`)과 읽음 여부(`isRead`)를 함께 저장하도록 개선되었습니다.
  * 새 알림 저장 시 원본 URL 정보가 함께 전달됩니다.
  * 알림을 원본 URL 또는 알림 ID 기준으로 읽음 상태로 변경할 수 있으며, 변경된 알림 정보를 바로 받을 수 있습니다.
* **Bug Fixes**
  * 읽음 상태 변경과 결과 조회가 한 번에 처리되어 더 일관된 응답을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->