### PR TITLE
[Feature] 시간표 학과 선택 화면 리디자인

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/DepartmentRadioButton.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/DepartmentRadioButton.kt
@@ -1,14 +1,20 @@
 package `in`.koreatech.koin.feature.timetable.component
 
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.selection.selectable
-import androidx.compose.material3.Surface
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 
 @Composable
@@ -18,27 +24,29 @@ fun DepartmentRadioButton(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    // TODO::버튼 색상 수정 필요
-    val containerColor = if (isSelected) KoinTheme.colors.primary100 else KoinTheme.colors.neutral0
-    val borderColor = if (isSelected) KoinTheme.colors.primary500 else KoinTheme.colors.neutral500
     val textColor = if (isSelected) KoinTheme.colors.primary500 else KoinTheme.colors.neutral500
-    Surface(
-        modifier =
-        modifier
-            .selectable(
-                selected = isSelected,
-                role = null,
-                onClick = onClick
-            ),
-        shape = KoinTheme.shapes.extraSmall,
-        color = containerColor,
-        border = BorderStroke(0.5.dp, borderColor)
+    Row(
+        modifier = modifier.noRippleClickable(onClick = onClick),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
+        RadioButton(
+            modifier = Modifier.size(24.dp),
+            selected = isSelected,
+            onClick = onClick,
+            colors = RadioButtonDefaults.colors(
+                selectedColor = KoinTheme.colors.primary500,
+                unselectedColor = KoinTheme.colors.neutral500
+            )
+        )
         Text(
-            modifier = Modifier.wrapContentSize(),
+            modifier = Modifier
+                .wrapContentSize()
+                .weight(1f)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Start,
             text = text,
-            style =
-            KoinTheme.typography.regular14.copy(
+            style = KoinTheme.typography.regular15.copy(
                 color = textColor
             )
         )

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/DepartmentRadioButton.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/component/DepartmentRadioButton.kt
@@ -2,9 +2,7 @@ package `in`.koreatech.koin.feature.timetable.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.RadioButtonDefaults
 import androidx.compose.material3.Text
@@ -40,10 +38,7 @@ fun DepartmentRadioButton(
             )
         )
         Text(
-            modifier = Modifier
-                .wrapContentSize()
-                .weight(1f)
-                .fillMaxWidth(),
+            modifier = Modifier.weight(1f),
             textAlign = TextAlign.Start,
             text = text,
             style = KoinTheme.typography.regular15.copy(

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/SelectDepartmentDialog.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/SelectDepartmentDialog.kt
@@ -3,19 +3,20 @@ package `in`.koreatech.koin.feature.timetable.view.dialog
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -23,12 +24,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.DialogProperties
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.feature.timetable.R
 import `in`.koreatech.koin.feature.timetable.component.DepartmentRadioButton
+import `in`.koreatech.koin.feature.timetable.component.FilledButtonType
 import `in`.koreatech.koin.feature.timetable.component.FilledTextButton
 import `in`.koreatech.koin.feature.timetable.model.TimetableConstants.departments
 
@@ -44,13 +48,11 @@ fun SelectDepartmentDialog(
     var selectedDepartment by remember { mutableStateOf(department) }
 
     BasicAlertDialog(
-        modifier =
-        modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 24.dp),
         onDismissRequest = { onDismiss(false) },
-        properties =
-        DialogProperties(
+        properties = DialogProperties(
             usePlatformDefaultWidth = false
         )
     ) {
@@ -59,22 +61,21 @@ fun SelectDepartmentDialog(
             color = Color.White
         ) {
             Column(
-                modifier =
-                Modifier
-                    .padding(
-                        horizontal = 12.dp,
-                        vertical = 18.dp
-                    ),
                 verticalArrangement = Arrangement.spacedBy(6.dp)
             ) {
                 Text(
+                    modifier = Modifier.padding(vertical = 12.dp, horizontal = 24.dp),
                     text = stringResource(id = R.string.select_department_title),
-                    style =
-                    KoinTheme.typography.medium18.copy(
-                        color = KoinTheme.colors.primary500
+                    style = KoinTheme.typography.medium18.copy(
+                        color = KoinTheme.colors.primary500,
+                        fontWeight = FontWeight.SemiBold
                     )
                 )
                 DepartmentRadioButtons(
+                    modifier = Modifier
+                        .padding(vertical = 12.dp, horizontal = 24.dp)
+                        .weight(1f, false)
+                        .verticalScroll(rememberScrollState()),
                     departments = departments,
                     selectedDepartment = selectedDepartment,
                     onClickDepartment = {
@@ -85,15 +86,30 @@ fun SelectDepartmentDialog(
                         }
                     }
                 )
-                FilledTextButton(
-                    modifier =
-                    Modifier
-                        .height(30.dp)
-                        .width(60.dp)
-                        .align(Alignment.End),
-                    text = stringResource(id = R.string.common_complete),
-                    onClick = { onConfirm(selectedDepartment) }
-                )
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 12.dp, horizontal = 24.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.End)
+                ) {
+                    FilledTextButton(
+                        modifier = Modifier
+                            .height(30.dp)
+                            .width(60.dp),
+                        text = stringResource(id = R.string.cancel),
+                        textStyle = KoinTheme.typography.regular14,
+                        buttonStyle = FilledButtonType.Neutral,
+                        onClick = { onDismiss(false) }
+                    )
+                    FilledTextButton(
+                        modifier = Modifier
+                            .height(30.dp)
+                            .width(60.dp),
+                        text = stringResource(id = R.string.common_complete),
+                        textStyle = KoinTheme.typography.regular14,
+                        onClick = { onConfirm(selectedDepartment) }
+                    )
+                }
             }
         }
     }
@@ -107,35 +123,20 @@ fun DepartmentRadioButtons(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier =
-        modifier
-            .wrapContentSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier
+            .wrapContentSize()
+            .fillMaxWidth(),
+        horizontalAlignment = Alignment.Start,
         verticalArrangement = Arrangement.spacedBy(14.dp)
     ) {
-        departments.chunked(2).forEach { rowDepartments ->
-            Row(
-                modifier =
-                Modifier
-                    .height(32.dp)
-                    .fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                rowDepartments.forEach { department ->
-                    DepartmentRadioButton(
-                        modifier =
-                        Modifier
-                            .fillMaxHeight()
-                            .weight(1.0F),
-                        text = department,
-                        isSelected = department == selectedDepartment,
-                        onClick = { onClickDepartment(department) }
-                    )
-                }
-                if (rowDepartments.size == 1) {
-                    Spacer(modifier = Modifier.weight(1.0F))
-                }
+        departments.fastForEach { department ->
+            key(department) {
+                DepartmentRadioButton(
+                    modifier = Modifier,
+                    text = department,
+                    isSelected = department == selectedDepartment,
+                    onClick = { onClickDepartment(department) }
+                )
             }
         }
     }


### PR DESCRIPTION
## PR 개요
- close: #1589 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
학과 선택 다이얼로그 신규 디자인을 반영했습니다.
<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/c21601bc-f486-4abc-95bc-78753f0f8ad1" />

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI 개선**
  - 학과 선택 항목을 라디오 버튼 기반의 직관적인 형태로 개선했습니다.
  - 학과 목록을 2열 그리드에서 세로 스크롤 가능한 단일 목록으로 변경했습니다.
  - 선택 화면의 제목, 목록 간격 및 글꼴 스타일을 조정했습니다.
  - 취소 및 완료 버튼을 나란히 배치해 선택을 쉽게 마무리할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->