### PR TITLE
[Refactor] Orbit-MVI 패턴 수정 및 리팩토링

### DIFF
--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubcreate/ClubCreateViewModel.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.feature.club.ui.clubcreate
 
 import android.net.Uri
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.model.user.User
@@ -11,7 +10,6 @@ import `in`.koreatech.koin.domain.usecase.presignedurl.UploadImageUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserStatusUseCase
 import `in`.koreatech.koin.feature.club.model.ClubCategories
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -31,7 +29,7 @@ class ClubCreateViewModel @Inject constructor(
         getUserInfo()
     }
 
-    private fun getUserInfo() = viewModelScope.launch {
+    private fun getUserInfo() = intent {
         getUserStatusUseCase().collect {
             when (it) {
                 is User.Anonymous -> {
@@ -39,13 +37,11 @@ class ClubCreateViewModel @Inject constructor(
                 }
 
                 is User.Student -> {
-                    intent {
-                        reduce {
-                            // TODO: User ID will be changed after the user team's sprint.
-                            state.copy(
-                                userId = it.email?.replace("@koreatech.ac.kr", "") ?: ""
-                            )
-                        }
+                    reduce {
+                        // TODO: User ID will be changed after the user team's sprint.
+                        state.copy(
+                            userId = it.email?.replace("@koreatech.ac.kr", "") ?: ""
+                        )
                     }
                 }
 
@@ -171,83 +167,73 @@ class ClubCreateViewModel @Inject constructor(
         fileType: String,
         fileName: String,
         imageUri: Uri
-    ) {
-        intent {
-            reduce {
-                state.copy(isLoading = true)
-            }
+    ) = intent {
+        reduce {
+            state.copy(isLoading = true)
         }
-        viewModelScope.launch {
-            uploadImageUseCase(
-                domain = PreSignedUrlDomain.CLUB,
-                contentLength = fileSize,
-                contentType = fileType,
-                fileName = fileName,
-                imageUri = imageUri.toString()
-            ).onSuccess {
-                intent {
-                    reduce {
-                        state.copy(
-                            clubImageUrl = it,
-                            isLoading = false
-                        )
-                    }
-                }
-            }.onFailure {
-                intent {
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    postSideEffect(ClubCreateSideEffect.ClubImageUploadFailure)
-                }
+        uploadImageUseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
+        ).onSuccess {
+            reduce {
+                state.copy(
+                    clubImageUrl = it,
+                    isLoading = false
+                )
             }
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            postSideEffect(ClubCreateSideEffect.ClubImageUploadFailure)
         }
     }
 
-    fun requestCreateClub() = viewModelScope.launch {
-        intent {
+    fun requestCreateClub() = intent {
+        reduce {
+            state.copy(
+                shouldCheckRequiredField = true
+            )
+        }
+
+        if (state.clubNameRequired || state.clubCategoryRequired || state.locationRequired || state.clubImageUrlRequired) return@intent
+
+        reduce {
+            state.copy(
+                isLoading = true
+            )
+        }
+
+        createClubUseCase(
+            name = state.clubName,
+            imageUrl = state.clubImageUrl,
+            clubManagers = listOf(state.userId),
+            clubCategoryId = state.clubCategory!!.id,
+            location = state.location,
+            description = state.clubDescription,
+            instagram = state.instagramUrl,
+            googleForm = state.googleFormUrl,
+            openChat = state.openChatUrl,
+            phoneNumber = state.phoneNumber,
+            role = state.userRole,
+            isLikeHidden = state.isLikeHidden
+        ).onSuccess {
             reduce {
                 state.copy(
-                    shouldCheckRequiredField = true
+                    isLoading = false
                 )
             }
-
-            if (state.clubNameRequired || state.clubCategoryRequired || state.locationRequired || state.clubImageUrlRequired) return@intent
-
+            postSideEffect(ClubCreateSideEffect.ClubCreateSuccess)
+        }.onFailure {
             reduce {
                 state.copy(
-                    isLoading = true
+                    isLoading = false
                 )
             }
-
-            createClubUseCase(
-                name = state.clubName,
-                imageUrl = state.clubImageUrl,
-                clubManagers = listOf(state.userId),
-                clubCategoryId = state.clubCategory!!.id,
-                location = state.location,
-                description = state.clubDescription,
-                instagram = state.instagramUrl,
-                googleForm = state.googleFormUrl,
-                openChat = state.openChatUrl,
-                phoneNumber = state.phoneNumber,
-                role = state.userRole,
-                isLikeHidden = state.isLikeHidden
-            ).onSuccess {
-                reduce {
-                    state.copy(
-                        isLoading = false
-                    )
-                }
-                postSideEffect(ClubCreateSideEffect.ClubCreateSuccess)
-            }.onFailure {
-                reduce {
-                    state.copy(
-                        isLoading = false
-                    )
-                }
-                postSideEffect(ClubCreateSideEffect.ClubCreateFailure)
-            }
+            postSideEffect(ClubCreateSideEffect.ClubCreateFailure)
         }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -35,13 +35,14 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import okhttp3.internal.immutableListOf
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
@@ -70,12 +71,10 @@ class ClubDetailViewModel @Inject constructor(
     ) {
         val clubId = savedStateHandle.get<Int>(CLUB_ID)
         checkNotNull(clubId)
-        intent {
-            reduce {
-                state.copy(
-                    clubId = clubId
-                )
-            }
+        reduce {
+            state.copy(
+                clubId = clubId
+            )
         }
     }
 
@@ -110,49 +109,48 @@ class ClubDetailViewModel @Inject constructor(
         }
     }
 
-    private fun loadClubDetails() = viewModelScope.launch {
-        intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun loadClubDetails() = subIntent {
+        reduce {
+            state.copy(isLoading = true, showDetailProgressBar = true)
+        }
+        getClubDetailsUseCase(state.clubId).onSuccess {
             reduce {
-                state.copy(isLoading = true, showDetailProgressBar = true)
+                state.copy(
+                    clubDetails = it.toParcelizeClubDetails(),
+                    isLoading = false,
+                    showDetailProgressBar = false
+                )
             }
-            getClubDetailsUseCase(state.clubId).onSuccess {
-                reduce {
-                    state.copy(
-                        clubDetails = it.toParcelizeClubDetails(),
-                        isLoading = false,
-                        showDetailProgressBar = false
-                    )
+        }.onFailure { e ->
+            reduce { state.copy(isLoading = false, showDetailProgressBar = false) }
+            when (e) {
+                is KoinClubException.ClubNotFoundException -> {
+                    postSideEffect(ClubDetailSideEffect.ClubNotFoundError)
                 }
-            }.onFailure { e ->
-                reduce { state.copy(isLoading = false, showDetailProgressBar = false) }
-                when (e) {
-                    is KoinClubException.ClubNotFoundException -> {
-                        postSideEffect(ClubDetailSideEffect.ClubNotFoundError)
-                    }
-                    else -> throw e
-                }
+                else -> throw e
             }
         }
     }
 
-    private fun loadClubQnas() = viewModelScope.launch {
-        intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun loadClubQnas() = subIntent {
+        reduce {
+            state.copy(isLoading = true, showQnasProgressBar = true)
+        }
+        getClubQnasUseCase(state.clubId).onSuccess {
             reduce {
-                state.copy(isLoading = true, showQnasProgressBar = true)
-            }
-            getClubQnasUseCase(state.clubId).onSuccess {
-                reduce {
-                    state.copy(
-                        clubQnasInfo = it.toParcelizeClubQnasInfo(),
-                        isLoading = false,
-                        showQnasProgressBar = false
-                    )
-                }
+                state.copy(
+                    clubQnasInfo = it.toParcelizeClubQnasInfo(),
+                    isLoading = false,
+                    showQnasProgressBar = false
+                )
             }
         }
     }
 
-    private fun loadClubRecruitment() = intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun loadClubRecruitment() = subIntent {
         reduce { state.copy(isLoading = true, showRecruitProgressBar = true) }
         getClubRecruitmentUseCase(state.clubId).onSuccess {
             reduce {
@@ -176,7 +174,8 @@ class ClubDetailViewModel @Inject constructor(
         }
     }
 
-    private fun loadClubEvents() = intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun loadClubEvents() = subIntent {
         reduce { state.copy(isLoading = true, showEventsProgressBar = true) }
         getClubEventsUseCase(state.clubId, state.clubEventSearchType.value).onSuccess {
             reduce {

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubdetail/ClubDetailViewModel.kt
@@ -146,6 +146,8 @@ class ClubDetailViewModel @Inject constructor(
                     showQnasProgressBar = false
                 )
             }
+        }.onFailure {
+            reduce { state.copy(isLoading = false, showQnasProgressBar = false) }
         }
     }
 

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
@@ -11,6 +11,7 @@ import `in`.koreatech.koin.domain.usecase.club.SearchClubsUseCase
 import `in`.koreatech.koin.domain.usecase.club.SetClubLikeUseCase
 import `in`.koreatech.koin.domain.usecase.user.GetUserInfoUseCase
 import `in`.koreatech.koin.feature.club.model.ClubSort
+import `in`.koreatech.koin.feature.club.model.ParcelizeClubItem
 import `in`.koreatech.koin.feature.club.model.toParcelizeClubItems
 import `in`.koreatech.koin.feature.club.navigation.CATEGORY_ID
 import javax.inject.Inject
@@ -154,65 +155,66 @@ class ClubListViewModel @Inject constructor(
         reduce {
             state.copy(isLoading = true)
         }
-        state.clubs.forEach { club ->
-            if (club.id == clubId) {
-                if (club.isLiked) {
-                    cancelClubLikeUseCase(clubId).onSuccess {
-                        reduce {
-                            state.copy(
-                                isLoading = false,
-                                clubs = state.clubs.map {
-                                    if (it.id == clubId) {
-                                        it.copy(
-                                            isLiked = !it.isLiked,
-                                            likes = it.likes - 1
-                                        )
-                                    } else {
-                                        it
-                                    }
-                                }
-                            )
-                        }
-                        EventLogger.logCampusClickEvent(
-                            AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE_CANCEL,
-                            club.name
-                        )
-                    }.onFailure {
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        postSideEffect(ClubListSideEffect.ClubDislikeFailed)
-                    }
-                } else {
-                    setClubLikeUseCase(clubId).onSuccess {
-                        reduce {
-                            state.copy(
-                                isLoading = false,
-                                clubs = state.clubs.map {
-                                    if (it.id == clubId) {
-                                        it.copy(
-                                            isLiked = !it.isLiked,
-                                            likes = it.likes + 1
-                                        )
-                                    } else {
-                                        it
-                                    }
-                                }
-                            )
-                        }
-                        EventLogger.logCampusClickEvent(
-                            AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE,
-                            club.name
-                        )
-                    }.onFailure {
-                        reduce {
-                            state.copy(isLoading = false)
-                        }
-                        postSideEffect(ClubListSideEffect.ClubLikeFailed)
-                    }
-                }
-                return@intent
+        val club = state.clubs.find { it.id == clubId } ?: return@intent
+        if (club.isLiked) {
+            unlikeClub(club)
+        } else {
+            likeClub(club)
+        }
+    }
+
+    @OptIn(OrbitExperimental::class)
+    private suspend fun unlikeClub(club: ParcelizeClubItem) = subIntent {
+        cancelClubLikeUseCase(club.id).onSuccess {
+            reduce {
+                state.copy(
+                    isLoading = false,
+                    clubs = updateClubLike(state.clubs, club.id, isLiked = false, likesDelta = -1)
+                )
             }
+            EventLogger.logCampusClickEvent(
+                AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE_CANCEL,
+                club.name
+            )
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            postSideEffect(ClubListSideEffect.ClubDislikeFailed)
+        }
+    }
+
+    @OptIn(OrbitExperimental::class)
+    private suspend fun likeClub(club: ParcelizeClubItem) = subIntent {
+        setClubLikeUseCase(club.id).onSuccess {
+            reduce {
+                state.copy(
+                    isLoading = false,
+                    clubs = updateClubLike(state.clubs, club.id, isLiked = true, likesDelta = 1)
+                )
+            }
+            EventLogger.logCampusClickEvent(
+                AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE,
+                club.name
+            )
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            postSideEffect(ClubListSideEffect.ClubLikeFailed)
+        }
+    }
+
+    private fun updateClubLike(
+        clubs: List<ParcelizeClubItem>,
+        clubId: Int,
+        isLiked: Boolean,
+        likesDelta: Int
+    ) = clubs.map {
+        if (it.id == clubId) {
+            it.copy(isLiked = isLiked, likes = it.likes + likesDelta)
+        } else {
+            it
         }
     }
 

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clublist/ClubListViewModel.kt
@@ -2,7 +2,6 @@ package `in`.koreatech.koin.feature.club.ui.clublist
 
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
@@ -15,12 +14,13 @@ import `in`.koreatech.koin.feature.club.model.ClubSort
 import `in`.koreatech.koin.feature.club.model.toParcelizeClubItems
 import `in`.koreatech.koin.feature.club.navigation.CATEGORY_ID
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
@@ -35,10 +35,8 @@ class ClubListViewModel @Inject constructor(
     override val container =
         container<ClubListState, ClubListSideEffect>(ClubListState(), savedStateHandle) {
             val categoryId = savedStateHandle.get<Int?>(CATEGORY_ID)
-            intent {
-                reduce {
-                    state.copy(categoryId = categoryId.takeIf { it != -1 }, isInitialized = true)
-                }
+            reduce {
+                state.copy(categoryId = categoryId.takeIf { it != -1 }, isInitialized = true)
             }
         }
 
@@ -96,26 +94,29 @@ class ClubListViewModel @Inject constructor(
 
     fun navigateToCreateClub() = intent { postSideEffect(ClubListSideEffect.NavigateToCreateClub) }
 
-    fun getClubs() = viewModelScope.launch {
-        intent {
+    fun getClubs() = intent {
+        fetchClubs()
+    }
+
+    @OptIn(OrbitExperimental::class)
+    private suspend fun fetchClubs() = subIntent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        getClubsUseCase(
+            categoryId = state.categoryId,
+            sortType = state.sortType.name,
+            isRecruiting = state.isRecruiting,
+            query = state.searchKeyword
+        ).onSuccess { clubs ->
             reduce {
-                state.copy(isLoading = true)
+                state.copy(clubs = clubs.toParcelizeClubItems(), isLoading = false)
             }
-            getClubsUseCase(
-                categoryId = state.categoryId,
-                sortType = state.sortType.name,
-                isRecruiting = state.isRecruiting,
-                query = state.searchKeyword
-            ).onSuccess { clubs ->
-                reduce {
-                    state.copy(clubs = clubs.toParcelizeClubItems(), isLoading = false)
-                }
-            }.onFailure {
-                reduce {
-                    state.copy(isLoading = false)
-                }
-                postSideEffect(ClubListSideEffect.ClubsFetchFailed)
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
             }
+            postSideEffect(ClubListSideEffect.ClubsFetchFailed)
         }
     }
 
@@ -123,7 +124,7 @@ class ClubListViewModel @Inject constructor(
         reduce {
             state.copy(suggestions = emptyList(), shouldExpandSearchBar = false, searchKeyword = searchKeyword)
         }
-        getClubs()
+        fetchClubs()
     }
 
     fun getSuggestion() = intent {
@@ -149,70 +150,68 @@ class ClubListViewModel @Inject constructor(
         }
     }
 
-    fun changeClubLike(clubId: Int) = viewModelScope.launch {
-        intent {
-            reduce {
-                state.copy(isLoading = true)
-            }
-            state.clubs.forEach { club ->
-                if (club.id == clubId) {
-                    if (club.isLiked) {
-                        cancelClubLikeUseCase(clubId).onSuccess {
-                            reduce {
-                                state.copy(
-                                    isLoading = false,
-                                    clubs = state.clubs.map {
-                                        if (it.id == clubId) {
-                                            it.copy(
-                                                isLiked = !it.isLiked,
-                                                likes = it.likes - 1
-                                            )
-                                        } else {
-                                            it
-                                        }
+    fun changeClubLike(clubId: Int) = intent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        state.clubs.forEach { club ->
+            if (club.id == clubId) {
+                if (club.isLiked) {
+                    cancelClubLikeUseCase(clubId).onSuccess {
+                        reduce {
+                            state.copy(
+                                isLoading = false,
+                                clubs = state.clubs.map {
+                                    if (it.id == clubId) {
+                                        it.copy(
+                                            isLiked = !it.isLiked,
+                                            likes = it.likes - 1
+                                        )
+                                    } else {
+                                        it
                                     }
-                                )
-                            }
-                            EventLogger.logCampusClickEvent(
-                                AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE_CANCEL,
-                                club.name
+                                }
                             )
-                        }.onFailure {
-                            reduce {
-                                state.copy(isLoading = false)
-                            }
-                            postSideEffect(ClubListSideEffect.ClubDislikeFailed)
                         }
-                    } else {
-                        setClubLikeUseCase(clubId).onSuccess {
-                            reduce {
-                                state.copy(
-                                    isLoading = false,
-                                    clubs = state.clubs.map {
-                                        if (it.id == clubId) {
-                                            it.copy(
-                                                isLiked = !it.isLiked,
-                                                likes = it.likes + 1
-                                            )
-                                        } else {
-                                            it
-                                        }
-                                    }
-                                )
-                            }
-                            EventLogger.logCampusClickEvent(
-                                AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE,
-                                club.name
-                            )
-                        }.onFailure {
-                            reduce {
-                                state.copy(isLoading = false)
-                            }
-                            postSideEffect(ClubListSideEffect.ClubLikeFailed)
+                        EventLogger.logCampusClickEvent(
+                            AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE_CANCEL,
+                            club.name
+                        )
+                    }.onFailure {
+                        reduce {
+                            state.copy(isLoading = false)
                         }
+                        postSideEffect(ClubListSideEffect.ClubDislikeFailed)
                     }
-                    return@intent
+                } else {
+                    setClubLikeUseCase(clubId).onSuccess {
+                        reduce {
+                            state.copy(
+                                isLoading = false,
+                                clubs = state.clubs.map {
+                                    if (it.id == clubId) {
+                                        it.copy(
+                                            isLiked = !it.isLiked,
+                                            likes = it.likes + 1
+                                        )
+                                    } else {
+                                        it
+                                    }
+                                }
+                            )
+                        }
+                        EventLogger.logCampusClickEvent(
+                            AnalyticsConstant.Label.Club.MAIN_CLUB_LIKE,
+                            club.name
+                        )
+                    }.onFailure {
+                        reduce {
+                            state.copy(isLoading = false)
+                        }
+                        postSideEffect(ClubListSideEffect.ClubLikeFailed)
+                    }
                 }
+                return@intent
             }
         }
     }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyScreen.kt
@@ -546,6 +546,10 @@ fun handleSideEffect(
         ClubModifySideEffect.ClubImageUploadFailure -> context.let {
             Toast.makeText(it, it.getString(R.string.club_image_upload_failed), Toast.LENGTH_SHORT).show()
         }
+
+        ClubModifySideEffect.ClubModifyFailure -> context.let {
+            Toast.makeText(it, it.getString(R.string.club_modify_failed), Toast.LENGTH_SHORT).show()
+        }
     }
 }
 

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifySideEffect.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifySideEffect.kt
@@ -3,4 +3,5 @@ package `in`.koreatech.koin.feature.club.ui.clubmodify
 sealed class ClubModifySideEffect {
     data object ClubModifySuccess : ClubModifySideEffect()
     data object ClubImageUploadFailure : ClubModifySideEffect()
+    data object ClubModifyFailure : ClubModifySideEffect()
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.club.ui.clubmodify
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.upload.PreSignedUrlDomain
 import `in`.koreatech.koin.domain.usecase.club.GetClubDetailsUseCase
@@ -13,12 +12,13 @@ import `in`.koreatech.koin.feature.club.model.ClubCategories
 import `in`.koreatech.koin.feature.club.model.toClubCategory
 import `in`.koreatech.koin.feature.club.navigation.CLUB_ID
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 import timber.log.Timber
 
@@ -32,39 +32,36 @@ class ClubModifyViewModel @Inject constructor(
     override val container = container<ClubModifyState, ClubModifySideEffect>(ClubModifyState(), savedStateHandle) {
         val clubId = savedStateHandle.get<Int>(CLUB_ID)
         checkNotNull(clubId)
-        intent {
-            reduce {
-                state.copy(
-                    clubId = clubId
-                )
-            }
+        reduce {
+            state.copy(
+                clubId = clubId
+            )
         }
         loadClubDetails(clubId)
     }
 
-    private fun loadClubDetails(clubId: Int) = viewModelScope.launch {
-        intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun loadClubDetails(clubId: Int) = subIntent {
+        reduce {
+            state.copy(isLoading = true)
+        }
+        getClubDetailsUseCase(clubId).onSuccess {
+            Timber.d("Club details loaded: $it")
             reduce {
-                state.copy(isLoading = true)
-            }
-            getClubDetailsUseCase(clubId).onSuccess {
-                Timber.d("Club details loaded: $it")
-                reduce {
-                    state.copy(
-                        isLoading = false,
-                        clubName = it.name,
-                        clubDescription = it.description,
-                        clubCategory = it.category.toClubCategory(),
-                        location = it.location,
-                        instagramUrl = it.instagram ?: "",
-                        googleFormUrl = it.googleForm ?: "",
-                        openChatUrl = it.openChat ?: "",
-                        phoneNumber = it.phoneNumber ?: "",
-                        isLikeHidden = it.isLikeHidden,
-                        likes = it.likes,
-                        clubImageUrl = it.imageUrl
-                    )
-                }
+                state.copy(
+                    isLoading = false,
+                    clubName = it.name,
+                    clubDescription = it.description,
+                    clubCategory = it.category.toClubCategory(),
+                    location = it.location,
+                    instagramUrl = it.instagram ?: "",
+                    googleFormUrl = it.googleForm ?: "",
+                    openChatUrl = it.openChat ?: "",
+                    phoneNumber = it.phoneNumber ?: "",
+                    isLikeHidden = it.isLikeHidden,
+                    likes = it.likes,
+                    clubImageUrl = it.imageUrl
+                )
             }
         }
     }
@@ -162,80 +159,70 @@ class ClubModifyViewModel @Inject constructor(
         fileType: String,
         fileName: String,
         imageUri: Uri
-    ) {
-        intent {
-            reduce {
-                state.copy(isLoading = true)
-            }
+    ) = intent {
+        reduce {
+            state.copy(isLoading = true)
         }
-        viewModelScope.launch {
-            uploadImageUseCase(
-                domain = PreSignedUrlDomain.CLUB,
-                contentLength = fileSize,
-                contentType = fileType,
-                fileName = fileName,
-                imageUri = imageUri.toString()
-            ).onSuccess {
-                intent {
-                    reduce {
-                        state.copy(
-                            clubImageUrl = it,
-                            isLoading = false
-                        )
-                    }
-                }
-            }.onFailure {
-                intent {
-                    reduce {
-                        state.copy(isLoading = false)
-                    }
-                    postSideEffect(ClubModifySideEffect.ClubImageUploadFailure)
-                }
+        uploadImageUseCase(
+            domain = PreSignedUrlDomain.CLUB,
+            contentLength = fileSize,
+            contentType = fileType,
+            fileName = fileName,
+            imageUri = imageUri.toString()
+        ).onSuccess {
+            reduce {
+                state.copy(
+                    clubImageUrl = it,
+                    isLoading = false
+                )
             }
+        }.onFailure {
+            reduce {
+                state.copy(isLoading = false)
+            }
+            postSideEffect(ClubModifySideEffect.ClubImageUploadFailure)
         }
     }
 
-    fun requestModifyClub() = viewModelScope.launch {
-        intent {
+    fun requestModifyClub() = intent {
+        reduce {
+            state.copy(
+                shouldCheckRequiredField = true
+            )
+        }
+
+        if (state.clubNameRequired || state.clubCategoryRequired || state.locationRequired) return@intent
+
+        reduce {
+            state.copy(
+                isLoading = true
+            )
+        }
+
+        modifyClubUseCase(
+            clubId = state.clubId,
+            name = state.clubName,
+            imageUrl = state.clubImageUrl,
+            clubCategoryId = state.clubCategory!!.id,
+            location = state.location,
+            description = state.clubDescription,
+            instagram = state.instagramUrl,
+            googleForm = state.googleFormUrl,
+            openChat = state.openChatUrl,
+            phoneNumber = state.phoneNumber,
+            isLikeHidden = state.isLikeHidden
+        ).onSuccess {
             reduce {
                 state.copy(
-                    shouldCheckRequiredField = true
+                    isLoading = false
                 )
             }
-
-            if (state.clubNameRequired || state.clubCategoryRequired || state.locationRequired) return@intent
-
+            postSideEffect(ClubModifySideEffect.ClubModifySuccess)
+        }.onFailure {
             reduce {
                 state.copy(
-                    isLoading = true
+                    isLoading = false
                 )
-            }
-
-            modifyClubUseCase(
-                clubId = state.clubId,
-                name = state.clubName,
-                imageUrl = state.clubImageUrl,
-                clubCategoryId = state.clubCategory!!.id,
-                location = state.location,
-                description = state.clubDescription,
-                instagram = state.instagramUrl,
-                googleForm = state.googleFormUrl,
-                openChat = state.openChatUrl,
-                phoneNumber = state.phoneNumber,
-                isLikeHidden = state.isLikeHidden
-            ).onSuccess {
-                reduce {
-                    state.copy(
-                        isLoading = false
-                    )
-                }
-                postSideEffect(ClubModifySideEffect.ClubModifySuccess)
-            }.onFailure {
-                reduce {
-                    state.copy(
-                        isLoading = false
-                    )
-                }
             }
         }
     }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -226,6 +226,7 @@ class ClubModifyViewModel @Inject constructor(
                     isLoading = false
                 )
             }
+            postSideEffect(ClubModifySideEffect.ClubModifyFailure)
         }
     }
 }

--- a/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
+++ b/feature/club/src/main/java/in/koreatech/koin/feature/club/ui/clubmodify/ClubModifyViewModel.kt
@@ -63,6 +63,8 @@ class ClubModifyViewModel @Inject constructor(
                     clubImageUrl = it.imageUrl
                 )
             }
+        }.onFailure {
+            reduce { state.copy(isLoading = false) }
         }
     }
 

--- a/feature/club/src/main/res/values/strings.xml
+++ b/feature/club/src/main/res/values/strings.xml
@@ -156,6 +156,7 @@
     <string name="club_create_dialog_permission_content_hint">해당 동아리에서 수행하고 있는 역할을 입력해주세요.</string>
     <string name="club_create_dialog_permission_content">동아리 공식 연락망을 통해 확인 후 승인처리됩니다.</string>
     <string name="club_create_failed">동아리 생성에 실패했습니다.</string>
+    <string name="club_modify_failed">동아리 수정에 실패했습니다.</string>
     <string name="club_create_image_guideline">1:1 비율로 업로드 해주세요</string>
 
     <string name="club_modify_save">저장</string>

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningDetailScreen.kt
@@ -103,6 +103,7 @@ import `in`.koreatech.koin.feature.dining.constants.PARAMS_TYPE
 import `in`.koreatech.koin.feature.dining.ui.diningdetail.scroll.DiningNestedScrollConnection
 import java.util.Date
 import kotlinx.coroutines.launch
+import org.orbitmvi.orbit.compose.collectAsState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -114,17 +115,7 @@ fun DiningDetailScreen(
 ) {
     val userState by viewModel.userState.collectAsState()
 
-    val selectedDate by viewModel.selectedDate.collectAsState()
-
-    val showBottomSheet by viewModel.showBottomSheet.collectAsState()
-
-    val isSoldOutSubscribed by viewModel.isSoldOutSubscribed.collectAsState()
-
-    val isDiningImageSubscribed by viewModel.isDiningImageSubscribed.collectAsState()
-
-    val isDiningRefreshing by viewModel.isDiningRefreshing.collectAsState()
-
-    val diningList by viewModel.dining.collectAsState()
+    val diningState by viewModel.collectAsState()
 
     val abTestExperimentGroup by viewModel.abTestExperimentGroup.collectAsState()
 
@@ -176,16 +167,16 @@ fun DiningDetailScreen(
         contentWindowInsets = WindowInsets(0, 0, 0, 0)
     ) { contentPadding ->
         DiningDetailScreenImpl(
-            diningList = diningList,
+            diningList = diningState.dining,
             contentPadding = contentPadding,
-            selectedDate = TimeUtil.stringToDateYYMMDD(selectedDate),
-            showBottomSheet = showBottomSheet,
+            selectedDate = TimeUtil.stringToDateYYMMDD(diningState.selectedDate),
+            showBottomSheet = diningState.showBottomSheet,
             experimentGroup = abTestExperimentGroup,
             isAnonymous = userState.isAnonymous,
-            isDiningRefreshing = isDiningRefreshing,
+            isDiningRefreshing = diningState.isDiningRefreshing,
             initialPage = if (initialPage != -1) initialPage else viewModel.getInitialPage(),
-            isSoldOutSubscribed = isSoldOutSubscribed,
-            isDiningImageSubscribed = isDiningImageSubscribed,
+            isSoldOutSubscribed = diningState.isSoldOutSubscribed,
+            isDiningImageSubscribed = diningState.isDiningImageSubscribed,
             refreshDining = viewModel::refreshDining,
             onDateClick = viewModel::setSelectedDate,
             changeSoldOutSubscribe = viewModel::changeIsSoldOutSubscribed,

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningState.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningState.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.feature.dining.ui.diningdetail
+
+import `in`.koreatech.koin.domain.model.dining.Dining
+
+data class DiningState(
+    val selectedDate: String,
+    val dining: List<Dining> = emptyList(),
+    val showBottomSheet: Boolean = false,
+    val isSoldOutSubscribed: Boolean = false,
+    val isDiningImageSubscribed: Boolean = false,
+    val isDiningRefreshing: Boolean = false,
+    val isLoading: Boolean = false
+)

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
@@ -155,23 +155,30 @@ class DiningViewModel @Inject constructor(
     fun changeIsSoldOutSubscribed(boolean: Boolean) = intent {
         reduce { state.copy(isSoldOutSubscribed = boolean) }
         if (userState.value.isAnonymous) return@intent
-        if (boolean) {
-            updateNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
-            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.BREAKFAST)
-            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.LUNCH)
-            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.DINNER)
+        val result = if (boolean) {
+            updateNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT).mapCatching {
+                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.BREAKFAST).getOrThrow()
+                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.LUNCH).getOrThrow()
+                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.DINNER).getOrThrow()
+            }
         } else {
             deleteNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
+        }
+        result.onFailure {
+            reduce { state.copy(isSoldOutSubscribed = !boolean) }
         }
     }
 
     fun changeIsDiningImageSubscribed(boolean: Boolean) = intent {
         reduce { state.copy(isDiningImageSubscribed = boolean) }
         if (userState.value.isAnonymous) return@intent
-        if (boolean) {
+        val result = if (boolean) {
             updateNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
         } else {
             deleteNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
+        }
+        result.onFailure {
+            reduce { state.copy(isDiningImageSubscribed = !boolean) }
         }
     }
 }

--- a/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
+++ b/feature/dining/src/main/java/in/koreatech/koin/feature/dining/ui/diningdetail/DiningViewModel.kt
@@ -7,7 +7,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.core.abtest.Experiment
 import `in`.koreatech.koin.core.onboarding.OnboardingManager
 import `in`.koreatech.koin.core.onboarding.OnboardingType
-import `in`.koreatech.koin.domain.model.dining.Dining
 import `in`.koreatech.koin.domain.model.dining.DiningPlace
 import `in`.koreatech.koin.domain.model.dining.DiningType
 import `in`.koreatech.koin.domain.model.notification.SubscribesDetailType
@@ -25,14 +24,15 @@ import `in`.koreatech.koin.domain.util.TimeUtil
 import `in`.koreatech.koin.feature.dining.navigation.INIT_DATE
 import java.util.Date
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
@@ -46,13 +46,13 @@ class DiningViewModel @Inject constructor(
     private val updateNotificationSubscriptionUseCase: UpdateNotificationSubscriptionUseCase,
     private val updateNotificationSubscriptionDetailUseCase: UpdateNotificationSubscriptionDetailUseCase,
     private val deleteNotificationSubscriptionUseCase: DeleteNotificationSubscriptionUseCase
-) : ViewModel(), ContainerHost<Unit, Nothing> {
-
-    override val container = container<Unit, Nothing>(Unit)
+) : ViewModel(), ContainerHost<DiningState, Nothing> {
 
     private val initDate = savedStateHandle.get<String>(INIT_DATE)
         .takeUnless { it.isNullOrBlank() }
         ?: TimeUtil.dateFormatToYYMMDD(DiningUtil.getCurrentDate())
+
+    override val container = container<DiningState, Nothing>(DiningState(selectedDate = initDate))
 
     private val _userState: StateFlow<User> = getUserStatusUseCase().stateIn(
         scope = viewModelScope,
@@ -60,26 +60,6 @@ class DiningViewModel @Inject constructor(
         initialValue = User.Anonymous
     )
     val userState: StateFlow<User> get() = _userState
-
-    private val _isLoading = MutableStateFlow(false)
-
-    private val _selectedDate = MutableStateFlow(initDate)
-    val selectedDate: StateFlow<String> get() = _selectedDate
-
-    private val _dining = MutableStateFlow<List<Dining>>(emptyList())
-    val dining: StateFlow<List<Dining>> get() = _dining
-
-    private val _showBottomSheet = MutableStateFlow(false)
-    val showBottomSheet: StateFlow<Boolean> get() = _showBottomSheet
-
-    private val _isSoldOutSubscribed = MutableStateFlow(false)
-    val isSoldOutSubscribed: StateFlow<Boolean> get() = _isSoldOutSubscribed
-
-    private val _isDiningImageSubscribed = MutableStateFlow(false)
-    val isDiningImageSubscribed: StateFlow<Boolean> get() = _isDiningImageSubscribed
-
-    private val _isDiningRefreshing = MutableStateFlow(false)
-    val isDiningRefreshing: StateFlow<Boolean> get() = _isDiningRefreshing
 
     val abTestExperimentGroup = flow {
         abTestUseCase(Experiment.DINING_SHARE.experimentTitle).onSuccess {
@@ -93,31 +73,38 @@ class DiningViewModel @Inject constructor(
         initialValue = Experiment.DINING_SHARE.experimentGroups.first()
     )
 
-    fun setSelectedDate(date: Date) {
-        _selectedDate.value = TimeUtil.dateFormatToYYMMDD(date)
-        getDining(selectedDate.value)
+    fun setSelectedDate(date: Date) = intent {
+        val formattedDate = TimeUtil.dateFormatToYYMMDD(date)
+        reduce { state.copy(selectedDate = formattedDate) }
+        fetchDining(formattedDate)
     }
 
-    fun refreshDining() {
-        _isDiningRefreshing.value = true
-        getDining(selectedDate.value)
+    fun refreshDining() = intent {
+        reduce { state.copy(isDiningRefreshing = true) }
+        fetchDining(state.selectedDate)
     }
 
-    fun getDining(date: String = selectedDate.value) {
-        if (!_isLoading.value) {
-            _isLoading.value = true
-            viewModelScope.launch {
-                getNotOperationFilteredDiningUseCase(date)
-                    .onSuccess {
-                        _dining.value = it.sortedBy { diningOrder[it.place] ?: Int.MAX_VALUE }
-                        _isLoading.value = false
-                        _isDiningRefreshing.value = false
-                    }
-                    .onFailure {
-                        _dining.value = listOf()
-                    }
+    fun getDining(date: String? = null) = intent {
+        fetchDining(date ?: state.selectedDate)
+    }
+
+    @OptIn(OrbitExperimental::class)
+    private suspend fun fetchDining(date: String) = subIntent {
+        if (state.isLoading) return@subIntent
+        reduce { state.copy(isLoading = true) }
+        getNotOperationFilteredDiningUseCase(date)
+            .onSuccess { result ->
+                reduce {
+                    state.copy(
+                        dining = result.sortedBy { diningOrder[it.place] ?: Int.MAX_VALUE },
+                        isLoading = false,
+                        isDiningRefreshing = false
+                    )
+                }
             }
-        }
+            .onFailure {
+                reduce { state.copy(dining = emptyList(), isLoading = false, isDiningRefreshing = false) }
+            }
     }
 
     fun getInitialPage(): Int = getDiningTabByType(DiningUtil.getCurrentType())
@@ -133,9 +120,9 @@ class DiningViewModel @Inject constructor(
 
     fun getShowBottomSheetValue() {
         if (userState.value.isAnonymous) return
-        viewModelScope.launch {
+        intent {
             if (onboardingManager.getShouldOnboard(OnboardingType.DINING_NOTIFICATION)) {
-                _showBottomSheet.value = true
+                reduce { state.copy(showBottomSheet = true) }
                 onboardingManager.updateShouldOnboard(OnboardingType.DINING_NOTIFICATION, false)
             }
         }
@@ -145,53 +132,47 @@ class DiningViewModel @Inject constructor(
         if (userState.value.isAnonymous) return
         intent {
             getNotificationPermissionInfoUseCase().onSuccess { info ->
+                var soldOutSubscribed = state.isSoldOutSubscribed
+                var diningImageSubscribed = state.isDiningImageSubscribed
                 info.subscribes.forEach {
                     when (it.type) {
-                        SubscribesType.DINING_SOLD_OUT ->
-                            _isSoldOutSubscribed.value = it.isPermit
-                        SubscribesType.DINING_IMAGE_UPLOAD ->
-                            _isDiningImageSubscribed.value = it.isPermit
+                        SubscribesType.DINING_SOLD_OUT -> soldOutSubscribed = it.isPermit
+                        SubscribesType.DINING_IMAGE_UPLOAD -> diningImageSubscribed = it.isPermit
                         SubscribesType.NOTHING -> Unit
                         else -> Unit
                     }
+                }
+                reduce {
+                    state.copy(
+                        isSoldOutSubscribed = soldOutSubscribed,
+                        isDiningImageSubscribed = diningImageSubscribed
+                    )
                 }
             }
         }
     }
 
-    private fun onSoldOutSubscribe(boolean: Boolean) {
-        if (userState.value.isAnonymous) return
-        intent {
-            if (boolean) {
-                updateNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
-                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.BREAKFAST)
-                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.LUNCH)
-                updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.DINNER)
-            } else {
-                deleteNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
-            }
+    fun changeIsSoldOutSubscribed(boolean: Boolean) = intent {
+        reduce { state.copy(isSoldOutSubscribed = boolean) }
+        if (userState.value.isAnonymous) return@intent
+        if (boolean) {
+            updateNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
+            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.BREAKFAST)
+            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.LUNCH)
+            updateNotificationSubscriptionDetailUseCase(SubscribesDetailType.DINNER)
+        } else {
+            deleteNotificationSubscriptionUseCase(SubscribesType.DINING_SOLD_OUT)
         }
     }
 
-    private fun onDiningImageSubscribe(boolean: Boolean) {
-        if (userState.value.isAnonymous) return
-        intent {
-            if (boolean) {
-                updateNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
-            } else {
-                deleteNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
-            }
+    fun changeIsDiningImageSubscribed(boolean: Boolean) = intent {
+        reduce { state.copy(isDiningImageSubscribed = boolean) }
+        if (userState.value.isAnonymous) return@intent
+        if (boolean) {
+            updateNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
+        } else {
+            deleteNotificationSubscriptionUseCase(SubscribesType.DINING_IMAGE_UPLOAD)
         }
-    }
-
-    fun changeIsSoldOutSubscribed(boolean: Boolean) {
-        _isSoldOutSubscribed.value = boolean
-        onSoldOutSubscribe(boolean)
-    }
-
-    fun changeIsDiningImageSubscribed(boolean: Boolean) {
-        _isDiningImageSubscribed.value = boolean
-        onDiningImageSubscribe(boolean)
     }
 }
 

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.lostandfound.ui.detail
 import android.webkit.URLUtil
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.article.LostAndFoundFilterParams
 import `in`.koreatech.koin.domain.model.user.User
@@ -19,7 +18,6 @@ import javax.inject.Inject
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/detail/LostAndFoundDetailViewModel.kt
@@ -48,23 +48,21 @@ class LostAndFoundDetailViewModel @Inject constructor(
         initUserInfo()
     }
 
-    private fun initUserInfo() = viewModelScope.launch {
+    private fun initUserInfo() = intent {
         getUserStatusUseCase().collectLatest {
-            intent {
-                when (it) {
-                    is User.Student -> reduce {
-                        state.copy(
-                            isLoggedIn = true
-                        )
-                    }
-                    is User.General -> reduce {
-                        state.copy(
-                            isLoggedIn = true
-                        )
-                    }
-                    is User.Anonymous -> reduce {
-                        state.copy(isLoggedIn = false)
-                    }
+            when (it) {
+                is User.Student -> reduce {
+                    state.copy(
+                        isLoggedIn = true
+                    )
+                }
+                is User.General -> reduce {
+                    state.copy(
+                        isLoggedIn = true
+                    )
+                }
+                is User.Anonymous -> reduce {
+                    state.copy(isLoggedIn = false)
                 }
             }
         }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReportViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/report/LostAndFoundReportViewModel.kt
@@ -1,19 +1,19 @@
 package `in`.koreatech.koin.feature.lostandfound.ui.report
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.model.article.ArticleLostAndFoundReportItem
 import `in`.koreatech.koin.domain.usecase.article.lostandfound.ReportLostAndFoundArticleUseCase
 import `in`.koreatech.koin.feature.lostandfound.enums.ReportReason
 import `in`.koreatech.koin.feature.lostandfound.ui.report.component.lostAndFoundReportReasonList
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
@@ -23,15 +23,17 @@ class LostAndFoundReportViewModel @Inject constructor(
     override val container =
         container<LostAndFoundReportState, LostAndFoundReportSideEffect>(LostAndFoundReportState())
 
-    private fun addReportReason(reportReason: ReportReason) =
-        intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun addReportReason(reportReason: ReportReason) =
+        subIntent {
             reduce {
                 state.copy(selectedReason = state.selectedReason + lostAndFoundReportReasonList.indexOf(reportReason))
             }
         }
 
-    private fun removeReportReason(reportReason: ReportReason) =
-        intent {
+    @OptIn(OrbitExperimental::class)
+    private suspend fun removeReportReason(reportReason: ReportReason) =
+        subIntent {
             reduce {
                 state.copy(
                     selectedReason = state.selectedReason.filterNot { lostAndFoundReportReasonList[it] == reportReason }.toIntArray()
@@ -56,31 +58,29 @@ class LostAndFoundReportViewModel @Inject constructor(
         }
 
     fun reportArticle(articleId: Int) =
-        viewModelScope.launch {
+        intent {
             val reportReasonList = mutableListOf<ArticleLostAndFoundReportItem>()
-            intent {
-                state.selectedReason.forEach {
-                    if (lostAndFoundReportReasonList[it] == ReportReason.OTHER) {
-                        reportReasonList.add(
-                            ArticleLostAndFoundReportItem(lostAndFoundReportReasonList[it].title, state.reportReasonDescription)
+            state.selectedReason.forEach {
+                if (lostAndFoundReportReasonList[it] == ReportReason.OTHER) {
+                    reportReasonList.add(
+                        ArticleLostAndFoundReportItem(lostAndFoundReportReasonList[it].title, state.reportReasonDescription)
+                    )
+                } else {
+                    reportReasonList.add(
+                        ArticleLostAndFoundReportItem(
+                            lostAndFoundReportReasonList[it].title,
+                            lostAndFoundReportReasonList[it].description
                         )
-                    } else {
-                        reportReasonList.add(
-                            ArticleLostAndFoundReportItem(
-                                lostAndFoundReportReasonList[it].title,
-                                lostAndFoundReportReasonList[it].description
-                            )
-                        )
-                    }
+                    )
                 }
-                reportLostAndFoundArticleUseCase(
-                    articleId,
-                    reportReasonList
-                ).onSuccess {
-                    postSideEffect(LostAndFoundReportSideEffect.ReportSuccess)
-                }.onFailure {
-                    postSideEffect(LostAndFoundReportSideEffect.ReportFailure(it.message ?: ""))
-                }
+            }
+            reportLostAndFoundArticleUseCase(
+                articleId,
+                reportReasonList
+            ).onSuccess {
+                postSideEffect(LostAndFoundReportSideEffect.ReportSuccess)
+            }.onFailure {
+                postSideEffect(LostAndFoundReportSideEffect.ReportFailure(it.message ?: ""))
             }
         }
 }

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/LostAndFoundWriteArticleViewModel.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/ui/write/LostAndFoundWriteArticleViewModel.kt
@@ -3,7 +3,6 @@ package `in`.koreatech.koin.feature.lostandfound.ui.write
 import android.net.Uri
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import `in`.koreatech.koin.domain.usecase.article.lostandfound.UploadLostAndFoundArticleUseCase
 import `in`.koreatech.koin.domain.usecase.business.UploadFileUseCase
@@ -14,11 +13,12 @@ import `in`.koreatech.koin.feature.lostandfound.enums.LostOrFoundType
 import `in`.koreatech.koin.feature.lostandfound.navigation.LOST_OR_FOUND_TYPE
 import java.time.LocalDate
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.annotation.OrbitExperimental
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.syntax.simple.subIntent
 import org.orbitmvi.orbit.viewmodel.container
 
 @HiltViewModel
@@ -94,7 +94,8 @@ class LostAndFoundWriteArticleViewModel @Inject constructor(
         }
     }
 
-    private fun uploadImage(
+    @OptIn(OrbitExperimental::class)
+    private suspend fun uploadImage(
         preSignedUrl: String,
         fileUrl: String,
         mediaType: String,
@@ -102,40 +103,36 @@ class LostAndFoundWriteArticleViewModel @Inject constructor(
         imageUri: Uri,
         itemIndex: Int,
         imageIndex: Int
-    ) = viewModelScope.launch {
+    ) = subIntent {
         uploadFilesUseCase(
             preSignedUrl,
             mediaType,
             mediaSize,
             imageUri.toString()
         ).onSuccess {
-            intent {
-                reduce {
-                    state.copy(
-                        itemList =
-                        state.itemList.mapIndexed { i, item ->
-                            if (i == itemIndex) {
-                                return@mapIndexed item.copy(
-                                    images =
-                                    item.images.mapIndexed { j, currentValue ->
-                                        if (j == imageIndex) {
-                                            return@mapIndexed fileUrl // Replace placeholder to real image url
-                                        } else {
-                                            currentValue
-                                        }
+            reduce {
+                state.copy(
+                    itemList =
+                    state.itemList.mapIndexed { i, item ->
+                        if (i == itemIndex) {
+                            return@mapIndexed item.copy(
+                                images =
+                                item.images.mapIndexed { j, currentValue ->
+                                    if (j == imageIndex) {
+                                        return@mapIndexed fileUrl // Replace placeholder to real image url
+                                    } else {
+                                        currentValue
                                     }
-                                )
-                            } else {
-                                item
-                            }
+                                }
+                            )
+                        } else {
+                            item
                         }
-                    )
-                }
+                    }
+                )
             }
         }.onFailure {
-            intent {
-                postSideEffect(LostAndFoundWriteArticleSideEffect.FailedToUploadImage)
-            }
+            postSideEffect(LostAndFoundWriteArticleSideEffect.FailedToUploadImage)
         }
     }
 
@@ -146,7 +143,7 @@ class LostAndFoundWriteArticleViewModel @Inject constructor(
         imageUri: Uri,
         itemIndex: Int,
         imageIndex: Int
-    ) = viewModelScope.launch {
+    ) = intent {
         getLostAndFoundPreSignedUrlUseCase(
             fileSize,
             fileType,
@@ -162,9 +159,7 @@ class LostAndFoundWriteArticleViewModel @Inject constructor(
                 imageIndex = imageIndex
             )
         }.onFailure {
-            intent {
-                postSideEffect(LostAndFoundWriteArticleSideEffect.FailedToUploadImage)
-            }
+            postSideEffect(LostAndFoundWriteArticleSideEffect.FailedToUploadImage)
         }
     }
 
@@ -285,17 +280,15 @@ class LostAndFoundWriteArticleViewModel @Inject constructor(
         }
 
     fun writeArticle() =
-        viewModelScope.launch {
-            intent {
-                uploadLostAndFoundArticleUseCase(
-                    state.itemList.map {
-                        it.toArticleLostAndFoundUpload()
-                    }
-                ).onSuccess {
-                    postSideEffect(LostAndFoundWriteArticleSideEffect.LostAndFoundWriteArticle(it.id))
-                }.onFailure {
-                    postSideEffect(LostAndFoundWriteArticleSideEffect.LostAndFoundWriteArticleFailed)
+        intent {
+            uploadLostAndFoundArticleUseCase(
+                state.itemList.map {
+                    it.toArticleLostAndFoundUpload()
                 }
+            ).onSuccess {
+                postSideEffect(LostAndFoundWriteArticleSideEffect.LostAndFoundWriteArticle(it.id))
+            }.onFailure {
+                postSideEffect(LostAndFoundWriteArticleSideEffect.LostAndFoundWriteArticleFailed)
             }
         }
 }

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInScreen.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInScreen.kt
@@ -70,8 +70,6 @@ fun SignInScreen(
 ) {
     val uiState by viewModel.collectAsState()
 
-    val sessionId by viewModel.sessionId.collectAsState()
-
     LaunchedEffect(Unit) {
         viewModel.getSignUpSessionId()
     }
@@ -88,7 +86,7 @@ fun SignInScreen(
         password = uiState.password,
         showPassword = uiState.showPassword,
         isError = uiState.loginError.isError,
-        sessionId = sessionId,
+        sessionId = uiState.sessionId,
         modifier = modifier,
         setLoginId = {
             viewModel.setLoginId(it)

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInState.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInState.kt
@@ -4,7 +4,8 @@ data class SignInState(
     val loginId: String = "",
     val password: String = "",
     val showPassword: Boolean = false,
-    val loginError: LoginError = LoginError()
+    val loginError: LoginError = LoginError(),
+    val sessionId: String = ""
 ) {
     data class LoginError(
         val isError: Boolean = false,

--- a/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInViewModel.kt
+++ b/feature/user/src/main/java/in/koreatech/koin/feature/user/ui/signin/SignInViewModel.kt
@@ -8,8 +8,6 @@ import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.domain.usecase.session.GetSessionIdUseCase
 import `in`.koreatech.koin.domain.usecase.user.UserLoginUseCase
 import javax.inject.Inject
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.blockingIntent
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -23,9 +21,6 @@ class SignInViewModel @Inject constructor(
     private val getSessionIdUseCase: GetSessionIdUseCase
 ) : ViewModel(), ContainerHost<SignInState, SignInSideEffect> {
     override val container = container<SignInState, SignInSideEffect>(SignInState())
-
-    private val _sessionId = MutableStateFlow("")
-    val sessionId: StateFlow<String> = _sessionId
 
     fun setLoginId(loginId: String) {
         blockingIntent {
@@ -73,11 +68,12 @@ class SignInViewModel @Inject constructor(
             }
     }
 
-    fun getSignUpSessionId() {
-        _sessionId.value = getSessionIdUseCase(
+    fun getSignUpSessionId() = blockingIntent {
+        val sessionId = getSessionIdUseCase(
             sessionName = "sign_up",
             isLoggedIn = false,
             shouldExpireOtherSessions = true
         )
+        reduce { state.copy(sessionId = sessionId) }
     }
 }


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1565

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [x] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `viewModelScope.launch` 및 `launch` 중첩을 제거했습니다.
- `launch` 중첩을 제거하고, `subIntent`로 교체했습니다.
- Orbit-MVI를 import 하고 있지만, 실제로 사용하지 않았던 dining detail 화면을 사용하도록 수정했습니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 식당 상세 화면의 식사 정보와 날짜, 알림 및 새로고침 상태 관리가 안정화되었습니다.
  * 식당 정보 조회 중복 요청을 방지하고, 실패 시 상태가 올바르게 복구됩니다.
  * 로그인·회원가입 과정에서 세션 정보가 화면에 일관되게 반영됩니다.
  * 동아리 및 분실물 등록·수정·신고와 이미지 업로드 처리가 개선되었습니다.
  * 동아리 수정 실패 시 안내 메시지가 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->