### PR TITLE
[Feature] 시간표 학과 옵션 수정

### DIFF
--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/model/TimetableConstants.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/model/TimetableConstants.kt
@@ -7,21 +7,6 @@ import java.time.LocalTime
 
 object TimetableConstants {
     val days = listOf("월", "화", "수", "목", "금")
-    val departments =
-        listOf(
-            "디자인ㆍ건축공학부",
-            "고용서비스정책학과",
-            "기계공학부",
-            "메카트로닉스공학부",
-            "산업경영학부",
-            "전기ㆍ전자ㆍ통신공학부",
-            "컴퓨터공학부",
-            "에너지신소재화학공학부",
-            "HRD학과",
-            "교양학부",
-            "안전공학과",
-            "융합학과"
-        )
     const val eventHeight = 64
 }
 

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/SelectDepartmentDialog.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/view/dialog/SelectDepartmentDialog.kt
@@ -34,7 +34,6 @@ import `in`.koreatech.koin.feature.timetable.R
 import `in`.koreatech.koin.feature.timetable.component.DepartmentRadioButton
 import `in`.koreatech.koin.feature.timetable.component.FilledButtonType
 import `in`.koreatech.koin.feature.timetable.component.FilledTextButton
-import `in`.koreatech.koin.feature.timetable.model.TimetableConstants.departments
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -148,7 +147,7 @@ private fun SelectDepartmentDialogPreview() {
     KoinTheme {
         SelectDepartmentDialog(
             department = "",
-            departments = departments,
+            departments = emptyList(),
             onConfirm = {},
             onDismiss = {}
         )

--- a/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/TimetableViewModel.kt
+++ b/feature/timetable/src/main/java/in/koreatech/koin/feature/timetable/viewmodel/TimetableViewModel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -92,6 +93,14 @@ class TimetableViewModel @Inject constructor(
             SharingStarted.WhileSubscribed(5_000),
             emptyList()
         )
+
+    val departments: StateFlow<List<String>> = _lectures.map { lectures ->
+        lectures.map { it.department }.filter { it.isNotBlank() }.distinct()
+    }.stateIn(
+        viewModelScope,
+        SharingStarted.WhileSubscribed(5_000),
+        emptyList()
+    )
 
     fun getInitData() {
         viewModelScope.launch {

--- a/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
+++ b/koin/src/main/java/in/koreatech/koin/ui/timetablev2/TimetableActivity.kt
@@ -39,7 +39,6 @@ import `in`.koreatech.koin.core.navigation.Navigator
 import `in`.koreatech.koin.core.util.KeyboardUtils
 import `in`.koreatech.koin.databinding.ActivityTimetableBinding
 import `in`.koreatech.koin.feature.timetable.component.CircleLoadingBar
-import `in`.koreatech.koin.feature.timetable.model.TimetableConstants.departments
 import `in`.koreatech.koin.feature.timetable.state.BottomSheetUI
 import `in`.koreatech.koin.feature.timetable.state.TimetableSideEffect
 import `in`.koreatech.koin.feature.timetable.utils.BitmapUtils
@@ -135,6 +134,7 @@ class TimetableActivity : KoinNavigationDrawerActivity() {
             val customContentState by viewModel.customContentState.collectAsStateWithLifecycle()
             val searchEngineState by viewModel.searchEngineState.collectAsStateWithLifecycle()
             val lectures by viewModel.lectures.collectAsStateWithLifecycle()
+            val departments by viewModel.departments.collectAsStateWithLifecycle()
             val sheetState = rememberBottomSheetState(BottomSheetValue.Collapsed)
             val bottomSheetScaffoldState = rememberBottomSheetScaffoldState(sheetState)
             val scrollState = rememberLazyListState()


### PR DESCRIPTION
## PR 개요
- close: #1593 

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [x] 기타

### 작업사항의 상세한 설명
- 시간표 학과 목록을 시간표 데이터에서 뽑아서 보여주도록 수정했습니다.
- iOS와 동일한 방식입니다.
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 시간표의 학과 선택 목록이 고정된 목록 대신 실제 강의 데이터에서 자동으로 제공됩니다.
  * 중복되거나 비어 있는 학과명이 목록에 표시되지 않습니다.
  * 강의 데이터에 따라 학과 선택 항목이 동적으로 갱신됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->