### PR TITLE
[Feature] 카테고리 채팅 메뉴 추가

### DIFF
--- a/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
+++ b/core/navigation/src/main/java/in/koreatech/koin/core/navigation/Navigator.kt
@@ -77,6 +77,10 @@ interface Navigator {
         context: Context
     ): Intent
 
+    fun navigateToChatList(
+        context: Context
+    ): Intent
+
     fun navigateToChatRoom(
         context: Context
     ): Intent

--- a/feature/category/src/main/java/in/koreatech/koin/feature/category/CategoryViewModel.kt
+++ b/feature/category/src/main/java/in/koreatech/koin/feature/category/CategoryViewModel.kt
@@ -42,6 +42,7 @@ class CategoryViewModel @Inject constructor(
             CategoryMenuId.BUS_TIMETABLE -> AnalyticsConstant.Label.Category.CATEGORY_TRANSPORTATION to "버스 시간표"
             CategoryMenuId.TRANSPORT_SEARCH -> AnalyticsConstant.Label.Category.CATEGORY_TRANSPORTATION to "교통편 조회하기"
             CategoryMenuId.CALLVAN -> AnalyticsConstant.Label.Category.CATEGORY_TRANSPORTATION to "콜벤팟 모집"
+            CategoryMenuId.CHAT -> AnalyticsConstant.Label.Category.CATEGORY_ETC to "채팅"
             CategoryMenuId.HOUSING -> AnalyticsConstant.Label.Category.CATEGORY_ETC to "복덕방"
             CategoryMenuId.KOIN_BUSINESS -> AnalyticsConstant.Label.Category.CATEGORY_ETC to "코인 for Business"
         }

--- a/feature/category/src/main/java/in/koreatech/koin/feature/category/component/CategoryMenu.kt
+++ b/feature/category/src/main/java/in/koreatech/koin/feature/category/component/CategoryMenu.kt
@@ -15,6 +15,7 @@ enum class CategoryMenuId {
     BUS_TIMETABLE,
     TRANSPORT_SEARCH,
     CALLVAN,
+    CHAT,
     HOUSING,
     KOIN_BUSINESS
 }
@@ -39,6 +40,7 @@ internal val TRANSPORT_MENUS = persistentListOf(
 )
 
 internal val OTHER_MENUS = persistentListOf(
+    CategoryMenu(CategoryMenuId.CHAT, R.drawable.ic_category_chat, R.string.chat),
     CategoryMenu(CategoryMenuId.HOUSING, R.drawable.ic_home, R.string.housing),
     CategoryMenu(CategoryMenuId.KOIN_BUSINESS, R.drawable.ic_koin_business, R.string.koin_business)
 )

--- a/feature/category/src/main/java/in/koreatech/koin/feature/category/navigation/CategoryNavigationHandler.kt
+++ b/feature/category/src/main/java/in/koreatech/koin/feature/category/navigation/CategoryNavigationHandler.kt
@@ -21,6 +21,7 @@ internal object CategoryNavigationHandler {
         CategoryMenuId.BUS_TIMETABLE -> navigator.navigateToBusTimeTable(context)
         CategoryMenuId.TRANSPORT_SEARCH -> navigator.navigateToBusSearch(context)
         CategoryMenuId.CALLVAN -> navigator.navigateToCallvan(context)
+        CategoryMenuId.CHAT -> navigator.navigateToChatList(context)
         CategoryMenuId.HOUSING -> navigator.navigateToLand(context)
         CategoryMenuId.KOIN_BUSINESS -> navigator.navigateToBusiness(context)
     }

--- a/feature/category/src/main/res/drawable/ic_category_chat.xml
+++ b/feature/category/src/main/res/drawable/ic_category_chat.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M7.5,8.5H16.5M7.5,12.5H13"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#B611F5"
+      android:strokeLineCap="round"/>
+  <path
+      android:pathData="M2,10.5C2,9.729 2.013,8.977 2.039,8.25C2.123,5.877 2.165,4.69 3.13,3.717C4.095,2.745 5.316,2.693 7.756,2.588C9.095,2.531 10.521,2.5 12,2.5C13.479,2.5 14.905,2.531 16.244,2.588C18.684,2.693 19.905,2.745 20.87,3.717C21.835,4.69 21.877,5.877 21.961,8.25C21.986,8.977 22,9.729 22,10.5C22,11.271 21.986,12.023 21.961,12.75C21.877,15.123 21.835,16.31 20.87,17.283C19.905,18.255 18.684,18.307 16.244,18.412C15.51,18.443 14.75,18.467 13.969,18.482C13.228,18.496 12.858,18.503 12.532,18.627C12.206,18.751 11.932,18.986 11.384,19.455L9.205,21.324C9.073,21.438 8.904,21.5 8.73,21.5C8.327,21.5 8,21.173 8,20.77V18.422C7.918,18.419 7.837,18.415 7.756,18.412C5.316,18.307 4.095,18.255 3.13,17.282C2.165,16.31 2.123,15.123 2.039,12.75C2.013,12.023 2,11.271 2,10.5Z"
+      android:strokeLineJoin="round"
+      android:strokeWidth="1.5"
+      android:fillColor="#00000000"
+      android:strokeColor="#B611F5"
+      android:strokeLineCap="round"/>
+</vector>

--- a/feature/category/src/main/res/values/strings.xml
+++ b/feature/category/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="callvan">콜밴팟 모집</string>
     <string name="other">기타</string>
     <string name="housing">복덕방</string>
+    <string name="chat">채팅</string>
     <string name="koin_business">코인 for Business</string>
     <string name="category_cannot_open_link">링크를 열 수 없습니다.</string>
 </resources>

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatList.kt
@@ -29,6 +29,7 @@ import `in`.koreatech.koin.core.analytics.AnalyticsConstant
 import `in`.koreatech.koin.core.analytics.EventLogger
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
+import `in`.koreatech.koin.core.navigation.utils.rememberNavigator
 import `in`.koreatech.koin.domain.model.chat.ChatListItem
 import `in`.koreatech.koin.feature.chat.R
 import `in`.koreatech.koin.feature.chat.ui.component.ChatProgressIndicator
@@ -39,6 +40,7 @@ import `in`.koreatech.koin.feature.chat.ui.room.ChatRoomViewModel.Companion.CHAT
 import java.time.LocalDateTime
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
+import org.orbitmvi.orbit.compose.collectSideEffect
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -53,6 +55,17 @@ fun ChatList(
     val snackbarHostState = remember { SnackbarHostState() }
 
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    val navigator = rememberNavigator()
+
+    viewModel.collectSideEffect { sideEffect ->
+        when (sideEffect) {
+            is ChatListSideEffect.NavigateToLogin -> {
+                context.startActivity(navigator.navigateToSignIn(context))
+                (context as? Activity)?.finish()
+            }
+        }
+    }
 
     LaunchedEffect(Unit) {
         lifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListSideEffect.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListSideEffect.kt
@@ -1,3 +1,5 @@
 package `in`.koreatech.koin.feature.chat.ui.list
 
-sealed class ChatListSideEffect
+sealed class ChatListSideEffect {
+    data object NavigateToLogin : ChatListSideEffect()
+}

--- a/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
+++ b/feature/chat/src/main/java/in/koreatech/koin/feature/chat/ui/list/ChatListViewModel.kt
@@ -25,6 +25,7 @@ import org.hildan.krossbow.stomp.LostReceiptException
 import org.hildan.krossbow.websocket.WebSocketConnectionException
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 import timber.log.Timber
@@ -69,13 +70,17 @@ class ChatListViewModel @Inject constructor(
                     }
                 }
 
-                is User.Anonymous -> throw IllegalAccessException()
+                is User.Anonymous -> {
+                    postSideEffect(ChatListSideEffect.NavigateToLogin)
+                    return@collectLatest
+                }
             }
             _connectChannel.send(true)
         }
     }
 
     fun fetchChatList() = viewModelScope.launch {
+        if (container.stateFlow.value.userId == -1) return@launch
         getChatListUseCase().collect { data ->
             intent {
                 reduce {

--- a/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
+++ b/koin/src/main/java/in/koreatech/koin/navigation/NavigatorImpl.kt
@@ -15,6 +15,7 @@ import `in`.koreatech.koin.core.navigation.utils.isValidDeepLink
 import `in`.koreatech.koin.data.constant.URLConstant
 import `in`.koreatech.koin.feature.callvan.CallvanActivity
 import `in`.koreatech.koin.feature.chat.ui.groupchat.GroupChatActivity
+import `in`.koreatech.koin.feature.chat.ui.list.ChatListActivity
 import `in`.koreatech.koin.feature.chat.ui.room.ChatRoomActivity
 import `in`.koreatech.koin.feature.department.DepartmentActivity
 import `in`.koreatech.koin.feature.dining.ui.DiningActivity
@@ -148,6 +149,12 @@ class NavigatorImpl @Inject constructor() : Navigator {
 
     override fun navigateToLostAndFound(context: Context): Intent {
         return context.buildIntent(LostAndFoundActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+    }
+
+    override fun navigateToChatList(context: Context): Intent {
+        return context.buildIntent(ChatListActivity::class.java).apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         }
     }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1574

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 카테고리 기타 섹션에 채팅 메뉴 추가 (`CategoryMenuId.CHAT`, `OTHER_MENUS`)
- `navigateToChatList()` Navigator 추가 및 `ChatListActivity`로 이동 구현
- 비로그인 사용자가 채팅 목록 진입 시 크래시 수정
  - `throw IllegalAccessException()` → `NavigateToLogin` SideEffect 발행 후 로그인 화면 이동
  - `fetchChatList()` 비로그인 상태 API 호출 방지 가드 추가 (401 방지)

### 논의 사항
채팅 list 는 로그인된 사용자만 진입이 가능하여 로그인 조건이 필요합니다.
category 에서 판정하기 보다 chat 에서 일괄적으로 처리하는게 맞을 거 같아 chat 에서 추가했습니다.
우선 따로 로그인 요청 dialog 는 띄우지 않고 즉시 로그인 화면으로 유도합니다.

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 카테고리 메뉴에 **채팅** 항목이 추가되었습니다.
  - 채팅 메뉴에서 채팅 목록 화면으로 바로 이동할 수 있습니다.
  - 채팅 아이콘이 새롭게 제공됩니다.

- **버그 수정**
  - 로그인하지 않은 상태에서 채팅 목록에 접근하면 오류 대신 로그인 화면으로 안내됩니다.
  - 로그인하지 않은 경우 불필요한 채팅 목록 조회를 시도하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->