### PR TITLE
[Fix] 메인화면 리디자인 오류 수정

### DIFF
--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/timetable/GetLocalTimetableLecturesUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/timetable/GetLocalTimetableLecturesUseCase.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.domain.usecase.timetable
+
+import `in`.koreatech.koin.domain.repository.TimetableRepository
+import javax.inject.Inject
+
+class GetLocalTimetableLecturesUseCase @Inject constructor(
+    private val timetableRepository: TimetableRepository
+) {
+    suspend operator fun invoke(semester: String) =
+        timetableRepository.getTimetableLectures(semester)
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/timetable/GetLocalTimetableLecturesUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/timetable/GetLocalTimetableLecturesUseCase.kt
@@ -1,11 +1,12 @@
 package `in`.koreatech.koin.domain.usecase.timetable
 
+import `in`.koreatech.koin.domain.model.timetable.response.TimetableLectures
 import `in`.koreatech.koin.domain.repository.TimetableRepository
 import javax.inject.Inject
 
 class GetLocalTimetableLecturesUseCase @Inject constructor(
     private val timetableRepository: TimetableRepository
 ) {
-    suspend operator fun invoke(semester: String) =
+    suspend operator fun invoke(semester: String): Result<TimetableLectures> =
         timetableRepository.getTimetableLectures(semester)
 }

--- a/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
+++ b/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinMainTopBar
@@ -53,6 +55,10 @@ fun ProfileScreen(
         when (sideEffect) {
             ProfileSideEffect.LogoutSuccess -> onRequestLogout()
         }
+    }
+
+    LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+        viewModel.refreshTimetable()
     }
 
     Scaffold(

--- a/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileViewModel.kt
+++ b/feature/profile/src/main/java/in/koreatech/koin/feature/profile/ProfileViewModel.kt
@@ -3,6 +3,7 @@ package `in`.koreatech.koin.feature.profile
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.user.User
+import `in`.koreatech.koin.domain.usecase.timetable.GetLocalTimetableLecturesUseCase
 import `in`.koreatech.koin.domain.usecase.timetable.GetTimetableFramesUseCase
 import `in`.koreatech.koin.domain.usecase.timetable.GetTimetableLecturesUseCase
 import `in`.koreatech.koin.domain.usecase.timetable.GetUserSemestersUseCase
@@ -32,7 +33,8 @@ class ProfileViewModel @Inject constructor(
     private val userLogoutUseCase: UserLogoutUseCase,
     private val getUserSemestersUseCase: GetUserSemestersUseCase,
     private val getTimetableFramesUseCase: GetTimetableFramesUseCase,
-    private val getTimetableLecturesUseCase: GetTimetableLecturesUseCase
+    private val getTimetableLecturesUseCase: GetTimetableLecturesUseCase,
+    private val getLocalTimetableLecturesUseCase: GetLocalTimetableLecturesUseCase
 ) : ViewModel(), ContainerHost<ProfileState, ProfileSideEffect> {
 
     override val container = container<ProfileState, ProfileSideEffect>(ProfileState())
@@ -61,7 +63,7 @@ class ProfileViewModel @Inject constructor(
                                 studentNumber = user.studentNumber.orEmpty()
                             )
                         }
-                        loadTimetable()
+                        loadTimetable(isAnonymous = false)
                     }
 
                     is User.General -> {
@@ -72,24 +74,30 @@ class ProfileViewModel @Inject constructor(
                                 studentNumber = ""
                             )
                         }
-                        loadTimetable()
+                        loadTimetable(isAnonymous = false)
                     }
 
-                    User.Anonymous -> reduce {
-                        state.copy(
-                            isLoggedIn = false,
-                            name = "",
-                            studentNumber = "",
-                            timetable = persistentListOf()
-                        )
+                    User.Anonymous -> {
+                        reduce {
+                            state.copy(
+                                isLoggedIn = false,
+                                name = "",
+                                studentNumber = ""
+                            )
+                        }
+                        loadTimetable(isAnonymous = true)
                     }
                 }
             }
     }
 
+    fun refreshTimetable() = intent {
+        loadTimetable(isAnonymous = !state.isLoggedIn)
+    }
+
     @OptIn(OrbitExperimental::class)
-    private suspend fun loadTimetable() = subIntent {
-        val semesters = getUserSemestersUseCase(false)
+    private suspend fun loadTimetable(isAnonymous: Boolean) = subIntent {
+        val semesters = getUserSemestersUseCase(isAnonymous)
             .catch { Timber.e(it) }
             .firstOrNull()
             .orEmpty()
@@ -98,16 +106,21 @@ class ProfileViewModel @Inject constructor(
             return@subIntent
         }
 
-        val frames = getTimetableFramesUseCase(semester)
-            .catch { Timber.e(it) }
-            .firstOrNull()
-            .orEmpty()
-        val mainFrame = frames.find { it.isMain } ?: run {
-            reduce { state.copy(timetable = persistentListOf()) }
-            return@subIntent
+        val result = if (isAnonymous) {
+            getLocalTimetableLecturesUseCase(semester)
+        } else {
+            val frames = getTimetableFramesUseCase(semester)
+                .catch { Timber.e(it) }
+                .firstOrNull()
+                .orEmpty()
+            val mainFrame = frames.find { it.isMain } ?: run {
+                reduce { state.copy(timetable = persistentListOf()) }
+                return@subIntent
+            }
+            getTimetableLecturesUseCase(mainFrame.id)
         }
 
-        getTimetableLecturesUseCase(mainFrame.id)
+        result
             .onSuccess { timetableLectures ->
                 reduce { state.copy(timetable = timetableLectures.toProfileTimetableLectures()) }
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/land/LandActivity.kt
@@ -86,7 +86,7 @@ class LandActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
 
             koinBaseAppBarDark.setOnClickListener {
                 when (it.id) {
-                    AppBarBase.getLeftButtonId() -> callDrawerItem(R.id.navi_item_home)
+                    AppBarBase.getLeftButtonId() -> onBackPressedDispatcher.onBackPressed()
                     AppBarBase.getRightButtonId() -> toggleNavigationDrawer()
                 }
             }

--- a/koin/src/main/java/in/koreatech/koin/ui/land/LandDetailActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/land/LandDetailActivity.kt
@@ -70,7 +70,7 @@ class LandDetailActivity : KoinNavigationDrawerActivity(), OnMapReadyCallback {
         with(binding) {
             koinBaseAppBarDark.setOnClickListener {
                 when (it.id) {
-                    AppBarBase.getLeftButtonId() -> callDrawerItem(R.id.navi_item_home)
+                    AppBarBase.getLeftButtonId() -> onBackPressedDispatcher.onBackPressed()
                     AppBarBase.getRightButtonId() -> toggleNavigationDrawer()
                 }
             }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1553 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 복덕방에서 Topbar의 뒤로가기 버튼을 클릭 시 이전 화면으로 이동하도록 수정하였습니다.
- 시간표 화면에서 수정 후 프로필 화면으로 복귀 시 `내 시간표` 항목이 업데이트 되지 않는 문제를 수정하였습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 비로그인 상태에서도 기기에 저장된 시간표 강의를 불러올 수 있습니다.
  * 프로필 화면에 다시 진입하면(복귀 시점) 시간표가 자동으로 새로고침됩니다.
* **버그 수정**
  * 랜드 및 상세 화면의 앱바 왼쪽 버튼이 홈 메뉴로 이동하는 대신 이전 화면으로 정상 이동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->