### PR TITLE
[Feature] 팀원 모집 알림 API 연동

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/auth/RecruitmentAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/RecruitmentAuthApi.kt
@@ -1,0 +1,28 @@
+package `in`.koreatech.koin.data.api.auth
+
+import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentNotificationListResponse
+import retrofit2.Response
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface RecruitmentAuthApi {
+    @GET("/team-recruitments/notifications")
+    suspend fun getNotifications(
+        @Query("page") page: Int? = 1,
+        @Query("limit") limit: Int? = 10
+    ): TeamRecruitmentNotificationListResponse
+
+    @DELETE("/team-recruitments/notifications")
+    suspend fun deleteAllNotifications(): Response<Unit>
+
+    @POST("/team-recruitments/notifications/{notificationId}/read")
+    suspend fun readNotification(
+        @Path("notificationId") notificationId: Int
+    ): Response<Unit>
+
+    @POST("/team-recruitments/notifications/mark-all-read")
+    suspend fun readAllNotifications(): Response<Unit>
+}

--- a/data/src/main/java/in/koreatech/koin/data/di/repository/BindsRepositoryModule.kt
+++ b/data/src/main/java/in/koreatech/koin/data/di/repository/BindsRepositoryModule.kt
@@ -7,12 +7,14 @@ import dagger.hilt.components.SingletonComponent
 import `in`.koreatech.koin.data.repository.BusRepositoryImpl
 import `in`.koreatech.koin.data.repository.CallvanRepositoryImpl
 import `in`.koreatech.koin.data.repository.DepartmentRepositoryImpl
+import `in`.koreatech.koin.data.repository.RecruitmentRepositoryImpl
 import `in`.koreatech.koin.data.repository.TimetableRepositoryImpl
 import `in`.koreatech.koin.data.repository.WeatherRepositoryImpl
 import `in`.koreatech.koin.data.repository.firebase.messaging.FirebaseMessagingRepositoryImpl
 import `in`.koreatech.koin.domain.repository.BusRepository
 import `in`.koreatech.koin.domain.repository.CallvanRepository
 import `in`.koreatech.koin.domain.repository.DepartmentRepository
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
 import `in`.koreatech.koin.domain.repository.TimetableRepository
 import `in`.koreatech.koin.domain.repository.WeatherRepository
 import `in`.koreatech.koin.domain.repository.firebase.messaging.FirebaseMessagingRepository
@@ -46,4 +48,8 @@ abstract class BindsRepositoryModule {
     @Binds
     @Singleton
     abstract fun bindsDepartmentRepository(departmentRepositoryImpl: DepartmentRepositoryImpl): DepartmentRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindsRecruitmentRepository(recruitmentRepositoryImpl: RecruitmentRepositoryImpl): RecruitmentRepository
 }

--- a/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
@@ -1,0 +1,28 @@
+package `in`.koreatech.koin.data.mapper
+
+import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentNotificationListResponse
+import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentNotificationResponse
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotification
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
+
+fun TeamRecruitmentNotificationResponse.toRecruitmentNotification() = RecruitmentNotification(
+    id = id,
+    type = type,
+    targetType = targetType,
+    messagePreview = messagePreview,
+    senderNickname = senderNickname,
+    isRead = isRead,
+    createdAt = createdAt,
+    recruitmentId = recruitmentId,
+    applicationId = applicationId,
+    chatRoomId = chatRoomId
+)
+
+fun TeamRecruitmentNotificationListResponse.toRecruitmentNotifications() = RecruitmentNotifications(
+    notifications = notifications.map { it.toRecruitmentNotification() },
+    unreadCount = unreadCount,
+    totalCount = totalCount,
+    currentCount = currentCount,
+    totalPage = totalPage,
+    currentPage = currentPage
+)

--- a/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
@@ -1,0 +1,51 @@
+package `in`.koreatech.koin.data.repository
+
+import `in`.koreatech.koin.data.mapper.toRecruitmentNotifications
+import `in`.koreatech.koin.data.source.remote.RecruitmentRemoteDataSource
+import `in`.koreatech.koin.data.util.mapHttpFailure
+import `in`.koreatech.koin.data.util.suspendRunCatching
+import `in`.koreatech.koin.domain.error.recruitment.KoinRecruitmentException
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class RecruitmentRepositoryImpl @Inject constructor(
+    private val recruitmentRemoteDataSource: RecruitmentRemoteDataSource
+) : RecruitmentRepository {
+    override suspend fun getNotifications(page: Int, limit: Int): Result<RecruitmentNotifications> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.getNotifications(
+                page = page,
+                limit = limit
+            ).toRecruitmentNotifications()
+        }.mapHttpFailure {
+            on(403) throws KoinRecruitmentException.ForbiddenException()
+        }
+    }
+
+    override suspend fun deleteAllNotifications(): Result<Unit> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.deleteAllNotifications()
+        }.mapHttpFailure {
+            on(403) throws KoinRecruitmentException.ForbiddenException()
+        }
+    }
+
+    override suspend fun readNotification(notificationId: Int): Result<Unit> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.readNotification(
+                notificationId = notificationId
+            )
+        }.mapHttpFailure {
+            on(403) throws KoinRecruitmentException.ForbiddenException()
+        }
+    }
+
+    override suspend fun readAllNotifications(): Result<Unit> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.readAllNotifications()
+        }.mapHttpFailure {
+            on(403) throws KoinRecruitmentException.ForbiddenException()
+        }
+    }
+}

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/TeamRecruitmentNotificationListResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/TeamRecruitmentNotificationListResponse.kt
@@ -1,0 +1,18 @@
+package `in`.koreatech.koin.data.response.recruitment
+
+import com.google.gson.annotations.SerializedName
+
+data class TeamRecruitmentNotificationListResponse(
+    @SerializedName("notifications")
+    val notifications: List<TeamRecruitmentNotificationResponse>,
+    @SerializedName("unread_count")
+    val unreadCount: Int,
+    @SerializedName("total_count")
+    val totalCount: Long,
+    @SerializedName("current_count")
+    val currentCount: Int,
+    @SerializedName("total_page")
+    val totalPage: Int,
+    @SerializedName("current_page")
+    val currentPage: Int
+)

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/TeamRecruitmentNotificationResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/TeamRecruitmentNotificationResponse.kt
@@ -1,0 +1,26 @@
+package `in`.koreatech.koin.data.response.recruitment
+
+import com.google.gson.annotations.SerializedName
+
+data class TeamRecruitmentNotificationResponse(
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("type")
+    val type: String,
+    @SerializedName("target_type")
+    val targetType: String,
+    @SerializedName("message_preview")
+    val messagePreview: String,
+    @SerializedName("sender_nickname")
+    val senderNickname: String?,
+    @SerializedName("is_read")
+    val isRead: Boolean,
+    @SerializedName("created_at")
+    val createdAt: String,
+    @SerializedName("recruitment_id")
+    val recruitmentId: Int,
+    @SerializedName("application_id")
+    val applicationId: Int?,
+    @SerializedName("chat_room_id")
+    val chatRoomId: Int?
+)

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/RecruitmentRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/RecruitmentRemoteDataSource.kt
@@ -1,0 +1,34 @@
+package `in`.koreatech.koin.data.source.remote
+
+import `in`.koreatech.koin.data.api.auth.RecruitmentAuthApi
+import javax.inject.Inject
+import retrofit2.HttpException
+
+class RecruitmentRemoteDataSource @Inject constructor(
+    private val recruitmentAuthApi: RecruitmentAuthApi
+) {
+    suspend fun getNotifications(
+        page: Int?,
+        limit: Int?
+    ) = recruitmentAuthApi.getNotifications(
+        page = page,
+        limit = limit
+    )
+
+    suspend fun deleteAllNotifications() {
+        val response = recruitmentAuthApi.deleteAllNotifications()
+        if (!response.isSuccessful) throw HttpException(response)
+    }
+
+    suspend fun readNotification(
+        notificationId: Int
+    ) {
+        val response = recruitmentAuthApi.readNotification(notificationId = notificationId)
+        if (!response.isSuccessful) throw HttpException(response)
+    }
+
+    suspend fun readAllNotifications() {
+        val response = recruitmentAuthApi.readAllNotifications()
+        if (!response.isSuccessful) throw HttpException(response)
+    }
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/error/recruitment/KoinRecruitmentException.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/error/recruitment/KoinRecruitmentException.kt
@@ -1,0 +1,10 @@
+package `in`.koreatech.koin.domain.error.recruitment
+
+import `in`.koreatech.koin.domain.error.KoinErrorException
+
+sealed class KoinRecruitmentException : KoinErrorException() {
+    /*
+     * Exceptions for 403
+     */
+    class ForbiddenException : KoinRecruitmentException()
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/RecruitmentNotification.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/RecruitmentNotification.kt
@@ -1,0 +1,14 @@
+package `in`.koreatech.koin.domain.model.recruitment
+
+data class RecruitmentNotification(
+    val id: Int,
+    val type: String,
+    val targetType: String,
+    val messagePreview: String,
+    val senderNickname: String?,
+    val isRead: Boolean,
+    val createdAt: String,
+    val recruitmentId: Int,
+    val applicationId: Int?,
+    val chatRoomId: Int?
+)

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/RecruitmentNotifications.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/RecruitmentNotifications.kt
@@ -1,0 +1,10 @@
+package `in`.koreatech.koin.domain.model.recruitment
+
+data class RecruitmentNotifications(
+    val notifications: List<RecruitmentNotification>,
+    val unreadCount: Int,
+    val totalCount: Long,
+    val currentCount: Int,
+    val totalPage: Int,
+    val currentPage: Int
+)

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
@@ -1,0 +1,13 @@
+package `in`.koreatech.koin.domain.repository
+
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
+
+interface RecruitmentRepository {
+    suspend fun getNotifications(page: Int, limit: Int): Result<RecruitmentNotifications>
+
+    suspend fun deleteAllNotifications(): Result<Unit>
+
+    suspend fun readNotification(notificationId: Int): Result<Unit>
+
+    suspend fun readAllNotifications(): Result<Unit>
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/DeleteAllNotificationsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/DeleteAllNotificationsUseCase.kt
@@ -1,0 +1,10 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class DeleteAllNotificationsUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(): Result<Unit> = recruitmentRepository.deleteAllNotifications()
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetNotificationsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetNotificationsUseCase.kt
@@ -1,0 +1,12 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class GetNotificationsUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(page: Int, limit: Int): Result<RecruitmentNotifications> =
+        recruitmentRepository.getNotifications(page = page, limit = limit)
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/ReadAllNotificationsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/ReadAllNotificationsUseCase.kt
@@ -1,0 +1,10 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class ReadAllNotificationsUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(): Result<Unit> = recruitmentRepository.readAllNotifications()
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/ReadNotificationUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/ReadNotificationUseCase.kt
@@ -1,0 +1,11 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class ReadNotificationUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(notificationId: Int): Result<Unit> =
+        recruitmentRepository.readNotification(notificationId = notificationId)
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -23,9 +23,10 @@ fun NavGraphBuilder.koinRecruitmentGraph(
     composable<RecruitmentNavType.Notification> {
         RecruitmentNotificationScreen(
             onBack = { navController.popBackStack() },
-            onNavigateToPost = {
-                // TODO: 모집글 상세 화면 라우트가 추가되면 postId 로 이동하도록 연결한다.
+            onNavigateToApplicantManagement = { recruitmentId ->
+                navController.navigate(RecruitmentNavType.ApplicantManagement(recruitmentId))
             }
+            // TODO: CHAT_ROOM / MY_APPLICATIONS / 모집글 상세 라우트가 추가되면 콜백을 추가 연결한다.
         )
     }
     composable<RecruitmentNavType.ApplicantManagement> { backStackEntry ->

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
@@ -181,7 +181,7 @@ private fun RecruitmentNotificationScreenImpl(
             RecruitmentNotificationItem(
                 modifier = Modifier.animateItem(),
                 category = notification.category,
-                title = notification.title,
+                senderNickname = notification.senderNickname,
                 content = notification.content,
                 timestamp = notification.timestamp,
                 isRead = notification.isRead,

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
@@ -19,8 +20,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -39,13 +42,15 @@ import `in`.koreatech.koin.feature.recruitment.ui.notification.component.Recruit
 import `in`.koreatech.koin.feature.recruitment.ui.notification.component.RecruitmentNotificationMenuButton
 import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotification
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
 @Composable
 internal fun RecruitmentNotificationScreen(
     onBack: () -> Unit = {},
-    onNavigateToPost: (Int) -> Unit = {},
+    onNavigateToApplicantManagement: (Long) -> Unit = {},
     viewModel: RecruitmentNotificationViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -55,12 +60,12 @@ internal fun RecruitmentNotificationScreen(
 
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is RecruitmentNotificationSideEffect.Error -> {
+            RecruitmentNotificationSideEffect.Error -> {
                 snackbarHostState.showSnackbar(context.getString(R.string.recruitment_notification_error))
             }
 
-            is RecruitmentNotificationSideEffect.NavigateToPost -> {
-                onNavigateToPost(sideEffect.postId)
+            is RecruitmentNotificationSideEffect.NavigateToApplicantManagement -> {
+                onNavigateToApplicantManagement(sideEffect.recruitmentId)
             }
 
             RecruitmentNotificationSideEffect.Deleted -> {
@@ -108,8 +113,10 @@ internal fun RecruitmentNotificationScreen(
             listState = listState,
             notifications = uiState.notifications,
             isLoading = uiState.isLoading,
+            isLoadingMore = uiState.isLoadingMore,
+            hasMore = uiState.currentPage < uiState.totalPage,
             onNotificationClick = viewModel::onNotificationClick,
-            onDelete = viewModel::deleteNotification
+            onLoadMore = viewModel::loadMoreNotifications
         )
     }
 }
@@ -119,10 +126,23 @@ private fun RecruitmentNotificationScreenImpl(
     listState: LazyListState,
     notifications: ImmutableList<RecruitmentNotification>,
     isLoading: Boolean,
+    isLoadingMore: Boolean,
+    hasMore: Boolean,
     onNotificationClick: (RecruitmentNotification) -> Unit,
-    onDelete: (Int) -> Unit,
+    onLoadMore: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    LaunchedEffect(listState, hasMore, isLoadingMore, notifications.size) {
+        snapshotFlow {
+            val layoutInfo = listState.layoutInfo
+            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
+        }
+            .distinctUntilChanged()
+            .filter { it }
+            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+    }
+
     if (isLoading) {
         Box(
             modifier = modifier.fillMaxSize(),
@@ -165,9 +185,25 @@ private fun RecruitmentNotificationScreenImpl(
                 content = notification.content,
                 timestamp = notification.timestamp,
                 isRead = notification.isRead,
-                onDelete = remember(notification.id) { { onDelete(notification.id) } },
                 onClick = remember(notification.id) { { onNotificationClick(notification) } }
             )
         }
+        if (isLoadingMore) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 16.dp),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = RebrandKoinTheme.colors.primary500
+                    )
+                }
+            }
+        }
     }
 }
+
+private const val LOAD_MORE_THRESHOLD = 3

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationSideEffect.kt
@@ -2,6 +2,6 @@ package `in`.koreatech.koin.feature.recruitment.ui.notification
 
 internal sealed class RecruitmentNotificationSideEffect {
     data object Error : RecruitmentNotificationSideEffect()
-    data class NavigateToPost(val postId: Int) : RecruitmentNotificationSideEffect()
+    data class NavigateToApplicantManagement(val recruitmentId: Long) : RecruitmentNotificationSideEffect()
     data object Deleted : RecruitmentNotificationSideEffect()
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationState.kt
@@ -6,5 +6,9 @@ import kotlinx.collections.immutable.persistentListOf
 
 internal data class RecruitmentNotificationState(
     val notifications: ImmutableList<RecruitmentNotification> = persistentListOf(),
-    val isLoading: Boolean = false
+    val unreadCount: Int = 0,
+    val currentPage: Int = 1,
+    val totalPage: Int = 1,
+    val isLoading: Boolean = false,
+    val isLoadingMore: Boolean = false
 )

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationViewModel.kt
@@ -2,8 +2,12 @@ package `in`.koreatech.koin.feature.recruitment.ui.notification
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import `in`.koreatech.koin.domain.usecase.recruitment.DeleteAllNotificationsUseCase
+import `in`.koreatech.koin.domain.usecase.recruitment.GetNotificationsUseCase
+import `in`.koreatech.koin.domain.usecase.recruitment.ReadAllNotificationsUseCase
+import `in`.koreatech.koin.domain.usecase.recruitment.ReadNotificationUseCase
 import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotification
-import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotificationCategory
+import `in`.koreatech.koin.feature.recruitment.ui.notification.model.toUiModel
 import javax.inject.Inject
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -13,8 +17,15 @@ import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
+private const val NOTIFICATIONS_PAGE_SIZE = 20
+
 @HiltViewModel
-internal class RecruitmentNotificationViewModel @Inject constructor() : ViewModel(), ContainerHost<RecruitmentNotificationState, RecruitmentNotificationSideEffect> {
+internal class RecruitmentNotificationViewModel @Inject constructor(
+    private val getNotificationsUseCase: GetNotificationsUseCase,
+    private val deleteAllNotificationsUseCase: DeleteAllNotificationsUseCase,
+    private val readNotificationUseCase: ReadNotificationUseCase,
+    private val readAllNotificationsUseCase: ReadAllNotificationsUseCase
+) : ViewModel(), ContainerHost<RecruitmentNotificationState, RecruitmentNotificationSideEffect> {
     override val container = container<RecruitmentNotificationState, RecruitmentNotificationSideEffect>(
         RecruitmentNotificationState()
     ) {
@@ -23,83 +34,87 @@ internal class RecruitmentNotificationViewModel @Inject constructor() : ViewMode
 
     private fun loadNotifications() = intent {
         reduce { state.copy(isLoading = true) }
-        reduce { state.copy(notifications = mockRecruitmentNotifications(), isLoading = false) }
+        getNotificationsUseCase(page = 1, limit = NOTIFICATIONS_PAGE_SIZE)
+            .onSuccess { notifications ->
+                reduce {
+                    state.copy(
+                        notifications = notifications.notifications.map { it.toUiModel() }.toImmutableList(),
+                        unreadCount = notifications.unreadCount,
+                        currentPage = notifications.currentPage,
+                        totalPage = notifications.totalPage,
+                        isLoading = false
+                    )
+                }
+            }
+            .onFailure {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(RecruitmentNotificationSideEffect.Error)
+            }
+    }
+
+    fun loadMoreNotifications() = intent {
+        if (state.isLoadingMore || state.currentPage >= state.totalPage) return@intent
+        reduce { state.copy(isLoadingMore = true) }
+        getNotificationsUseCase(page = state.currentPage + 1, limit = NOTIFICATIONS_PAGE_SIZE)
+            .onSuccess { notifications ->
+                reduce {
+                    state.copy(
+                        notifications = (
+                            state.notifications + notifications.notifications.map { it.toUiModel() }
+                            ).toImmutableList(),
+                        unreadCount = notifications.unreadCount,
+                        currentPage = notifications.currentPage,
+                        totalPage = notifications.totalPage,
+                        isLoadingMore = false
+                    )
+                }
+            }
+            .onFailure {
+                reduce { state.copy(isLoadingMore = false) }
+                postSideEffect(RecruitmentNotificationSideEffect.Error)
+            }
     }
 
     fun onNotificationClick(notification: RecruitmentNotification) = intent {
-        reduce {
-            state.copy(
-                notifications = state.notifications
-                    .map { if (it.id == notification.id) it.copy(isRead = true) else it }
-                    .toImmutableList()
-            )
-        }
-        postSideEffect(RecruitmentNotificationSideEffect.NavigateToPost(notification.postId))
-    }
+        readNotificationUseCase(notification.id)
+            .onSuccess {
+                reduce {
+                    state.copy(
+                        notifications = state.notifications
+                            .map { if (it.id == notification.id) it.copy(isRead = true) else it }
+                            .toImmutableList()
+                    )
+                }
+            }
 
-    fun deleteNotification(id: Int) = intent {
-        reduce {
-            state.copy(notifications = state.notifications.filterNot { it.id == id }.toImmutableList())
+        when (notification.targetType) {
+            "APPLICANT_MANAGEMENT" -> postSideEffect(
+                RecruitmentNotificationSideEffect.NavigateToApplicantManagement(notification.recruitmentId.toLong())
+            )
+            // TODO: CHAT_ROOM / MY_APPLICATIONS 라우트가 추가되면 연결한다.
+            "CHAT_ROOM", "MY_APPLICATIONS", "NONE" -> Unit
         }
-        postSideEffect(RecruitmentNotificationSideEffect.Deleted)
     }
 
     fun readAllNotifications() = intent {
-        reduce {
-            state.copy(notifications = state.notifications.map { it.copy(isRead = true) }.toImmutableList())
-        }
+        readAllNotificationsUseCase()
+            .onSuccess {
+                reduce {
+                    state.copy(
+                        notifications = state.notifications.map { it.copy(isRead = true) }.toImmutableList(),
+                        unreadCount = 0
+                    )
+                }
+            }
+            .onFailure { postSideEffect(RecruitmentNotificationSideEffect.Error) }
     }
 
     fun deleteAllNotifications() = intent {
-        reduce { state.copy(notifications = persistentListOf()) }
-        postSideEffect(RecruitmentNotificationSideEffect.Deleted)
+        deleteAllNotificationsUseCase()
+            .onSuccess {
+                reduce { state.copy(notifications = persistentListOf(), unreadCount = 0) }
+                postSideEffect(RecruitmentNotificationSideEffect.Deleted)
+            }
+            .onFailure { postSideEffect(RecruitmentNotificationSideEffect.Error) }
     }
 }
-
-internal fun mockRecruitmentNotifications() = persistentListOf(
-    RecruitmentNotification(
-        id = 1,
-        postId = 101,
-        category = RecruitmentNotificationCategory.MESSAGE,
-        title = "팀원모집 @@@님의 메세지",
-        content = "메세지메세지",
-        timestamp = "2시간 전",
-        isRead = false
-    ),
-    RecruitmentNotification(
-        id = 2,
-        postId = 102,
-        category = RecruitmentNotificationCategory.APPLICATION_APPROVED,
-        title = "팀원 모집 지원 승인",
-        content = "지원했던 AI 공모전 팀원 모집에 승인되었어요.",
-        timestamp = "2시간 전",
-        isRead = false
-    ),
-    RecruitmentNotification(
-        id = 3,
-        postId = 103,
-        category = RecruitmentNotificationCategory.APPLICATION_REJECTED,
-        title = "팀원 모집 지원 거절",
-        content = "지원했던 AI 공모전 팀원 모집에 승인 거절되었어요.\n다른 모집글에 지원해보세요.",
-        timestamp = "2시간 전",
-        isRead = false
-    ),
-    RecruitmentNotification(
-        id = 4,
-        postId = 104,
-        category = RecruitmentNotificationCategory.POST_DELETED,
-        title = "팀원 모집글 삭제",
-        content = "지원했던 AI 공모전 팀원 모집글이 삭제되었어요.\n다른 모집글에 지원해보세요.",
-        timestamp = "2시간 전",
-        isRead = false
-    ),
-    RecruitmentNotification(
-        id = 5,
-        postId = 105,
-        category = RecruitmentNotificationCategory.RECRUITMENT_CLOSED,
-        title = "팀원 모집기간 종료",
-        content = "작성했던 AI 공모전 팀원 모집 기간이 종료되었어요.",
-        timestamp = "2시간 전",
-        isRead = false
-    )
-)

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/component/RecruitmentNotificationItem.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/component/RecruitmentNotificationItem.kt
@@ -2,50 +2,27 @@ package `in`.koreatech.koin.feature.recruitment.ui.notification.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.AnchoredDraggableState
-import androidx.compose.foundation.gestures.DraggableAnchors
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.gestures.anchoredDraggable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
-import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotificationCategory
-import kotlin.math.roundToInt
-
-private enum class SwipeAnchor { Closed, Open, Dismissed }
 
 @Composable
 internal fun RecruitmentNotificationItem(
@@ -55,102 +32,52 @@ internal fun RecruitmentNotificationItem(
     isRead: Boolean,
     category: RecruitmentNotificationCategory,
     modifier: Modifier = Modifier,
-    onDelete: () -> Unit = {},
     onClick: () -> Unit = {}
 ) {
-    val density = LocalDensity.current
-    val state = remember { AnchoredDraggableState(initialValue = SwipeAnchor.Closed) }
-    var itemSize by remember { mutableStateOf(IntSize.Zero) }
-    val isOpen = state.settledValue != SwipeAnchor.Closed
-
-    LaunchedEffect(itemSize, isOpen) {
-        if (itemSize == IntSize.Zero) return@LaunchedEffect
-        state.updateAnchors(
-            DraggableAnchors {
-                SwipeAnchor.Closed at 0f
-                SwipeAnchor.Open at -itemSize.height.toFloat()
-                if (isOpen) SwipeAnchor.Dismissed at -itemSize.width.toFloat()
-            }
-        )
-    }
-
-    LaunchedEffect(state) {
-        snapshotFlow { state.settledValue }.collect {
-            if (it == SwipeAnchor.Dismissed) onDelete()
-        }
-    }
-
-    Box(
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick),
-        contentAlignment = Alignment.CenterEnd
+            .clickable(onClick = onClick)
+            .background(Color.White)
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(20.dp),
+        verticalAlignment = Alignment.Top
     ) {
-        Row(
-            modifier = Modifier
-                .zIndex(1f)
-                .fillMaxWidth()
-                .onSizeChanged { if (itemSize != it) itemSize = it }
-                .offset { IntOffset(x = state.offset.takeIf { !it.isNaN() }?.roundToInt() ?: 0, y = 0) }
-                .anchoredDraggable(state = state, orientation = Orientation.Horizontal)
-                .background(Color.White)
-                .padding(horizontal = 20.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(20.dp),
-            verticalAlignment = Alignment.Top
+        Icon(
+            imageVector = ImageVector.vectorResource(category.drawableRes),
+            contentDescription = stringResource(category.labelRes),
+            modifier = Modifier.size(30.dp),
+            tint = if (isRead) Color(0xFF727272) else Color(0xFFB611F5)
+        )
+        Column(
+            modifier = Modifier.weight(1f),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
         ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(category.drawableRes),
-                contentDescription = stringResource(category.labelRes),
-                modifier = Modifier.size(30.dp),
-                tint = if (isRead) Color(0xFF727272) else Color(0xFFB611F5)
-            )
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        text = title,
-                        style = KoinTheme.typography.bold13,
-                        color = if (isRead) Color(0xFF727272) else Color(0xFF000000),
-                        modifier = Modifier.weight(1f),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis
-                    )
-                    Text(
-                        text = timestamp,
-                        style = KoinTheme.typography.regular10,
-                        color = Color(0xFFCACACA)
-                    )
-                }
                 Text(
-                    text = content,
-                    style = KoinTheme.typography.medium12,
-                    color = Color(0xFF727272),
-                    maxLines = 2,
+                    text = title,
+                    style = KoinTheme.typography.bold13,
+                    color = if (isRead) Color(0xFF727272) else Color(0xFF000000),
+                    modifier = Modifier.weight(1f),
+                    maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
+                Text(
+                    text = timestamp,
+                    style = KoinTheme.typography.regular10,
+                    color = Color(0xFFCACACA)
+                )
             }
-        }
-
-        Box(
-            modifier = Modifier
-                .width(with(density) { itemSize.height.toDp() })
-                .height(with(density) { itemSize.height.toDp() })
-                .background(KoinTheme.colors.danger600)
-                .clickable(onClick = onDelete)
-                .zIndex(-1f),
-            contentAlignment = Alignment.Center
-        ) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_trash_can),
-                contentDescription = stringResource(R.string.recruitment_notification_delete_content_description),
-                tint = Color.White,
-                modifier = Modifier.size(30.dp)
+            Text(
+                text = content,
+                style = KoinTheme.typography.medium12,
+                color = Color(0xFF727272),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }
@@ -166,7 +93,6 @@ private fun RecruitmentNotificationItemUnreadPreview() {
             content = "메세지메세지",
             timestamp = "2시간 전",
             isRead = false,
-            onDelete = {},
             onClick = {}
         )
     }
@@ -182,7 +108,6 @@ private fun RecruitmentNotificationItemReadPreview() {
             content = "지원했던 AI 공모전 팀원 모집에 승인 거절되었어요.\n다른 모집글에 지원해보세요.",
             timestamp = "2시간 전",
             isRead = true,
-            onDelete = {},
             onClick = {}
         )
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/component/RecruitmentNotificationItem.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/component/RecruitmentNotificationItem.kt
@@ -22,11 +22,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.theme.KoinTheme
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
+import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotificationCategory
 
 @Composable
 internal fun RecruitmentNotificationItem(
-    title: String,
+    senderNickname: String?,
     content: String,
     timestamp: String,
     isRead: Boolean,
@@ -34,6 +35,13 @@ internal fun RecruitmentNotificationItem(
     modifier: Modifier = Modifier,
     onClick: () -> Unit = {}
 ) {
+    val title = when (category) {
+        RecruitmentNotificationCategory.MESSAGE -> senderNickname?.let {
+            stringResource(R.string.recruitment_notification_message_with_sender, it)
+        } ?: stringResource(category.labelRes)
+        else -> stringResource(category.labelRes)
+    }
+
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -89,7 +97,7 @@ private fun RecruitmentNotificationItemUnreadPreview() {
     RebrandKoinTheme {
         RecruitmentNotificationItem(
             category = RecruitmentNotificationCategory.MESSAGE,
-            title = "팀원모집 @@@님의 메세지",
+            senderNickname = "@@@",
             content = "메세지메세지",
             timestamp = "2시간 전",
             isRead = false,
@@ -104,7 +112,7 @@ private fun RecruitmentNotificationItemReadPreview() {
     RebrandKoinTheme {
         RecruitmentNotificationItem(
             category = RecruitmentNotificationCategory.APPLICATION_REJECTED,
-            title = "팀원 모집 지원 거절",
+            senderNickname = null,
             content = "지원했던 AI 공모전 팀원 모집에 승인 거절되었어요.\n다른 모집글에 지원해보세요.",
             timestamp = "2시간 전",
             isRead = true,

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
@@ -10,7 +10,7 @@ internal data class RecruitmentNotification(
     val recruitmentId: Int,
     val targetType: String,
     val category: RecruitmentNotificationCategory,
-    val title: String,
+    val senderNickname: String?,
     val content: String,
     val timestamp: String,
     val isRead: Boolean
@@ -23,7 +23,7 @@ internal fun DomainRecruitmentNotification.toUiModel(): RecruitmentNotification 
         recruitmentId = recruitmentId,
         targetType = targetType,
         category = category,
-        title = category.toTitle(senderNickname),
+        senderNickname = senderNickname,
         content = messagePreview,
         timestamp = createdAt.toDatetimeDiff(),
         isRead = isRead
@@ -38,15 +38,6 @@ private fun String.toRecruitmentNotificationCategory(): RecruitmentNotificationC
     "RECRUITMENT_DELETED" -> RecruitmentNotificationCategory.POST_DELETED
     "NEW_CHAT_MESSAGE" -> RecruitmentNotificationCategory.MESSAGE
     else -> RecruitmentNotificationCategory.MESSAGE
-}
-
-private fun RecruitmentNotificationCategory.toTitle(senderNickname: String?): String = when (this) {
-    RecruitmentNotificationCategory.MESSAGE -> senderNickname?.let { "팀원모집 ${it}님의 메세지" } ?: "팀원모집 메세지"
-    RecruitmentNotificationCategory.NEW_APPLICATION -> "팀원 모집 신규 지원"
-    RecruitmentNotificationCategory.APPLICATION_APPROVED -> "팀원 모집 지원 승인"
-    RecruitmentNotificationCategory.APPLICATION_REJECTED -> "팀원 모집 지원 거절"
-    RecruitmentNotificationCategory.POST_DELETED -> "팀원 모집글 삭제"
-    RecruitmentNotificationCategory.RECRUITMENT_CLOSED -> "팀원 모집기간 종료"
 }
 
 private val CREATED_AT_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
@@ -1,11 +1,64 @@
 package `in`.koreatech.koin.feature.recruitment.ui.notification.model
 
+import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotification as DomainRecruitmentNotification
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
+
 internal data class RecruitmentNotification(
     val id: Int,
-    val postId: Int,
+    val recruitmentId: Int,
+    val targetType: String,
     val category: RecruitmentNotificationCategory,
     val title: String,
     val content: String,
     val timestamp: String,
     val isRead: Boolean
 )
+
+internal fun DomainRecruitmentNotification.toUiModel(): RecruitmentNotification {
+    val category = type.toRecruitmentNotificationCategory()
+    return RecruitmentNotification(
+        id = id,
+        recruitmentId = recruitmentId,
+        targetType = targetType,
+        category = category,
+        title = category.toTitle(senderNickname),
+        content = messagePreview,
+        timestamp = createdAt.toDatetimeDiff(),
+        isRead = isRead
+    )
+}
+
+private fun String.toRecruitmentNotificationCategory(): RecruitmentNotificationCategory = when (this) {
+    "NEW_APPLICATION" -> RecruitmentNotificationCategory.NEW_APPLICATION
+    "APPLICATION_ACCEPTED" -> RecruitmentNotificationCategory.APPLICATION_APPROVED
+    "APPLICATION_REJECTED" -> RecruitmentNotificationCategory.APPLICATION_REJECTED
+    "RECRUITMENT_CLOSED" -> RecruitmentNotificationCategory.RECRUITMENT_CLOSED
+    "RECRUITMENT_DELETED" -> RecruitmentNotificationCategory.POST_DELETED
+    "NEW_CHAT_MESSAGE" -> RecruitmentNotificationCategory.MESSAGE
+    else -> RecruitmentNotificationCategory.MESSAGE
+}
+
+private fun RecruitmentNotificationCategory.toTitle(senderNickname: String?): String = when (this) {
+    RecruitmentNotificationCategory.MESSAGE -> senderNickname?.let { "팀원모집 ${it}님의 메세지" } ?: "팀원모집 메세지"
+    RecruitmentNotificationCategory.NEW_APPLICATION -> "팀원 모집 신규 지원"
+    RecruitmentNotificationCategory.APPLICATION_APPROVED -> "팀원 모집 지원 승인"
+    RecruitmentNotificationCategory.APPLICATION_REJECTED -> "팀원 모집 지원 거절"
+    RecruitmentNotificationCategory.POST_DELETED -> "팀원 모집글 삭제"
+    RecruitmentNotificationCategory.RECRUITMENT_CLOSED -> "팀원 모집기간 종료"
+}
+
+private val CREATED_AT_FORMATTER: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+
+private fun String.toDatetimeDiff(): String {
+    val createdAt = LocalDateTime.parse(this, CREATED_AT_FORMATTER)
+    val now = LocalDateTime.now()
+    val days = ChronoUnit.DAYS.between(createdAt, now)
+    if (days > 0) return "${days}일 전"
+    val hours = ChronoUnit.HOURS.between(createdAt, now)
+    if (hours > 0) return "${hours}시간 전"
+    val minutes = ChronoUnit.MINUTES.between(createdAt, now)
+    if (minutes > 0) return "${minutes}분 전"
+    return "방금 전"
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotificationCategory.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotificationCategory.kt
@@ -9,6 +9,10 @@ internal enum class RecruitmentNotificationCategory(
     @param:StringRes val labelRes: Int
 ) {
     MESSAGE(R.drawable.ic_notification_recruitment_chat, R.string.recruitment_notification_category_message),
+    NEW_APPLICATION(
+        R.drawable.ic_notification_recruitment,
+        R.string.recruitment_notification_category_new_application
+    ),
     APPLICATION_APPROVED(
         R.drawable.ic_notification_recruitment,
         R.string.recruitment_notification_category_application_approved

--- a/feature/recruitment/src/main/res/values/strings.xml
+++ b/feature/recruitment/src/main/res/values/strings.xml
@@ -13,8 +13,8 @@
     <string name="recruitment_notification_mark_all_read">모두 읽음으로 표시</string>
     <string name="recruitment_notification_delete_all">알림 전체 삭제</string>
     <string name="recruitment_notification_empty">아직 알림이 없어요</string>
-    <string name="recruitment_notification_delete_content_description">삭제</string>
     <string name="recruitment_notification_category_message">팀원모집 메세지</string>
+    <string name="recruitment_notification_category_new_application">팀원 모집 신규 지원</string>
     <string name="recruitment_notification_category_application_approved">팀원 모집 지원 승인</string>
     <string name="recruitment_notification_category_application_rejected">팀원 모집 지원 거절</string>
     <string name="recruitment_notification_category_post_deleted">팀원 모집글 삭제</string>

--- a/feature/recruitment/src/main/res/values/strings.xml
+++ b/feature/recruitment/src/main/res/values/strings.xml
@@ -14,6 +14,7 @@
     <string name="recruitment_notification_delete_all">알림 전체 삭제</string>
     <string name="recruitment_notification_empty">아직 알림이 없어요</string>
     <string name="recruitment_notification_category_message">팀원모집 메세지</string>
+    <string name="recruitment_notification_message_with_sender">팀원모집 %1$s님의 메세지</string>
     <string name="recruitment_notification_category_new_application">팀원 모집 신규 지원</string>
     <string name="recruitment_notification_category_application_approved">팀원 모집 지원 승인</string>
     <string name="recruitment_notification_category_application_rejected">팀원 모집 지원 거절</string>

--- a/koin/src/main/java/in/koreatech/koin/di/network/AuthNetworkModule.kt
+++ b/koin/src/main/java/in/koreatech/koin/di/network/AuthNetworkModule.kt
@@ -21,6 +21,7 @@ import `in`.koreatech.koin.data.api.auth.CallvanAuthApi
 import `in`.koreatech.koin.data.api.auth.CartAuthApi
 import `in`.koreatech.koin.data.api.auth.ChatAuthApi
 import `in`.koreatech.koin.data.api.auth.ClubAuthApi
+import `in`.koreatech.koin.data.api.auth.RecruitmentAuthApi
 import `in`.koreatech.koin.data.api.auth.StoreAuthApi
 import `in`.koreatech.koin.data.api.auth.TimetableAuthApi
 import `in`.koreatech.koin.data.api.auth.UserAuthApi
@@ -181,6 +182,12 @@ object AuthNetworkModule {
     @Singleton
     fun provideCallvanAuthApi(@Auth retrofit: Retrofit): CallvanAuthApi {
         return retrofit.create(CallvanAuthApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideRecruitmentAuthApi(@Auth retrofit: Retrofit): RecruitmentAuthApi {
+        return retrofit.create(RecruitmentAuthApi::class.java)
     }
 }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 팀원 모집 알림 화면(mock 데이터)을 실제 API에 연동했습니다.
- domain/data 계층에 알림 조회, 전체 읽음, 개별 읽음, 전체 삭제 API를 추가했습니다.
- 알림 클릭 시 `target_type`이 지원자 관리 화면(`APPLICANT_MANAGEMENT`)인 경우에 한해 이동을 연결했고, 그 외(`CHAT_ROOM`/`MY_APPLICATIONS`/모집글 상세)는 대상 화면·라우트 부재로 TODO로 남겨두었습니다.
- 개별 알림 삭제 API가 명세에 없어 기존 스와이프 삭제 UI/로직을 제거했습니다.

### 논의 사항
- stage 서버(`api.stage.koreatech.in`)에 해당 알림 API 4종이 아직 배포되어 있지 않아 실기기 테스트를 진행하지 못했습니다. 백엔드 배포 후 실기기 테스트를 완료하고 머지하겠습니다.

### 스크린샷


## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 팀 모집 알림을 서버에서 조회하고 페이지별로 추가 로드할 수 있습니다.
  * 알림을 개별 또는 전체 읽음 처리하고, 전체 알림을 삭제할 수 있습니다.
  * 신규 지원서 알림 유형이 추가되었습니다.
  * 알림 선택 시 관련 지원자 관리 화면으로 이동합니다.

* **개선 사항**
  * 읽지 않은 알림 개수와 페이지 진행 상태를 표시합니다.
  * 알림 항목에 발신자 정보와 상대 시간이 표시됩니다.
  * 알림 항목의 스와이프 삭제 기능이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->