### PR TITLE
[Feature] V2 게시글 API 및 AI 요약 도메인 모델 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/ArticleApi.kt
@@ -4,6 +4,7 @@ import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationRe
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundStatsResponse
 import `in`.koreatech.koin.data.response.article.ArticlePaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleResponse
+import `in`.koreatech.koin.data.response.article.ArticleV2Response
 import `in`.koreatech.koin.data.response.article.KeywordsResponse
 import retrofit2.http.GET
 import retrofit2.http.Path
@@ -33,6 +34,17 @@ interface ArticleApi {
         @Path("id") articleId: Int,
         @Query("boardId") boardId: Int
     ): ArticleResponse
+
+    /**
+     * 단일 게시글 조회 + AI 요약
+     * @param id 게시글 아이디
+     * @param boardId 게시판 아이디, 이전 및 다음 게시글을 판별하기 위함
+     */
+    @GET("v2/articles/{id}")
+    suspend fun fetchArticleV2(
+        @Path("id") articleId: Int,
+        @Query("boardId") boardId: Int
+    ): ArticleV2Response
 
     @GET("articles/hot")
     suspend fun fetchHotArticles(): List<ArticleResponse>

--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -122,6 +122,15 @@ class ArticleRepositoryImpl @Inject constructor(
         }
     }
 
+    override fun fetchArticleV2(
+        articleId: Int,
+        boardId: Int
+    ): Flow<Article> {
+        return flow {
+            emit(articleRemoteDataSource.fetchArticleV2(articleId, boardId).toArticle())
+        }
+    }
+
     override fun fetchPreviousArticle(
         articleId: Int,
         boardId: Int

--- a/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/ArticleRepositoryImpl.kt
@@ -113,6 +113,7 @@ class ArticleRepositoryImpl @Inject constructor(
         }
     }
 
+    @Deprecated("Use fetchArticleV2 instead")
     override fun fetchArticle(
         articleId: Int,
         boardId: Int

--- a/data/src/main/java/in/koreatech/koin/data/response/article/ArticleResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/article/ArticleResponse.kt
@@ -49,6 +49,7 @@ data class ArticleResponse(
     fun toArticle() =
         Article(
             header = toArticleHeader(),
+            aiSummary = null,
             content = content ?: "",
             prevArticleId = prevArticleId,
             nextArticleId = nextArticleId,

--- a/data/src/main/java/in/koreatech/koin/data/response/article/ArticleV2Response.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/article/ArticleV2Response.kt
@@ -1,0 +1,69 @@
+package `in`.koreatech.koin.data.response.article
+
+import com.google.gson.annotations.SerializedName
+import `in`.koreatech.koin.domain.model.article.Article
+import `in`.koreatech.koin.domain.model.article.ArticleAiSummary
+import `in`.koreatech.koin.domain.model.article.ArticleHeader
+
+data class ArticleV2Response(
+    @SerializedName("id") val id: Int?,
+    @SerializedName("board_id") val boardId: Int?,
+    @SerializedName("title") val title: String?,
+    @SerializedName("content") val content: String?,
+    @SerializedName("ai_summary") val aiSummary: AiSummaryResponse?,
+    @SerializedName("author") val author: String?,
+    @SerializedName("hit") val viewCount: Int?,
+    @SerializedName("registered_at") val registeredAt: String?,
+    @SerializedName("updated_at") val updatedAt: String?,
+    @SerializedName("prev_id") val prevArticleId: Int?,
+    @SerializedName("next_id") val nextArticleId: Int?,
+    @SerializedName("attachments") val attachments: List<AttachmentResponse>?,
+    @SerializedName("url") val url: String?
+) {
+    fun toArticleHeader() =
+        ArticleHeader(
+            id = id ?: 0,
+            boardId = boardId ?: 0,
+            title = title ?: "",
+            author = author ?: "",
+            viewCount = viewCount ?: 0,
+            registeredAt = registeredAt ?: "",
+            updatedAt = updatedAt ?: ""
+        )
+
+    fun toArticle() =
+        Article(
+            header = toArticleHeader(),
+            aiSummary = aiSummary?.toArticleAiSummary(),
+            content = content ?: "",
+            prevArticleId = prevArticleId,
+            nextArticleId = nextArticleId,
+            attachments = attachments?.map { it.toAttachment() } ?: listOf(),
+            url = url ?: ""
+        )
+}
+
+data class AiSummaryResponse(
+    @SerializedName("status") val status: String,
+    @SerializedName("items") val items: List<SummaryItem>
+) {
+    fun toArticleAiSummary() =
+        ArticleAiSummary(
+            status = status,
+            summaryItems = items.toSummaryItems()
+        )
+
+    data class SummaryItem(
+        @SerializedName("icon") val icon: String,
+        @SerializedName("text") val text: String
+    ) {
+        fun toSummaryItem() =
+            ArticleAiSummary.SummaryItem(
+                icon = icon,
+                text = text
+            )
+    }
+
+    private fun List<SummaryItem>.toSummaryItems() =
+        this.map { it.toSummaryItem() }
+}

--- a/data/src/main/java/in/koreatech/koin/data/response/article/ArticleV2Response.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/article/ArticleV2Response.kt
@@ -38,7 +38,7 @@ data class ArticleV2Response(
             content = content ?: "",
             prevArticleId = prevArticleId,
             nextArticleId = nextArticleId,
-            attachments = attachments?.map { it.toAttachment() } ?: listOf(),
+            attachments = attachments?.map { it.toAttachment() } ?: emptyList(),
             url = url ?: ""
         )
 }

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/ArticleRemoteDataSource.kt
@@ -11,6 +11,7 @@ import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundPaginationRe
 import `in`.koreatech.koin.data.response.article.ArticleLostAndFoundResponse
 import `in`.koreatech.koin.data.response.article.ArticlePaginationResponse
 import `in`.koreatech.koin.data.response.article.ArticleResponse
+import `in`.koreatech.koin.data.response.article.ArticleV2Response
 import `in`.koreatech.koin.data.response.article.KeywordsResponse
 import `in`.koreatech.koin.domain.model.article.ArticleLostAndFoundUpload
 import `in`.koreatech.koin.domain.model.article.KeywordType
@@ -33,6 +34,13 @@ class ArticleRemoteDataSource @Inject constructor(
         boardId: Int
     ): ArticleResponse {
         return articleApi.fetchArticle(articleId, boardId)
+    }
+
+    suspend fun fetchArticleV2(
+        articleId: Int,
+        boardId: Int
+    ): ArticleV2Response {
+        return articleApi.fetchArticleV2(articleId, boardId)
     }
 
     suspend fun fetchPreviousArticle(

--- a/domain/src/main/java/in/koreatech/koin/domain/model/article/Article.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/article/Article.kt
@@ -2,6 +2,7 @@ package `in`.koreatech.koin.domain.model.article
 
 data class Article(
     val header: ArticleHeader,
+    val aiSummary: ArticleAiSummary?,
     val content: String,
     val prevArticleId: Int?,
     val nextArticleId: Int?,

--- a/domain/src/main/java/in/koreatech/koin/domain/model/article/ArticleAiSummary.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/article/ArticleAiSummary.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.domain.model.article
+
+data class ArticleAiSummary(
+    val status: String,
+    val summaryItems: List<SummaryItem>
+) {
+    data class SummaryItem(
+        val icon: String,
+        val text: String
+    )
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
@@ -24,6 +24,11 @@ interface ArticleRepository {
         boardId: Int
     ): Flow<Article>
 
+    fun fetchArticleV2(
+        articleId: Int,
+        boardId: Int
+    ): Flow<Article>
+
     fun fetchPreviousArticle(
         articleId: Int,
         boardId: Int

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/ArticleRepository.kt
@@ -19,6 +19,7 @@ interface ArticleRepository {
         limit: Int
     ): Flow<ArticlePagination>
 
+    @Deprecated("Use fetchArticleV2 instead")
     fun fetchArticle(
         articleId: Int,
         boardId: Int

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/article/FetchArticleV2UseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/article/FetchArticleV2UseCase.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.domain.usecase.article
+
+import `in`.koreatech.koin.domain.model.article.Article
+import `in`.koreatech.koin.domain.repository.ArticleRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
+
+class FetchArticleV2UseCase @Inject constructor(
+    private val articleRepository: ArticleRepository
+) {
+    operator fun invoke(articleId: Int, boardId: Int): Flow<Article> =
+        articleRepository.fetchArticleV2(articleId, boardId)
+}


### PR DESCRIPTION
## PR 개요
이슈 번호:#1573

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `GET v2/articles/{id}` API 엔드포인트 추가 (`ArticleApi`, `ArticleRemoteDataSource`)
- `ArticleV2Response` DTO 추가 — AI 요약(`ai_summary`) 필드 포함
- `ArticleAiSummary` 도메인 모델 추가
- `Article` 도메인 모델에 `aiSummary: ArticleAiSummary?` 필드 추가 (V1 API는 null)
- `ArticleRepository` 인터페이스 및 `ArticleRepositoryImpl`에 `fetchArticleV2()` 추가
- `FetchArticleV2UseCase` 추가

### 논의 사항
기존 api 는 사용하진 않지만 호환성을 위해 nullable 한 ai summary 필드로 만들었습니다.
기본 값을 줘도 상관없지만 우선 null 로 처리했습니다.

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 상세 정보에 AI 요약을 함께 제공합니다.
  * AI 요약 상태와 항목별 아이콘·내용을 확인할 수 있습니다.
  * 요약이 제공되지 않는 기존 게시글도 정상적으로 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->