### PR TITLE
[Feature] 홈화면/네비게이션 바 클릭 이벤트 로깅 추가

### DIFF
--- a/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
+++ b/core/analytics/src/main/java/in/koreatech/koin/core/analytics/AnalyticsConstant.kt
@@ -115,6 +115,21 @@ object AnalyticsConstant {
         const val TO_MANAGE_KEYWORD = "to_manage_keyword"
 
         const val LOGIN_PROMPT = "login_prompt"
+        const val NOTIFICATION_LIST = "notification_list"
+        const val NOTIFICATION_LIST_READ_ALL = "notification_list_read_all"
+        const val NOTIFICATION_DELETE_ALL = "notification_delete_all"
+        const val NOTIFICATION_LIST_DELETE = "notification_list_delete"
+        const val TODAY_MEAL = "today_meal"
+        const val MENU_CORNER = "menu_corner"
+        const val SHUTTLE_TICKET = "shuttle_ticket"
+        const val CALLVANPOT = "callvanpot"
+        const val BUS_ROUTE = "bus_route"
+        const val SHOP = "shop"
+        const val POPULAR_SHOP = "popular_shop"
+        const val NAV_HOME = "nav_home"
+        const val NAV_CATEGORY = "nav_category"
+        const val NAV_BULLETIN = "nav_bulletin"
+        const val NAV_PROFILE = "nav_profile"
 
         object LostAndFound {
             const val LOST_ITEM_ADD_ITEM = "lost_item_add_item"

--- a/feature/home/src/main/java/in/koreatech/koin/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/in/koreatech/koin/feature/home/HomeScreen.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import coil.compose.AsyncImage
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
@@ -134,7 +136,10 @@ private fun HeaderSection(
         Spacer(modifier = Modifier.weight(1f))
 
         Image(
-            modifier = Modifier.noRippleClickable(onClick = onNotificationClick),
+            modifier = Modifier.noRippleClickable {
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.NOTIFICATION, "알림 아이콘")
+                onNotificationClick()
+            },
             imageVector = if (isNewNotificationReceived) {
                 ImageVector.vectorResource(R.drawable.ic_home_notification_dot)
             } else {
@@ -219,6 +224,7 @@ private fun DiningSection(
         more = {
             Row(
                 modifier = Modifier.noRippleClickable {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.TODAY_MEAL, "전체보기")
                     navigator.navigateToDining(context).let(context::startActivity)
                 },
                 verticalAlignment = Alignment.CenterVertically
@@ -259,6 +265,7 @@ private fun BusSection(
         },
         more = {
             ShuttleTicketCard {
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.SHUTTLE_TICKET, "셔틀 탑승권")
                 navigator.navigateToUnibus(context).let(context::startActivity)
             }
         }
@@ -314,6 +321,7 @@ private fun BusSection(
                     }
                 },
                 onClick = {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.CALLVANPOT, "콜밴팟 모집보기")
                     navigator.navigateToCallvan(context).let(context::startActivity)
                 }
             )
@@ -353,6 +361,7 @@ private fun BusSection(
                     )
                 },
                 onClick = {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.BUS_TIMETABLE, "버스 시간표 조회하기")
                     navigator.navigateToBusTimeTable(context).let(context::startActivity)
                 }
             )
@@ -388,6 +397,7 @@ private fun BusSection(
                     )
                 },
                 onClick = {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.BUS_ROUTE, "버스 노선 조회하기")
                     navigator.navigateToBusSearch(context).let(context::startActivity)
                 }
             )
@@ -418,6 +428,7 @@ private fun ShopSection(
         more = {
             Row(
                 modifier = Modifier.noRippleClickable {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.SHOP, "전체보기")
                     navigator.navigateToStore(context).let(context::startActivity)
                 },
                 verticalAlignment = Alignment.CenterVertically
@@ -469,6 +480,7 @@ private fun ShopSection(
                 )
             },
             onClick = {
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.POPULAR_SHOP, "많이 찾는 상점 둘러보기")
                 navigator.navigateToStore(context).let(context::startActivity)
             }
         )

--- a/feature/home/src/main/java/in/koreatech/koin/feature/home/component/DiningPager.kt
+++ b/feature/home/src/main/java/in/koreatech/koin/feature/home/component/DiningPager.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.domain.model.dining.DiningPlace
 import `in`.koreatech.koin.feature.home.R
@@ -82,6 +84,7 @@ fun DiningPager(
                     place = data[page].place,
                     isSelected = isSelected
                 ) {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.MENU_CORNER, data[page].place)
                     if (isSelected) return@DiningPagerIndicator
                     coroutineScope.launch {
                         pagerState.animateScrollToPage(page)

--- a/feature/home/src/main/java/in/koreatech/koin/feature/home/component/DiningPager.kt
+++ b/feature/home/src/main/java/in/koreatech/koin/feature/home/component/DiningPager.kt
@@ -84,8 +84,8 @@ fun DiningPager(
                     place = data[page].place,
                     isSelected = isSelected
                 ) {
-                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.MENU_CORNER, data[page].place)
                     if (isSelected) return@DiningPagerIndicator
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.MENU_CORNER, data[page].place)
                     coroutineScope.launch {
                         pagerState.animateScrollToPage(page)
                     }

--- a/feature/notification/src/main/java/in/koreatech/koin/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/in/koreatech/koin/feature/notification/NotificationScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHost
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
@@ -151,6 +153,7 @@ private fun NotificationMenuButton(
                 )
             },
             onClick = {
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.NOTIFICATION_LIST_READ_ALL, "모두 읽음으로 표시")
                 onMarkAllAsRead()
                 expanded = false
             }
@@ -164,12 +167,25 @@ private fun NotificationMenuButton(
                 )
             },
             onClick = {
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.NOTIFICATION_DELETE_ALL, "알림 전체 삭제")
                 onDeleteAll()
                 expanded = false
             }
         )
     }
 }
+
+private fun notificationListEventValue(type: String): String =
+    when (type) {
+        "callvan", "callvan-chat" -> "콜밴팟"
+        "dining" -> "식단"
+        "shop" -> "상점"
+        "lost-item" -> "분실물"
+        "chat" -> "쪽지"
+        // Edge-case fallback for future backend-added notification types.
+        // If a new slug starts reaching this branch, add an explicit Korean label mapping in a follow-up issue.
+        else -> "기타"
+    }
 
 @Composable
 private fun NotificationScreenImpl(
@@ -212,8 +228,20 @@ private fun NotificationScreenImpl(
                 content = notification.content,
                 timestamp = notification.datetimeDiff,
                 isRead = notification.isRead,
-                onDelete = remember(notification.id) { { onDelete(notification.id) } },
-                onClick = remember(notification.id) { { onNotificationClick(notification) } }
+                onDelete = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.NOTIFICATION_LIST_DELETE,
+                        "알림 삭제"
+                    )
+                    onDelete(notification.id)
+                },
+                onClick = {
+                    EventLogger.logCampusClickEvent(
+                        AnalyticsConstant.Label.NOTIFICATION_LIST,
+                        notificationListEventValue(notification.type)
+                    )
+                    onNotificationClick(notification)
+                }
             )
         }
     }

--- a/feature/notification/src/main/java/in/koreatech/koin/feature/notification/NotificationScreen.kt
+++ b/feature/notification/src/main/java/in/koreatech/koin/feature/notification/NotificationScreen.kt
@@ -46,6 +46,7 @@ import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.feature.notification.component.NotificationItem
 import `in`.koreatech.koin.feature.notification.model.LocalNotification
+import `in`.koreatech.koin.feature.notification.model.NotificationCategory
 import kotlinx.collections.immutable.ImmutableList
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -175,18 +176,6 @@ private fun NotificationMenuButton(
     }
 }
 
-private fun notificationListEventValue(type: String): String =
-    when (type) {
-        "callvan", "callvan-chat" -> "콜밴팟"
-        "dining" -> "식단"
-        "shop" -> "상점"
-        "lost-item" -> "분실물"
-        "chat" -> "쪽지"
-        // Edge-case fallback for future backend-added notification types.
-        // If a new slug starts reaching this branch, add an explicit Korean label mapping in a follow-up issue.
-        else -> "기타"
-    }
-
 @Composable
 private fun NotificationScreenImpl(
     listState: LazyListState,
@@ -228,19 +217,23 @@ private fun NotificationScreenImpl(
                 content = notification.content,
                 timestamp = notification.datetimeDiff,
                 isRead = notification.isRead,
-                onDelete = {
-                    EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.NOTIFICATION_LIST_DELETE,
-                        "알림 삭제"
-                    )
-                    onDelete(notification.id)
+                onDelete = remember(notification.id) {
+                    {
+                        EventLogger.logCampusClickEvent(
+                            AnalyticsConstant.Label.NOTIFICATION_LIST_DELETE,
+                            "알림 삭제"
+                        )
+                        onDelete(notification.id)
+                    }
                 },
-                onClick = {
-                    EventLogger.logCampusClickEvent(
-                        AnalyticsConstant.Label.NOTIFICATION_LIST,
-                        notificationListEventValue(notification.type)
-                    )
-                    onNotificationClick(notification)
+                onClick = remember(notification.id, notification.type) {
+                    {
+                        EventLogger.logCampusClickEvent(
+                            AnalyticsConstant.Label.NOTIFICATION_LIST,
+                            NotificationCategory.from(notification.type).analyticsLabel
+                        )
+                        onNotificationClick(notification)
+                    }
                 }
             )
         }

--- a/feature/notification/src/main/java/in/koreatech/koin/feature/notification/component/NotificationItem.kt
+++ b/feature/notification/src/main/java/in/koreatech/koin/feature/notification/component/NotificationItem.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.zIndex
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.notification.R
+import `in`.koreatech.koin.feature.notification.model.NotificationCategory
 import kotlin.math.roundToInt
 
 private enum class SwipeAnchor { Closed, Open, Dismissed }
@@ -63,16 +64,7 @@ fun NotificationItem(
     val state = remember { AnchoredDraggableState(initialValue = SwipeAnchor.Closed) }
     var itemSize by remember { mutableStateOf(IntSize.Zero) }
     val isOpen = state.settledValue != SwipeAnchor.Closed
-    val drawableRes = remember(type) {
-        when (type) {
-            "shop" -> R.drawable.ic_notification_store
-            "dining" -> R.drawable.ic_notification_dining
-            "lost-item" -> R.drawable.ic_notification_lostitem
-            "chat" -> R.drawable.ic_notification_chat
-            "callvan", "callvan-chat" -> R.drawable.ic_notification_callvan
-            else -> null
-        }
-    }
+    val drawableRes = remember(type) { NotificationCategory.from(type).drawableRes }
 
     LaunchedEffect(itemSize, isOpen) {
         if (itemSize == IntSize.Zero) return@LaunchedEffect

--- a/feature/notification/src/main/java/in/koreatech/koin/feature/notification/model/NotificationCategory.kt
+++ b/feature/notification/src/main/java/in/koreatech/koin/feature/notification/model/NotificationCategory.kt
@@ -1,0 +1,25 @@
+package `in`.koreatech.koin.feature.notification.model
+
+import `in`.koreatech.koin.feature.notification.R
+
+internal enum class NotificationCategory(val drawableRes: Int?, val analyticsLabel: String) {
+    SHOP(R.drawable.ic_notification_store, "상점"),
+    DINING(R.drawable.ic_notification_dining, "식단"),
+    LOST_ITEM(R.drawable.ic_notification_lostitem, "분실물"),
+    CHAT(R.drawable.ic_notification_chat, "쪽지"),
+    CALLVAN(R.drawable.ic_notification_callvan, "콜밴팟"),
+
+    // 백엔드가 신규 type을 추가하면 이 enum에 항목을 추가한다.
+    UNKNOWN(drawableRes = null, analyticsLabel = "기타");
+
+    companion object {
+        fun from(type: String): NotificationCategory = when (type) {
+            "shop" -> SHOP
+            "dining" -> DINING
+            "lost-item" -> LOST_ITEM
+            "chat" -> CHAT
+            "callvan", "callvan-chat" -> CALLVAN
+            else -> UNKNOWN
+        }
+    }
+}

--- a/koin/src/main/java/in/koreatech/koin/ui/newmain/NewMainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/newmain/NewMainActivity.kt
@@ -53,18 +53,13 @@ class NewMainActivity : AppCompatActivity() {
 
         binding.bottomNavigationMain.setupWithNavController(navController)
 
+        // setOnItemReselectedListener를 따로 등록하면 재탭 시 기본 popUpTo/restoreState 동작이 사라지므로 등록하지 않는다.
+        // 리스너가 없으면 재탭도 이 setOnItemSelectedListener로 그대로 들어와 로깅과 기본 동작이 모두 보존된다.
         binding.bottomNavigationMain.setOnItemSelectedListener { item ->
             navigationLogValue(item.itemId)?.let { (label, value) ->
                 EventLogger.logCampusClickEvent(label, value)
             }
             NavigationUI.onNavDestinationSelected(item, navController)
-        }
-
-        binding.bottomNavigationMain.setOnItemReselectedListener { item ->
-            navigationLogValue(item.itemId)?.let { (label, value) ->
-                EventLogger.logCampusClickEvent(label, value)
-            }
-            navController.popBackStack(item.itemId, false)
         }
 
         val topLevelDestinations = setOf(

--- a/koin/src/main/java/in/koreatech/koin/ui/newmain/NewMainActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/newmain/NewMainActivity.kt
@@ -8,9 +8,12 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
 import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.NavigationUI
 import androidx.navigation.ui.setupWithNavController
 import dagger.hilt.android.AndroidEntryPoint
 import `in`.koreatech.koin.R
+import `in`.koreatech.koin.core.analytics.AnalyticsConstant
+import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.util.enableEdgeToEdgeWithLightStatusBar
 import `in`.koreatech.koin.databinding.ActivityNewMainBinding
 
@@ -18,6 +21,15 @@ import `in`.koreatech.koin.databinding.ActivityNewMainBinding
 class NewMainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityNewMainBinding
+
+    private fun navigationLogValue(itemId: Int): Pair<String, String>? = when (itemId) {
+        R.id.bottom_navigation_home -> AnalyticsConstant.Label.NAV_HOME to "홈"
+        R.id.bottom_navigation_category -> AnalyticsConstant.Label.NAV_CATEGORY to "카테고리"
+        R.id.bottom_navigation_article -> AnalyticsConstant.Label.NAV_BULLETIN to "게시판"
+        R.id.bottom_navigation_profile -> AnalyticsConstant.Label.NAV_PROFILE to "프로필"
+        else -> null
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdgeWithLightStatusBar()
         super.onCreate(savedInstanceState)
@@ -40,6 +52,20 @@ class NewMainActivity : AppCompatActivity() {
         val navController = navHostFragment.navController
 
         binding.bottomNavigationMain.setupWithNavController(navController)
+
+        binding.bottomNavigationMain.setOnItemSelectedListener { item ->
+            navigationLogValue(item.itemId)?.let { (label, value) ->
+                EventLogger.logCampusClickEvent(label, value)
+            }
+            NavigationUI.onNavDestinationSelected(item, navController)
+        }
+
+        binding.bottomNavigationMain.setOnItemReselectedListener { item ->
+            navigationLogValue(item.itemId)?.let { (label, value) ->
+                EventLogger.logCampusClickEvent(label, value)
+            }
+            navController.popBackStack(item.itemId, false)
+        }
 
         val topLevelDestinations = setOf(
             R.id.bottom_navigation_home,


### PR DESCRIPTION
## PR 개요
이슈 번호: #1511

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
홈 화면, 알림 화면, 네비게이션 바에 사용자의 클릭 이벤트를 Firebase Analytics에 로깅하도록 구현했습니다. `AnalyticsConstant`에 15개의 신규 라벨 상수를 추가하고, 각 UI 클릭 콜백에 `EventLogger.logCampusClickEvent` 호출을 삽입했습니다. 알림 타입 슬러그를 한글 라벨로 매핑하는 `notificationListEventValue` 함수를 추가해 보안 및 데이터 일관성을 확보했습니다. 네비게이션 바는 선택 및 재선택 리스너를 구현해 탭 클릭을 모두 로깅하고, 기존 동작을 유지하도록 `popBackStack`을 호출했습니다. 관련 import 및 코드 스타일 정리를 수행했으며, ktlint 및 컴파일 검증을 통과했습니다.

### 논의 사항
재선택 탭 로깅 구현 시 기존 NavigationUI 동작을 유지하기 위해 `popBackStack`을 명시적으로 호출했습니다. 또한 `navigationLogValue`에서 locale‑dependent `getString` 대신 하드코딩된 한글 문자열을 사용해 이벤트 값의 일관성을 보장했습니다.

### 스크린샷
(UI 변경 없음)

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 주요 화면에서 사용자 클릭/탭 이벤트 분석이 확장되었습니다. (알림 목록, 오늘 식단, 메뉴/셔틀, 콜밴, 버스, 상점, 하단 네비게이션 등)
  * 알림 항목의 유형별 라벨/표시 기반으로 이벤트가 보다 정교하게 기록됩니다.
* **Bug Fixes**
  * 하단 탭 재선택 및 전환 동작을 더 일관되게 처리하도록 개선했습니다.
  * 알림 “모두 읽음/전체 삭제” 및 개별 알림 삭제/열람 동작 추적이 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->