### PR TITLE
[chore] Target, Compile SDK 36 으로 변경 + 화면 방향 제한 property

### DIFF
--- a/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
+++ b/build-logic/convention/src/main/java/in/koreatech/convention/AndroidLibrary.kt
@@ -9,15 +9,15 @@ internal fun Project.configureAndroidLibrary(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     (commonExtension as? LibraryExtension)?.let {
-        it.defaultConfig.targetSdk = 35
+        it.defaultConfig.targetSdk = 36
     }
 
     commonExtension.apply {
         (this as? LibraryExtension)?.let {
-            it.defaultConfig.targetSdk = 35
+            it.defaultConfig.targetSdk = 36
         }
 
-        compileSdk = 35
+        compileSdk = 36
 
         defaultConfig {
             minSdk = 28

--- a/build-logic/convention/src/main/java/in/koreatech/convention/AndroidProject.kt
+++ b/build-logic/convention/src/main/java/in/koreatech/convention/AndroidProject.kt
@@ -9,13 +9,13 @@ internal fun configureAndroidProject(
     commonExtension: CommonExtension<*, *, *, *, *, *>,
 ) {
     (commonExtension as? ApplicationExtension)?.let {
-        it.defaultConfig.targetSdk = 35
+        it.defaultConfig.targetSdk = 36
     }
 
     commonExtension.apply {
-        compileSdk = 35
+        compileSdk = 36
         (this as? ApplicationExtension)?.let {
-            it.defaultConfig.targetSdk = 35
+            it.defaultConfig.targetSdk = 36
         }
         defaultConfig {
             minSdk = 28

--- a/koin/src/main/AndroidManifest.xml
+++ b/koin/src/main/AndroidManifest.xml
@@ -197,6 +197,10 @@
         <activity
             android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
             android:theme="@style/KAPTheme.License" />
+
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1561

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
- targetSdk 및 compileSdk를 35 → 36으로 업그레이드
- SDK 36에서 screenOrientation 고정 요청이 무시되는 문제를 임시 대응하기 위해                                                                                                            
    PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY 추가 (앱 전체 적용)                                                                                                                      
    - SDK 37 대응 시 제거 예정             

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Android SDK 기준을 36으로 업데이트했습니다.
  * 앱 창의 제한된 크기 조정 호환성을 활성화해 다양한 화면 환경에서의 동작을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->