### PR TITLE
[Fix] 분실물 화면에서 뒤로가기 시 목록이 새로고침되는 오류

### DIFF
--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.lostandfound.navigation
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -36,9 +37,11 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
             }
     }
 
-    val onBackPressedWithCancel = {
+    val popBackStackWithCancel = {
         cancelRefreshList(true)
-        onBackPressed()
+        if (!navController.popBackStack()) {
+            onBackPressed()
+        }
     }
 
     val navigateToList = { cancelRefresh: Boolean ->
@@ -91,9 +94,12 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     composable<LostAndFoundNavType.LostAndFoundDetailRoute> {
         val navigator = rememberNavigator()
         val context = LocalContext.current
+        BackHandler(enabled = navController.previousBackStackEntry != null) {
+            popBackStackWithCancel()
+        }
         LostAndFoundDetail(
             navigateToArticleList = navigateToList,
-            onTopbarBackClick = onBackPressedWithCancel,
+            onTopbarBackClick = popBackStackWithCancel,
             refreshList = { cancelRefreshList(false) },
             navigateToChatRoom = { articleId ->
                 val intent = navigator.navigateToChatRoom(context)
@@ -122,23 +128,32 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
 
     composable<LostAndFoundNavType.LostAndFoundReportRoute> { backStackEntry ->
         val route = backStackEntry.toRoute<LostAndFoundNavType.LostAndFoundReportRoute>()
+        BackHandler(enabled = navController.previousBackStackEntry != null) {
+            popBackStackWithCancel()
+        }
         LostAndFoundReport(
             articleId = route.articleId,
-            onTopbarBackClick = onBackPressedWithCancel,
+            onTopbarBackClick = popBackStackWithCancel,
             onSuccess = { navigateToList(false) }
         )
     }
 
     composable<LostAndFoundNavType.LostAndFoundWriteRoute> {
+        BackHandler(enabled = navController.previousBackStackEntry != null) {
+            popBackStackWithCancel()
+        }
         LostAndFoundWriteArticle(
-            onBackClick = onBackPressedWithCancel,
+            onBackClick = popBackStackWithCancel,
             onComplete = { navigateToList(false) }
         )
     }
 
     composable<LostAndFoundNavType.LostAndFoundModifyRoute> {
+        BackHandler(enabled = navController.previousBackStackEntry != null) {
+            popBackStackWithCancel()
+        }
         LostAndFoundModify(
-            onBackClick = onBackPressedWithCancel,
+            onBackClick = popBackStackWithCancel,
             onComplete = { articleId ->
                 navigateToList(false)
                 navController.navigate(LostAndFoundNavType.LostAndFoundDetailRoute(articleId))

--- a/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
+++ b/feature/lostandfound/src/main/java/in/koreatech/koin/feature/lostandfound/navigation/Navigation.kt
@@ -26,7 +26,8 @@ fun NavGraphBuilder.koinLostAndFoundGraph(
     onBackPressed: () -> Unit
 ) {
     val cancelRefreshList = { cancelRefresh: Boolean ->
-        navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute)
+        runCatching { navController.getBackStackEntry(LostAndFoundNavType.LostAndFoundListRoute) }
+            .getOrNull()
             ?.savedStateHandle
             ?.let { handle ->
                 if (handle.get<Boolean>(CANCEL_REFRESH_LIST) != false) {


### PR DESCRIPTION
## PR 개요
이슈 번호: #1581

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명

분실물 상세/신고/작성/수정 화면에서 상단바 back 버튼이 아닌 시스템 back(하드웨어 버튼, 제스처)으로 목록으로 돌아가면, `CANCEL_REFRESH_LIST` savedStateHandle 플래그가 세팅되지 않아 목록이 항상 새로고침되면서 스크롤 위치가 초기화되는 문제가 있었습니다.

- 상단바 back 버튼만 `cancelRefreshList(true)`를 호출한 뒤 back을 트리거했고, 시스템 back은 NavHost의 기본 pop 콜백으로 곧장 빠져나가 이 로직을 우회했습니다.
- 각 화면(Detail/Report/Write/Modify)에 `BackHandler`를 추가하고, `cancelRefreshList(true)` → `navController.popBackStack()`을 직접 수행하는 `popBackStackWithCancel`로 통일하여 상단바/시스템 back이 동일한 경로를 타도록 수정했습니다.
- 부수적으로, 딥링크로 상세 화면에 진입한 경우(List route가 백스택에 없음) `getBackStackEntry`가 예외를 던져 크래시가 날 수 있는 부분을 `runCatching`으로 가드했습니다.

두 커밋으로 분리했습니다:
1. `fix: Prevent crash when list route is missing from lost-and-found back stack`
2. `fix: Route system back button through cancelRefreshList in lost-and-found`

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 분실물 상세·신고·작성·수정 화면에서 시스템 뒤로 가기와 상단 뒤로 가기 동작을 일관되게 처리합니다.
  * 이전 화면이 없을 때도 기존 뒤로 가기 동작이 정상적으로 실행됩니다.
  * 뒤로 가기 중 발생할 수 있는 예외 상황을 안정적으로 처리합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->