### PR TITLE
[Feature] 게시글 이전/다음 이동 버튼 제거 및 원본 글 이동 버튼 배치

### DIFF
--- a/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/detail/ArticleDetailFragment.kt
+++ b/feature/article/src/main/java/in/koreatech/koin/feature/article/ui/article/detail/ArticleDetailFragment.kt
@@ -98,7 +98,6 @@ class ArticleDetailFragment : Fragment() {
                 viewModel.article.collectLatest {
                     setHeader(it)
                     setContent(it)
-                    setNavigateArticleButtonVisibility(it)
                     initPortalLinkButton(it)
 
                     if (it.attachments.isEmpty()) {
@@ -161,28 +160,6 @@ class ArticleDetailFragment : Fragment() {
                             inclusive = true
                         }
                         launchSingleTop = true
-                    }
-                )
-            }
-        }
-        binding.buttonToPrevArticle.setOnClickListener {
-            viewModel.article.value.prevArticleId?.let { prevId ->
-                navController.navigate(
-                    R.id.action_articleDetailFragment_to_articleDetailFragment,
-                    Bundle().apply {
-                        putInt(ARTICLE_ID, prevId)
-                        putInt(NAVIGATED_BOARD_ID, viewModel.navigatedBoardId)
-                    }
-                )
-            }
-        }
-        binding.buttonToNextArticle.setOnClickListener {
-            viewModel.article.value.nextArticleId?.let { nextId ->
-                navController.navigate(
-                    R.id.action_articleDetailFragment_to_articleDetailFragment,
-                    Bundle().apply {
-                        putInt(ARTICLE_ID, nextId)
-                        putInt(NAVIGATED_BOARD_ID, viewModel.navigatedBoardId)
                     }
                 )
             }
@@ -255,11 +232,6 @@ class ArticleDetailFragment : Fragment() {
                 putExtra("url", url)
             }.run(::startActivity)
         }
-    }
-
-    private fun setNavigateArticleButtonVisibility(article: ArticleState) {
-        binding.buttonToPrevArticle.visibility = if (article.prevArticleId != null) View.VISIBLE else View.INVISIBLE
-        binding.buttonToNextArticle.visibility = if (article.nextArticleId != null) View.VISIBLE else View.INVISIBLE
     }
 
     private fun onAttachmentClick(attachment: AttachmentState) {

--- a/feature/article/src/main/res/layout/fragment_article_detail.xml
+++ b/feature/article/src/main/res/layout/fragment_article_detail.xml
@@ -89,12 +89,28 @@
                 app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
                 app:layout_constraintTop_toBottomOf="@id/text_attachment" />
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/button_to_portal"
+            <androidx.appcompat.widget.AppCompatButton
+                android:id="@+id/button_to_list"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
                 android:layout_marginStart="24dp"
+                android:minHeight="0dp"
+                android:minWidth="0dp"
+                android:paddingHorizontal="14dp"
+                android:paddingVertical="8dp"
+                android:text="@string/list"
+                android:textColor="@color/gray14"
+                android:stateListAnimator="@null"
+                android:background="@drawable/bg_article_navigate_button"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/recycler_view_attachments" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_to_portal"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="24dp"
                 android:minHeight="0dp"
                 android:minWidth="0dp"
                 android:visibility="gone"
@@ -105,60 +121,9 @@
                 android:textColor="@color/black"
                 android:backgroundTint="#E4EAF2"
                 app:cornerRadius="6dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/recycler_view_attachments" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/button_to_list"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:layout_marginStart="24dp"
-                android:minHeight="0dp"
-                android:minWidth="0dp"
-                android:paddingHorizontal="14dp"
-                android:paddingVertical="8dp"
-                android:text="@string/list"
-                android:textColor="@color/gray14"
-                android:stateListAnimator="@null"
-                android:background="@drawable/bg_article_navigate_button"
-                app:layout_goneMarginTop="16dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/button_to_portal" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/button_to_next_article"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="@id/button_to_list"
-                app:layout_constraintBottom_toBottomOf="@id/button_to_list"
                 app:layout_constraintEnd_toEndOf="parent"
-                android:minHeight="0dp"
-                android:minWidth="0dp"
-                android:layout_marginEnd="24dp"
-                android:paddingHorizontal="14dp"
-                android:paddingVertical="8dp"
-                android:stateListAnimator="@null"
-                android:text="@string/next_article"
-                android:textColor="@color/color_article_navigate_button_text"
-                android:background="@drawable/bg_article_navigate_button" />
-
-            <androidx.appcompat.widget.AppCompatButton
-                android:id="@+id/button_to_prev_article"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
                 app:layout_constraintTop_toTopOf="@id/button_to_list"
-                app:layout_constraintBottom_toBottomOf="@id/button_to_list"
-                app:layout_constraintEnd_toStartOf="@id/button_to_next_article"
-                android:minHeight="0dp"
-                android:minWidth="0dp"
-                android:layout_marginEnd="8dp"
-                android:paddingHorizontal="14dp"
-                android:paddingVertical="8dp"
-                android:stateListAnimator="@null"
-                android:text="@string/prev_article"
-                android:textColor="@color/color_article_navigate_button_text"
-                android:background="@drawable/bg_article_navigate_button" />
+                app:layout_constraintBottom_toBottomOf="@id/button_to_list" />
 
 
             <View


### PR DESCRIPTION
## PR 개요
이슈 번호: #1496

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
- 게시글 상세 화면에서 이전/다음 게시글 이동 버튼 및 관련 로직 제거
- 원본 글 이동 버튼을 기존 버튼 자리에 배치

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 기사 상세 화면에서 이전·다음 기사 이동 버튼을 제거했습니다.
  * 원문 링크와 목록 버튼의 배치를 정리하고 간격을 개선했습니다.
  * 첨부파일 영역과 콘텐츠 구분선 사이의 화면 구성을 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->