### PR TITLE
[fix] 비로그인 시에도 설정 화면 접속 가능하도록 수정

### DIFF
--- a/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
@@ -75,8 +75,9 @@ fun ProfileScreen(
                 }
             },
             onSettingClick = {
-                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.Profile.HOME_SETTINGS, "설정")
-                if (!uiState.isLoggedIn) {
+                if (uiState.isLoggedIn) {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.Profile.HOME_SETTINGS, "설정")
+                } else {
                     EventLogger.logCampusClickEvent(AnalyticsConstant.Label.LOGIN_PROMPT, "설정(비로그인)")
                 }
                 onNavigateToSetting()

--- a/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
@@ -75,11 +75,7 @@ fun ProfileScreen(
                 }
             },
             onSettingClick = {
-                if (uiState.isLoggedIn) {
-                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.Profile.HOME_SETTINGS, "설정")
-                } else {
-                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.LOGIN_PROMPT, "설정(비로그인)")
-                }
+                EventLogger.logCampusClickEvent(AnalyticsConstant.Label.Profile.HOME_SETTINGS, "설정")
                 onNavigateToSetting()
             },
             onNotificationClick = {

--- a/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
@@ -76,11 +76,10 @@ fun ProfileScreen(
             },
             onSettingClick = {
                 EventLogger.logCampusClickEvent(AnalyticsConstant.Label.Profile.HOME_SETTINGS, "설정")
-                if (uiState.isLoggedIn) {
-                    onNavigateToSetting()
-                } else {
-                    navigator.navigateToSignIn(context, DEEPLINK_MAIN_PROFILE).let { context.startActivity(it) }
+                if (!uiState.isLoggedIn) {
+                    EventLogger.logCampusClickEvent(AnalyticsConstant.Label.LOGIN_PROMPT, "설정(비로그인)")
                 }
+                onNavigateToSetting()
             },
             onNotificationClick = {
                 EventLogger.logCampusClickEvent(AnalyticsConstant.Label.NOTIFICATION, "알림 아이콘")


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1542

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 비로그인 시에도 설정화면에 접속 가능하도록 수정하였습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 프로필 화면에서 **설정** 클릭 시 동작이 변경되었습니다.
  * 설정 관련 안내 이벤트를 기록한 뒤, **로그인 여부와 관계없이 설정 화면으로 이동**합니다.
  * 기존에 비로그인 상태에서 **로그인 화면으로 자동 전환**되던 흐름은 제거했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->