### PR TITLE
[Feature] 지원자 상세 화면 추가

### DIFF
--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -3,13 +3,24 @@ package `in`.koreatech.koin.feature.recruitment.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.ApplicantDetailScreen
 import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.ApplicantManagementScreen
 
 fun NavGraphBuilder.koinRecruitmentGraph(
     navController: NavController
 ) {
-    composable<RecruitmentNavType.ApplicantManagement> {
+    composable<RecruitmentNavType.ApplicantManagement> { backStackEntry ->
+        val route = backStackEntry.toRoute<RecruitmentNavType.ApplicantManagement>()
         ApplicantManagementScreen(
+            onNavigateUp = { navController.navigateUp() },
+            onApplicantDetail = { applicantId ->
+                navController.navigate(RecruitmentNavType.ApplicantDetail(route.postId, applicantId))
+            }
+        )
+    }
+    composable<RecruitmentNavType.ApplicantDetail> {
+        ApplicantDetailScreen(
             onNavigateUp = { navController.navigateUp() }
         )
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -20,9 +20,6 @@ fun NavGraphBuilder.koinRecruitmentGraph(
             }
         )
     }
-    composable<RecruitmentNavType.ApplicantManagement> {
-        ApplicantManagementScreen()
-    }
     composable<RecruitmentNavType.MyRecruitment> {
         MyRecruitmentScreen(
             onNavigateUp = { navController.navigateUp() }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/RecruitmentNavType.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/RecruitmentNavType.kt
@@ -6,4 +6,7 @@ import kotlinx.serialization.Serializable
 sealed class RecruitmentNavType {
     @Serializable
     data class ApplicantManagement(val postId: Long) : RecruitmentNavType()
+
+    @Serializable
+    data class ApplicantDetail(val postId: Long, val applicantId: Long) : RecruitmentNavType()
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailScreen.kt
@@ -1,0 +1,191 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
+import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component.ApplicantActivityInfoBox
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component.ApplicantDecisionButtons
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component.ApplicantDecisionDialog
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component.ApplicantDetailProfileCard
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component.ApplicantLabeledInfoBox
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantActivity
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantDetail
+import kotlinx.collections.immutable.persistentListOf
+import org.orbitmvi.orbit.compose.collectAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApplicantDetailScreen(
+    viewModel: ApplicantDetailViewModel = hiltViewModel(),
+    onNavigateUp: () -> Unit = {}
+) {
+    val state by viewModel.collectAsState()
+    val applicant = state.applicant
+
+    Scaffold(
+        containerColor = RebrandKoinTheme.colors.neutral50,
+        topBar = {
+            KoinTopAppBar(
+                title = stringResource(R.string.recruitment_applicant_detail_title),
+                onNavigationIconClick = onNavigateUp,
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = RebrandKoinTheme.colors.neutral50
+                )
+            )
+        },
+        bottomBar = {
+            if (applicant != null) {
+                ApplicantDecisionButtons(
+                    onReject = { viewModel.showRejectDialog() },
+                    onApprove = { viewModel.showApproveDialog() },
+                    modifier = Modifier
+                        .windowInsetsPadding(WindowInsets.navigationBars)
+                        .padding(horizontal = 21.5.dp, vertical = 16.dp)
+                )
+            }
+        }
+    ) { innerPadding ->
+        if (applicant != null) {
+            ApplicantDetailScreenImpl(
+                applicant = applicant,
+                modifier = Modifier.padding(innerPadding)
+            )
+        }
+    }
+
+    if (state.showApproveDialog) {
+        ApplicantDecisionDialog(
+            title = stringResource(R.string.recruitment_applicant_approve_dialog_title),
+            message = stringResource(R.string.recruitment_applicant_approve_dialog_message),
+            confirmText = stringResource(R.string.recruitment_applicant_approve_dialog_confirm),
+            onDismiss = { viewModel.dismissApproveDialog() },
+            onConfirm = { viewModel.approve() }
+        )
+    }
+
+    if (state.showRejectDialog) {
+        ApplicantDecisionDialog(
+            title = stringResource(R.string.recruitment_applicant_reject_dialog_title),
+            message = stringResource(R.string.recruitment_applicant_reject_dialog_message),
+            confirmText = stringResource(R.string.recruitment_applicant_reject_dialog_confirm),
+            onDismiss = { viewModel.dismissRejectDialog() },
+            onConfirm = { viewModel.reject() }
+        )
+    }
+}
+
+@Composable
+private fun ApplicantDetailScreenImpl(
+    applicant: ApplicantDetail,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 21.5.dp, vertical = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(24.dp)
+    ) {
+        item {
+            ApplicantDetailProfileCard(
+                name = applicant.name,
+                role = applicant.role,
+                department = applicant.department,
+                studentNumber = applicant.studentNumber,
+                status = applicant.status
+            )
+        }
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = stringResource(R.string.recruitment_applicant_detail_basic_info),
+                    style = RebrandKoinTheme.typography.bold16,
+                    color = RebrandKoinTheme.colors.neutral800
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ApplicantLabeledInfoBox(
+                        label = stringResource(R.string.recruitment_applicant_detail_skills),
+                        content = applicant.skills.joinToString()
+                    )
+                    applicant.activities.forEach { activity ->
+                        ApplicantActivityInfoBox(
+                            title = activity.title,
+                            period = activity.period,
+                            content = activity.content
+                        )
+                    }
+                    ApplicantLabeledInfoBox(
+                        label = stringResource(R.string.recruitment_applicant_detail_introduction),
+                        content = applicant.introduction
+                    )
+                }
+            }
+        }
+        item {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Text(
+                    text = stringResource(R.string.recruitment_applicant_detail_application_info),
+                    style = RebrandKoinTheme.typography.bold16,
+                    color = RebrandKoinTheme.colors.neutral800
+                )
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ApplicantLabeledInfoBox(
+                        label = stringResource(R.string.recruitment_applicant_detail_motivation),
+                        content = applicant.motivation
+                    )
+                    ApplicantLabeledInfoBox(
+                        label = stringResource(R.string.recruitment_applicant_detail_available_time),
+                        content = applicant.availableTime
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF8F8FA)
+@Composable
+private fun ApplicantDetailScreenPreview() {
+    RebrandKoinTheme {
+        ApplicantDetailScreenImpl(
+            applicant = ApplicantDetail(
+                id = 1L,
+                name = "김철수",
+                role = "프론트엔드",
+                department = "컴퓨터공학부",
+                studentNumber = "23학번",
+                status = ApplicantStatus.PENDING,
+                skills = persistentListOf("정보처리기사"),
+                activities = persistentListOf(
+                    ApplicantActivity(
+                        title = "AI 공모전",
+                        period = "2026.03.23 - 2026.04.06",
+                        content = "AI 공모전에서 기획을 담당했고 @@@를 주제로 @@@를 만들었습니다"
+                    )
+                ),
+                introduction = "안녕하세요.",
+                motivation = "안녕하세요.",
+                availableTime = "월 수 금 20시 이후"
+            )
+        )
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailSideEffect.kt
@@ -1,0 +1,3 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail
+
+sealed interface ApplicantDetailSideEffect

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailState.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail
+
+import androidx.compose.runtime.Immutable
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantDetail
+
+@Immutable
+data class ApplicantDetailState(
+    val applicant: ApplicantDetail? = null,
+    val showApproveDialog: Boolean = false,
+    val showRejectDialog: Boolean = false
+)

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailViewModel.kt
@@ -1,0 +1,82 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.navigation.RecruitmentNavType
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantActivity
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantDetail
+import javax.inject.Inject
+import kotlinx.collections.immutable.persistentListOf
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+
+@HiltViewModel
+class ApplicantDetailViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle
+) : ViewModel(), ContainerHost<ApplicantDetailState, ApplicantDetailSideEffect> {
+
+    private val route = savedStateHandle.toRoute<RecruitmentNavType.ApplicantDetail>()
+
+    override val container = container<ApplicantDetailState, ApplicantDetailSideEffect>(
+        ApplicantDetailState(
+            applicant = ApplicantDetail(
+                id = route.applicantId,
+                name = "김철수",
+                role = "프론트엔드",
+                department = "컴퓨터공학부",
+                studentNumber = "23학번",
+                status = ApplicantStatus.PENDING,
+                skills = persistentListOf("정보처리기사"),
+                activities = persistentListOf(
+                    ApplicantActivity(
+                        title = "AI 공모전",
+                        period = "2026.03.23 - 2026.04.06",
+                        content = "AI 공모전에서 기획을 담당했고 @@@를 주제로 @@@를 만들었습니다"
+                    )
+                ),
+                introduction = "안녕하세요.",
+                motivation = "안녕하세요.",
+                availableTime = "월 수 금 20시 이후"
+            )
+        )
+    )
+
+    fun showApproveDialog() = intent {
+        reduce { state.copy(showApproveDialog = true) }
+    }
+
+    fun dismissApproveDialog() = intent {
+        reduce { state.copy(showApproveDialog = false) }
+    }
+
+    fun showRejectDialog() = intent {
+        reduce { state.copy(showRejectDialog = true) }
+    }
+
+    fun dismissRejectDialog() = intent {
+        reduce { state.copy(showRejectDialog = false) }
+    }
+
+    fun approve() = intent {
+        reduce {
+            state.copy(
+                showApproveDialog = false,
+                applicant = state.applicant?.copy(status = ApplicantStatus.APPROVED)
+            )
+        }
+    }
+
+    fun reject() = intent {
+        reduce {
+            state.copy(
+                showRejectDialog = false,
+                applicant = state.applicant?.copy(status = ApplicantStatus.REJECTED)
+            )
+        }
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDecisionButtons.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDecisionButtons.kt
@@ -1,0 +1,70 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonColors
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
+import `in`.koreatech.koin.core.designsystem.component.button.OutlinedBoxButton
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
+
+@Composable
+fun ApplicantDecisionButtons(
+    onReject: () -> Unit,
+    onApprove: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        OutlinedBoxButton(
+            text = stringResource(R.string.recruitment_applicant_detail_reject),
+            onClick = onReject,
+            textStyle = RebrandKoinTheme.typography.bold15,
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonColors(
+                containerColor = RebrandKoinTheme.colors.neutral0,
+                contentColor = RebrandKoinTheme.colors.primary500,
+                disabledContainerColor = RebrandKoinTheme.colors.neutral300,
+                disabledContentColor = RebrandKoinTheme.colors.neutral600
+            ),
+            border = BorderStroke(0.5.dp, RebrandKoinTheme.colors.primary500),
+            modifier = Modifier
+                .weight(1f)
+                .height(48.dp)
+        )
+        FilledButton(
+            text = stringResource(R.string.recruitment_applicant_detail_approve),
+            onClick = onApprove,
+            textStyle = RebrandKoinTheme.typography.bold15,
+            shape = RoundedCornerShape(16.dp),
+            colors = ButtonColors(
+                containerColor = RebrandKoinTheme.colors.primary500,
+                contentColor = RebrandKoinTheme.colors.neutral0,
+                disabledContainerColor = RebrandKoinTheme.colors.neutral300,
+                disabledContentColor = RebrandKoinTheme.colors.neutral600
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .height(48.dp)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ApplicantDecisionButtonsPreview() {
+    RebrandKoinTheme {
+        ApplicantDecisionButtons(onReject = {}, onApprove = {})
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDecisionDialog.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDecisionDialog.kt
@@ -1,0 +1,107 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.component.button.FilledButton
+import `in`.koreatech.koin.core.designsystem.component.button.OutlinedBoxButton
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
+import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentDialog
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ApplicantDecisionDialog(
+    title: String,
+    message: String,
+    confirmText: String,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    RecruitmentDialog(
+        onDismiss = onDismiss,
+        modifier = modifier
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                text = title,
+                style = RebrandKoinTheme.typography.medium15,
+                color = RebrandKoinTheme.colors.neutral700
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = message,
+                style = RebrandKoinTheme.typography.regular13,
+                color = RebrandKoinTheme.colors.neutral500
+            )
+            Spacer(modifier = Modifier.height(20.dp))
+            Row(modifier = Modifier.fillMaxWidth()) {
+                OutlinedBoxButton(
+                    text = stringResource(R.string.recruitment_applicant_decision_dialog_cancel),
+                    onClick = onDismiss,
+                    textStyle = RebrandKoinTheme.typography.medium16,
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonColors(
+                        containerColor = RebrandKoinTheme.colors.neutral0,
+                        contentColor = RebrandKoinTheme.colors.neutral600,
+                        disabledContainerColor = RebrandKoinTheme.colors.neutral300,
+                        disabledContentColor = RebrandKoinTheme.colors.neutral600
+                    ),
+                    border = BorderStroke(1.dp, RebrandKoinTheme.colors.neutral500),
+                    contentPadding = PaddingValues(vertical = 12.dp),
+                    modifier = Modifier.weight(1f)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                FilledButton(
+                    text = confirmText,
+                    onClick = onConfirm,
+                    textStyle = RebrandKoinTheme.typography.medium16,
+                    shape = RoundedCornerShape(16.dp),
+                    colors = ButtonColors(
+                        containerColor = RebrandKoinTheme.colors.primary500,
+                        contentColor = RebrandKoinTheme.colors.neutral0,
+                        disabledContainerColor = RebrandKoinTheme.colors.neutral300,
+                        disabledContentColor = RebrandKoinTheme.colors.neutral600
+                    ),
+                    contentPadding = PaddingValues(vertical = 12.dp),
+                    modifier = Modifier.weight(1f)
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview(showBackground = true)
+@Composable
+private fun ApplicantDecisionDialogPreview() {
+    RebrandKoinTheme {
+        ApplicantDecisionDialog(
+            title = stringResource(R.string.recruitment_applicant_approve_dialog_title),
+            message = stringResource(R.string.recruitment_applicant_approve_dialog_message),
+            confirmText = stringResource(R.string.recruitment_applicant_approve_dialog_confirm),
+            onDismiss = {},
+            onConfirm = {}
+        )
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDetailProfileCard.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantDetailProfileCard.kt
@@ -1,0 +1,85 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
+import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.ui.component.ApplicantAvatar
+import `in`.koreatech.koin.feature.recruitment.ui.component.ApplicantStatusText
+
+@Composable
+fun ApplicantDetailProfileCard(
+    name: String,
+    role: String,
+    department: String,
+    studentNumber: String,
+    status: ApplicantStatus,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = RebrandKoinTheme.colors.neutral0),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            ApplicantAvatar()
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = name,
+                        style = RebrandKoinTheme.typography.regular14,
+                        color = RebrandKoinTheme.colors.neutral800
+                    )
+                    ApplicantStatusText(status = status)
+                }
+                Text(
+                    text = stringResource(R.string.recruitment_applicant_role_info, role, department, studentNumber),
+                    style = RebrandKoinTheme.typography.regular12,
+                    color = RebrandKoinTheme.colors.neutral500
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF8F8FA)
+@Composable
+private fun ApplicantDetailProfileCardPreview() {
+    RebrandKoinTheme {
+        ApplicantDetailProfileCard(
+            name = "김철수",
+            role = "프론트엔드",
+            department = "컴퓨터공학부",
+            studentNumber = "23학번",
+            status = ApplicantStatus.PENDING
+        )
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantInfoBox.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/component/ApplicantInfoBox.kt
@@ -1,0 +1,121 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
+
+@Composable
+fun ApplicantLabeledInfoBox(
+    label: String,
+    content: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = label,
+            style = RebrandKoinTheme.typography.medium14,
+            color = RebrandKoinTheme.colors.neutral800
+        )
+        Text(
+            text = content,
+            style = RebrandKoinTheme.typography.regular14,
+            color = RebrandKoinTheme.colors.neutral500,
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(RebrandKoinTheme.colors.neutral100, RoundedCornerShape(16.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        )
+    }
+}
+
+@Composable
+fun ApplicantActivityInfoBox(
+    title: String,
+    period: String,
+    content: String,
+    modifier: Modifier = Modifier,
+    label: String = stringResource(R.string.recruitment_applicant_detail_activities),
+    periodLabel: String = stringResource(R.string.recruitment_applicant_detail_activity_period),
+    contentLabel: String = stringResource(R.string.recruitment_applicant_detail_activity_content)
+) {
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = label,
+            style = RebrandKoinTheme.typography.medium14,
+            color = RebrandKoinTheme.colors.neutral800
+        )
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(RebrandKoinTheme.colors.neutral100, RoundedCornerShape(16.dp))
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(
+                text = title,
+                style = RebrandKoinTheme.typography.bold14,
+                color = RebrandKoinTheme.colors.neutral800
+            )
+            ApplicantActivityRow(label = periodLabel, value = period)
+            ApplicantActivityRow(label = contentLabel, value = content)
+        }
+    }
+}
+
+@Composable
+private fun ApplicantActivityRow(
+    label: String,
+    value: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        Text(
+            text = label,
+            style = RebrandKoinTheme.typography.regular12,
+            color = RebrandKoinTheme.colors.neutral500,
+            modifier = Modifier.width(45.dp)
+        )
+        Text(
+            text = value,
+            style = RebrandKoinTheme.typography.regular12,
+            color = RebrandKoinTheme.colors.neutral800,
+            modifier = Modifier.weight(1f)
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF8F8FA)
+@Composable
+private fun ApplicantLabeledInfoBoxPreview() {
+    RebrandKoinTheme {
+        ApplicantLabeledInfoBox(label = "자기소개", content = "안녕하세요.")
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF8F8FA)
+@Composable
+private fun ApplicantActivityInfoBoxPreview() {
+    RebrandKoinTheme {
+        ApplicantActivityInfoBox(
+            title = "AI 공모전",
+            period = "2026.03.23 - 2026.04.06",
+            content = "AI 공모전에서 기획을 담당했고 @@@를 주제로 @@@를 만들었습니다"
+        )
+    }
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/model/ApplicantDetail.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/model/ApplicantDetail.kt
@@ -1,0 +1,27 @@
+package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model
+
+import androidx.compose.runtime.Immutable
+import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import kotlinx.collections.immutable.ImmutableList
+
+@Immutable
+data class ApplicantDetail(
+    val id: Long,
+    val name: String,
+    val role: String,
+    val department: String,
+    val studentNumber: String,
+    val status: ApplicantStatus,
+    val skills: ImmutableList<String>,
+    val activities: ImmutableList<ApplicantActivity>,
+    val introduction: String,
+    val motivation: String,
+    val availableTime: String
+)
+
+@Immutable
+data class ApplicantActivity(
+    val title: String,
+    val period: String,
+    val content: String
+)

--- a/feature/recruitment/src/main/res/values/strings.xml
+++ b/feature/recruitment/src/main/res/values/strings.xml
@@ -37,4 +37,25 @@
     <string name="recruitment_applicant_role_info">%1$s |  %2$s · %3$s</string>
     <string name="recruitment_applicant_empty_title">아직 지원자가 없어요.</string>
     <string name="recruitment_applicant_empty_subtitle">새로운 지원자가 등록되면 이곳에서 확인할 수 있어요.</string>
+
+    <string name="recruitment_applicant_detail_title">지원자 상세</string>
+    <string name="recruitment_applicant_detail_basic_info">기본 정보</string>
+    <string name="recruitment_applicant_detail_skills">보유기술</string>
+    <string name="recruitment_applicant_detail_activities">활동 이력</string>
+    <string name="recruitment_applicant_detail_activity_period">활동 기간</string>
+    <string name="recruitment_applicant_detail_activity_content">활동 내용</string>
+    <string name="recruitment_applicant_detail_introduction">자기소개</string>
+    <string name="recruitment_applicant_detail_application_info">지원 내용</string>
+    <string name="recruitment_applicant_detail_motivation">지원 동기</string>
+    <string name="recruitment_applicant_detail_available_time">활동 가능 시간</string>
+    <string name="recruitment_applicant_detail_reject">거절하기</string>
+    <string name="recruitment_applicant_detail_approve">승인하기</string>
+
+    <string name="recruitment_applicant_approve_dialog_title">해당 지원자를 승인하시겠어요?</string>
+    <string name="recruitment_applicant_approve_dialog_message">승인 후 지원자와 채팅방이 생성됩니다.</string>
+    <string name="recruitment_applicant_approve_dialog_confirm">승인하기</string>
+    <string name="recruitment_applicant_reject_dialog_title">해당 지원자를 거절하시겠어요?</string>
+    <string name="recruitment_applicant_reject_dialog_message">거절 후에는 되돌릴 수 없습니다.</string>
+    <string name="recruitment_applicant_reject_dialog_confirm">거절하기</string>
+    <string name="recruitment_applicant_decision_dialog_cancel">취소</string>
 </resources>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
지원자 상세 화면(ApplicantDetailScreen)을 구현합니다. #1587(지원자 관리 화면)을 base로 하는 후속 PR입니다.

**지원자 상세 화면 (`ui/applicantdetail/`)**
- `ApplicantDetailScreen` — 프로필 카드 + 기본 정보(보유기술/활동 이력/자기소개) + 지원 내용(지원 동기/활동 가능 시간) + 하단 승인/거절 버튼
- `ApplicantDetailProfileCard` — 공통 `ApplicantAvatar`/`ApplicantStatusText` 재사용
- `ApplicantLabeledInfoBox` / `ApplicantActivityInfoBox` — 라벨+박스 형태의 정보 섹션 컴포넌트
- `ApplicantDecisionButtons` — 거절하기/승인하기 버튼
- `ApplicantDecisionDialog` — 승인/거절 확인 다이얼로그, 기존 `RecruitmentDialog`/`CloseRecruitmentDialog` 패턴 재사용

### 논의 사항
- Figma의 "지원자 상세 - 승인 모달"/"거절 모달" 프레임은 배경 dim 처리만 있고 실제 팝업 내용은 그려져 있지 않아, 기존 `CloseRecruitmentDialog`와 동일한 구조(제목+설명+취소/확인 버튼)로 확인 다이얼로그를 구성했습니다.
- 승인/거절은 현재 로컬 state만 갱신하고 화면 이동은 하지 않습니다(기존 모집 마감 처리와 동일한 패턴). API 연동 시 실제 요청/네비게이션 처리가 추가로 필요합니다.
- 아직 API가 없어 `ApplicantDetailViewModel`은 목업 데이터로 초기 state를 구성했습니다.

### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

> ⚠️ 이 PR은 develop이 아니라 #1587(feature/#1583-recruitment-applicants)을 base로 하는 스택 PR입니다. #1587 머지 후 순차 머지 부탁드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 모집 지원자 관리 화면에서 지원자 상세 정보를 확인할 수 있습니다.
  * 지원자의 기본 정보, 기술, 활동 이력, 자기소개 및 지원 내용을 제공합니다.
  * 지원자 승인 및 거절 기능과 확인 대화상자를 추가했습니다.
  * 지원자 목록에서 상세 화면으로 이동하고 이전 화면으로 돌아올 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->