### PR TITLE
[Feature] 팀원 모집 목록 화면 페이지네이션 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentPaginationMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentPaginationMapper.kt
@@ -1,0 +1,22 @@
+package `in`.koreatech.koin.data.mapper
+
+import `in`.koreatech.koin.data.response.recruitment.MyAppliedRecruitmentListResponse
+import `in`.koreatech.koin.data.response.recruitment.MyRecruitmentListResponse
+import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
+import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
+
+fun MyRecruitmentListResponse.toMyRecruitmentPosts() = MyRecruitmentPosts(
+    posts = recruitments.map { it.toMyRecruitmentPost() },
+    totalCount = totalCount.toLong(),
+    currentCount = currentCount,
+    totalPage = totalPage,
+    currentPage = currentPage
+)
+
+fun MyAppliedRecruitmentListResponse.toMyAppliedRecruitments() = MyAppliedRecruitments(
+    applications = applications.map { it.toMyAppliedRecruitment() },
+    totalCount = totalCount.toLong(),
+    currentCount = currentCount,
+    totalPage = totalPage,
+    currentPage = currentPage
+)

--- a/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package `in`.koreatech.koin.data.repository
 
-import `in`.koreatech.koin.data.mapper.toMyAppliedRecruitment
-import `in`.koreatech.koin.data.mapper.toMyRecruitmentPost
+import `in`.koreatech.koin.data.mapper.toMyAppliedRecruitments
+import `in`.koreatech.koin.data.mapper.toMyRecruitmentPosts
 import `in`.koreatech.koin.data.mapper.toRecruitmentDetail
 import `in`.koreatech.koin.data.mapper.toRecruitmentNotifications
 import `in`.koreatech.koin.data.mapper.toRecruitmentUpdateRequest
@@ -9,8 +9,8 @@ import `in`.koreatech.koin.data.mapper.toRecruitments
 import `in`.koreatech.koin.data.source.remote.RecruitmentRemoteDataSource
 import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.domain.error.recruitment.KoinRecruitmentException
-import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitment
-import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPost
+import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
+import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentDetail
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentUpdate
@@ -109,12 +109,11 @@ class RecruitmentRepositoryImpl @Inject constructor(
         sort: String,
         page: Int,
         limit: Int
-    ): Result<List<MyRecruitmentPost>> {
+    ): Result<MyRecruitmentPosts> {
         return suspendRunCatching {
             recruitmentRemoteDataSource
                 .getMyRecruitmentPosts(status, sort, page, limit)
-                .recruitments
-                .map { it.toMyRecruitmentPost() }
+                .toMyRecruitmentPosts()
         }.mapHttpFailure {
             on(400, "ILLEGAL_ARGUMENT") throws KoinRecruitmentException.InvalidArgumentException()
             on(401) throws KoinRecruitmentException.UnauthorizedUserException()
@@ -127,12 +126,11 @@ class RecruitmentRepositoryImpl @Inject constructor(
         sort: String,
         page: Int,
         limit: Int
-    ): Result<List<MyAppliedRecruitment>> {
+    ): Result<MyAppliedRecruitments> {
         return suspendRunCatching {
             recruitmentRemoteDataSource
                 .getMyAppliedRecruitments(statuses, sort, page, limit)
-                .applications
-                .map { it.toMyAppliedRecruitment() }
+                .toMyAppliedRecruitments()
         }.mapHttpFailure {
             on(400, "ILLEGAL_ARGUMENT") throws KoinRecruitmentException.InvalidArgumentException()
             on(401) throws KoinRecruitmentException.UnauthorizedUserException()

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyAppliedRecruitments.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyAppliedRecruitments.kt
@@ -1,0 +1,9 @@
+package `in`.koreatech.koin.domain.model.recruitment
+
+data class MyAppliedRecruitments(
+    val applications: List<MyAppliedRecruitment>,
+    val totalCount: Long,
+    val currentCount: Int,
+    val totalPage: Int,
+    val currentPage: Int
+)

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyRecruitmentPosts.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyRecruitmentPosts.kt
@@ -1,0 +1,9 @@
+package `in`.koreatech.koin.domain.model.recruitment
+
+data class MyRecruitmentPosts(
+    val posts: List<MyRecruitmentPost>,
+    val totalCount: Long,
+    val currentCount: Int,
+    val totalPage: Int,
+    val currentPage: Int
+)

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
@@ -1,7 +1,7 @@
 package `in`.koreatech.koin.domain.repository
 
-import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitment
-import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPost
+import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
+import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentDetail
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentNotifications
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentUpdate
@@ -38,14 +38,14 @@ interface RecruitmentRepository {
         sort: String,
         page: Int,
         limit: Int
-    ): Result<List<MyRecruitmentPost>>
+    ): Result<MyRecruitmentPosts>
 
     suspend fun getMyAppliedRecruitments(
         statuses: List<String>,
         sort: String,
         page: Int,
         limit: Int
-    ): Result<List<MyAppliedRecruitment>>
+    ): Result<MyAppliedRecruitments>
 
     suspend fun closeRecruitmentPost(postId: Int): Result<Unit>
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetMyAppliedRecruitmentsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetMyAppliedRecruitmentsUseCase.kt
@@ -1,6 +1,6 @@
 package `in`.koreatech.koin.domain.usecase.recruitment
 
-import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitment
+import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
 import `in`.koreatech.koin.domain.repository.RecruitmentRepository
 import javax.inject.Inject
 
@@ -12,6 +12,6 @@ class GetMyAppliedRecruitmentsUseCase @Inject constructor(
         sort: String = "LATEST_DESC",
         page: Int = 1,
         limit: Int = 10
-    ): Result<List<MyAppliedRecruitment>> =
+    ): Result<MyAppliedRecruitments> =
         recruitmentRepository.getMyAppliedRecruitments(statuses, sort, page, limit)
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetMyRecruitmentPostsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetMyRecruitmentPostsUseCase.kt
@@ -1,6 +1,6 @@
 package `in`.koreatech.koin.domain.usecase.recruitment
 
-import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPost
+import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
 import `in`.koreatech.koin.domain.repository.RecruitmentRepository
 import javax.inject.Inject
 
@@ -12,6 +12,6 @@ class GetMyRecruitmentPostsUseCase @Inject constructor(
         sort: String = "LATEST_DESC",
         page: Int = 1,
         limit: Int = 20
-    ): Result<List<MyRecruitmentPost>> =
+    ): Result<MyRecruitmentPosts> =
         recruitmentRepository.getMyRecruitmentPosts(status, sort, page, limit)
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentPagination.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentPagination.kt
@@ -1,0 +1,35 @@
+package `in`.koreatech.koin.feature.recruitment.ui.component
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+
+private const val DEFAULT_LOAD_MORE_THRESHOLD = 3
+
+@Composable
+fun rememberRecruitmentPaginationListState(
+    hasMore: Boolean,
+    isLoadingMore: Boolean,
+    itemCount: Int,
+    onLoadMore: () -> Unit,
+    loadMoreThreshold: Int = DEFAULT_LOAD_MORE_THRESHOLD
+): LazyListState {
+    val listState = rememberLazyListState()
+
+    LaunchedEffect(listState, hasMore, isLoadingMore, itemCount) {
+        snapshotFlow {
+            val layoutInfo = listState.layoutInfo
+            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisibleItemIndex >= layoutInfo.totalItemsCount - loadMoreThreshold
+        }
+            .distinctUntilChanged()
+            .filter { it }
+            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+    }
+
+    return listState
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentPagination.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentPagination.kt
@@ -4,6 +4,8 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -14,13 +16,15 @@ private const val DEFAULT_LOAD_MORE_THRESHOLD = 3
 fun rememberRecruitmentPaginationListState(
     hasMore: Boolean,
     isLoadingMore: Boolean,
-    itemCount: Int,
     onLoadMore: () -> Unit,
     loadMoreThreshold: Int = DEFAULT_LOAD_MORE_THRESHOLD
 ): LazyListState {
     val listState = rememberLazyListState()
+    val latestHasMore by rememberUpdatedState(hasMore)
+    val latestIsLoadingMore by rememberUpdatedState(isLoadingMore)
+    val latestOnLoadMore by rememberUpdatedState(onLoadMore)
 
-    LaunchedEffect(listState, hasMore, isLoadingMore, itemCount) {
+    LaunchedEffect(listState) {
         snapshotFlow {
             val layoutInfo = listState.layoutInfo
             val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
@@ -28,7 +32,7 @@ fun rememberRecruitmentPaginationListState(
         }
             .distinctUntilChanged()
             .filter { it }
-            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+            .collect { if (latestHasMore && !latestIsLoadingMore) latestOnLoadMore() }
     }
 
     return listState

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
@@ -15,8 +15,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
@@ -25,7 +27,9 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -56,8 +60,12 @@ import `in`.koreatech.koin.feature.recruitment.ui.main.model.RecruitmentFilterSt
 import `in`.koreatech.koin.feature.recruitment.ui.main.model.RecruitmentItemModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
+
+private const val LOAD_MORE_THRESHOLD = 3
 
 @Composable
 fun RecruitmentMainScreen(
@@ -101,6 +109,9 @@ fun RecruitmentMainScreen(
         totalCount = state.totalCount,
         isRefreshing = state.isRefreshing,
         onRefresh = { viewModel.fetchRecruitments(isRefresh = true) },
+        isLoadingMore = state.isLoadingMore,
+        hasMore = state.currentPage < state.totalPage,
+        onLoadMore = viewModel::loadMoreRecruitments,
         filterState = state.filterState,
         onSearchValueChange = viewModel::updateSearch,
         onFilterClick = { viewModel.updateFilterVisible(true) },
@@ -125,6 +136,9 @@ private fun RecruitmentMainScreenImpl(
     filterState: RecruitmentFilterState,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
+    isLoadingMore: Boolean = false,
+    hasMore: Boolean = false,
+    onLoadMore: () -> Unit = {},
     onSearchValueChange: (String) -> Unit = {},
     onFilterClick: () -> Unit = {},
     onRemoveStatus: () -> Unit = {},
@@ -264,8 +278,22 @@ private fun RecruitmentMainScreenImpl(
                         RecruitmentEmptyContent(modifier = Modifier.padding(bottom = 40.dp))
                     }
                 } else {
+                    val listState = rememberLazyListState()
+
+                    LaunchedEffect(listState, hasMore, isLoadingMore, items.size) {
+                        snapshotFlow {
+                            val layoutInfo = listState.layoutInfo
+                            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
+                        }
+                            .distinctUntilChanged()
+                            .filter { it }
+                            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+                    }
+
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
+                        state = listState,
                         contentPadding = PaddingValues(start = 24.dp, end = 24.dp, top = 8.dp, bottom = 96.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
@@ -274,6 +302,21 @@ private fun RecruitmentMainScreenImpl(
                                 item = item,
                                 onClick = { onItemClick(item.id) }
                             )
+                        }
+                        if (isLoadingMore) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 16.dp),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier.size(24.dp),
+                                        color = RebrandKoinTheme.colors.primary500
+                                    )
+                                }
+                            }
                         }
                     }
                 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CircularProgressIndicator
@@ -27,9 +26,7 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -50,6 +47,7 @@ import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentLocation
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentStatus
+import `in`.koreatech.koin.feature.recruitment.ui.component.rememberRecruitmentPaginationListState
 import `in`.koreatech.koin.feature.recruitment.ui.main.component.RecruitmentAppliedFilterChipGroup
 import `in`.koreatech.koin.feature.recruitment.ui.main.component.RecruitmentChip
 import `in`.koreatech.koin.feature.recruitment.ui.main.component.RecruitmentChipDefaults
@@ -60,12 +58,8 @@ import `in`.koreatech.koin.feature.recruitment.ui.main.model.RecruitmentFilterSt
 import `in`.koreatech.koin.feature.recruitment.ui.main.model.RecruitmentItemModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
-
-private const val LOAD_MORE_THRESHOLD = 3
 
 @Composable
 fun RecruitmentMainScreen(
@@ -278,18 +272,12 @@ private fun RecruitmentMainScreenImpl(
                         RecruitmentEmptyContent(modifier = Modifier.padding(bottom = 40.dp))
                     }
                 } else {
-                    val listState = rememberLazyListState()
-
-                    LaunchedEffect(listState, hasMore, isLoadingMore, items.size) {
-                        snapshotFlow {
-                            val layoutInfo = listState.layoutInfo
-                            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                            lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
-                        }
-                            .distinctUntilChanged()
-                            .filter { it }
-                            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
-                    }
+                    val listState = rememberRecruitmentPaginationListState(
+                        hasMore = hasMore,
+                        isLoadingMore = isLoadingMore,
+                        itemCount = items.size,
+                        onLoadMore = onLoadMore
+                    )
 
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
@@ -275,7 +275,6 @@ private fun RecruitmentMainScreenImpl(
                     val listState = rememberRecruitmentPaginationListState(
                         hasMore = hasMore,
                         isLoadingMore = isLoadingMore,
-                        itemCount = items.size,
                         onLoadMore = onLoadMore
                     )
 

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainState.kt
@@ -11,8 +11,11 @@ data class RecruitmentMainState(
     val searchValue: String = "",
     val items: ImmutableList<RecruitmentItemModel> = persistentListOf(),
     val totalCount: Long = 0,
+    val currentPage: Int = 1,
+    val totalPage: Int = 1,
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
+    val isLoadingMore: Boolean = false,
     val filterState: RecruitmentFilterState = RecruitmentFilterState(),
     val pendingFilterState: RecruitmentFilterState = RecruitmentFilterState(),
     val isFilterVisible: Boolean = false

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainViewModel.kt
@@ -57,7 +57,9 @@ class RecruitmentMainViewModel @Inject constructor(
                 .takeIf { it.isNotEmpty() }
                 ?.map { it.apiValue },
             meetingType = filter.selectedLocation?.apiValue,
-            sort = filter.selectedSort.apiValue
+            sort = filter.selectedSort.apiValue,
+            page = 1,
+            limit = RECRUITMENTS_PAGE_SIZE
         ).onSuccess { recruitments ->
             reduce {
                 state.copy(
@@ -65,12 +67,46 @@ class RecruitmentMainViewModel @Inject constructor(
                         .map { it.toRecruitmentItemModel() }
                         .toImmutableList(),
                     totalCount = recruitments.totalCount,
+                    currentPage = recruitments.currentPage,
+                    totalPage = recruitments.totalPage,
                     isLoading = false,
                     isRefreshing = false
                 )
             }
         }.onFailure {
             reduce { state.copy(isLoading = false, isRefreshing = false) }
+            postSideEffect(RecruitmentMainSideEffect.ShowError)
+        }
+    }
+
+    fun loadMoreRecruitments() = intent {
+        if (state.isLoadingMore || state.currentPage >= state.totalPage) return@intent
+        reduce { state.copy(isLoadingMore = true) }
+        val filter = state.filterState
+        getRecruitmentsUseCase(
+            keyword = state.searchValue.takeIf { it.isNotBlank() },
+            status = filter.selectedStatus?.apiValue,
+            categories = filter.selectedCategories
+                .takeIf { it.isNotEmpty() }
+                ?.map { it.apiValue },
+            meetingType = filter.selectedLocation?.apiValue,
+            sort = filter.selectedSort.apiValue,
+            page = state.currentPage + 1,
+            limit = RECRUITMENTS_PAGE_SIZE
+        ).onSuccess { recruitments ->
+            reduce {
+                state.copy(
+                    items = (
+                        state.items + recruitments.recruitments.map { it.toRecruitmentItemModel() }
+                        ).toImmutableList(),
+                    totalCount = recruitments.totalCount,
+                    currentPage = recruitments.currentPage,
+                    totalPage = recruitments.totalPage,
+                    isLoadingMore = false
+                )
+            }
+        }.onFailure {
+            reduce { state.copy(isLoadingMore = false) }
             postSideEffect(RecruitmentMainSideEffect.ShowError)
         }
     }
@@ -133,6 +169,7 @@ class RecruitmentMainViewModel @Inject constructor(
 
     companion object {
         private const val SEARCH_DEBOUNCE_MILLIS = 300L
+        private const val RECRUITMENTS_PAGE_SIZE = 10
     }
 }
 

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
@@ -12,16 +12,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -35,18 +32,15 @@ import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentRole
 import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentEmptyState
 import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentFilterButton
+import `in`.koreatech.koin.feature.recruitment.ui.component.rememberRecruitmentPaginationListState
 import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.component.AppliedRecruitmentFilterBottomSheet
 import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.component.AppliedRecruitmentPostCard
 import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.model.AppliedRecruitmentPost
 import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.model.AppliedRecruitmentStatus
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
-
-private const val LOAD_MORE_THRESHOLD = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -130,18 +124,12 @@ private fun MyAppliedRecruitmentScreenImpl(
                 )
             }
         } else {
-            val listState = rememberLazyListState()
-
-            LaunchedEffect(listState, hasMore, isLoadingMore, posts.size) {
-                snapshotFlow {
-                    val layoutInfo = listState.layoutInfo
-                    val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                    lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
-                }
-                    .distinctUntilChanged()
-                    .filter { it }
-                    .collect { if (hasMore && !isLoadingMore) onLoadMore() }
-            }
+            val listState = rememberRecruitmentPaginationListState(
+                hasMore = hasMore,
+                isLoadingMore = isLoadingMore,
+                itemCount = posts.size,
+                onLoadMore = onLoadMore
+            )
 
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
@@ -127,7 +127,6 @@ private fun MyAppliedRecruitmentScreenImpl(
             val listState = rememberRecruitmentPaginationListState(
                 hasMore = hasMore,
                 isLoadingMore = isLoadingMore,
-                itemCount = posts.size,
                 onLoadMore = onLoadMore
             )
 

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
@@ -9,14 +9,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -36,8 +41,12 @@ import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.model.App
 import `in`.koreatech.koin.feature.recruitment.ui.myappliedrecruitment.model.AppliedRecruitmentStatus
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
+
+private const val LOAD_MORE_THRESHOLD = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -68,6 +77,9 @@ fun MyAppliedRecruitmentScreen(
     ) { innerPadding ->
         MyAppliedRecruitmentScreenImpl(
             posts = state.posts,
+            isLoadingMore = state.isLoadingMore,
+            hasMore = state.currentPage < state.totalPage,
+            onLoadMore = viewModel::loadMoreMyAppliedRecruitments,
             onFilter = { viewModel.showFilterSheet() },
             modifier = Modifier.padding(innerPadding)
         )
@@ -86,6 +98,9 @@ fun MyAppliedRecruitmentScreen(
 private fun MyAppliedRecruitmentScreenImpl(
     posts: ImmutableList<AppliedRecruitmentPost>,
     modifier: Modifier = Modifier,
+    isLoadingMore: Boolean = false,
+    hasMore: Boolean = false,
+    onLoadMore: () -> Unit = {},
     onFilter: () -> Unit = {}
 ) {
     Column(modifier = modifier.fillMaxSize()) {
@@ -115,13 +130,39 @@ private fun MyAppliedRecruitmentScreenImpl(
                 )
             }
         } else {
+            val listState = rememberLazyListState()
+
+            LaunchedEffect(listState, hasMore, isLoadingMore, posts.size) {
+                snapshotFlow {
+                    val layoutInfo = listState.layoutInfo
+                    val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                    lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
+                }
+                    .distinctUntilChanged()
+                    .filter { it }
+                    .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
+                state = listState,
                 contentPadding = PaddingValues(start = 21.5.dp, end = 21.5.dp, bottom = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(posts, key = { it.id }) { post ->
                     AppliedRecruitmentPostCard(post = post)
+                }
+                if (isLoadingMore) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        }
+                    }
                 }
             }
         }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentState.kt
@@ -10,6 +10,9 @@ import kotlinx.collections.immutable.persistentListOf
 data class MyAppliedRecruitmentState(
     val posts: ImmutableList<AppliedRecruitmentPost> = persistentListOf(),
     val filter: AppliedFilterState = AppliedFilterState(),
+    val currentPage: Int = 1,
+    val totalPage: Int = 1,
     val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
     val showFilterSheet: Boolean = false
 )

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentViewModel.kt
@@ -47,14 +47,42 @@ class MyAppliedRecruitmentViewModel @Inject constructor(
         reduce { state.copy(isLoading = true) }
         getMyAppliedRecruitmentsUseCase(
             statuses = filter.status.toApiValue(),
-            sort = filter.sort.toApiValue()
-        ).onSuccess { applications ->
+            sort = filter.sort.toApiValue(),
+            page = 1,
+            limit = MY_APPLIED_RECRUITMENT_PAGE_SIZE
+        ).onSuccess { result ->
             reduce {
                 state.copy(
                     isLoading = false,
-                    posts = applications.map { it.toAppliedRecruitmentPost() }.toPersistentList()
+                    posts = result.applications.map { it.toAppliedRecruitmentPost() }.toPersistentList(),
+                    currentPage = result.currentPage,
+                    totalPage = result.totalPage
                 )
             }
+        }.onFailure {
+            reduce { state.copy(isLoading = false) }
+        }
+    }
+
+    fun loadMoreMyAppliedRecruitments() = intent {
+        if (state.isLoadingMore || state.currentPage >= state.totalPage) return@intent
+        reduce { state.copy(isLoadingMore = true) }
+        getMyAppliedRecruitmentsUseCase(
+            statuses = state.filter.status.toApiValue(),
+            sort = state.filter.sort.toApiValue(),
+            page = state.currentPage + 1,
+            limit = MY_APPLIED_RECRUITMENT_PAGE_SIZE
+        ).onSuccess { result ->
+            reduce {
+                state.copy(
+                    isLoadingMore = false,
+                    posts = (state.posts + result.applications.map { it.toAppliedRecruitmentPost() }).toPersistentList(),
+                    currentPage = result.currentPage,
+                    totalPage = result.totalPage
+                )
+            }
+        }.onFailure {
+            reduce { state.copy(isLoadingMore = false) }
         }
     }
 
@@ -69,5 +97,9 @@ class MyAppliedRecruitmentViewModel @Inject constructor(
     fun applyFilter(filter: AppliedFilterState) = intent {
         reduce { state.copy(filter = filter, showFilterSheet = false) }
         loadMyAppliedRecruitments(filter)
+    }
+
+    companion object {
+        private const val MY_APPLIED_RECRUITMENT_PAGE_SIZE = 10
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
@@ -12,16 +12,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -34,6 +31,7 @@ import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentRole
 import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentFilterButton
+import `in`.koreatech.koin.feature.recruitment.ui.component.rememberRecruitmentPaginationListState
 import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.component.CloseRecruitmentDialog
 import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.component.MyRecruitmentEmptyState
 import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.component.RecruitmentFilterBottomSheet
@@ -42,12 +40,8 @@ import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.MyRecruitm
 import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.RecruitmentStatus
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
-
-private const val LOAD_MORE_THRESHOLD = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -152,18 +146,12 @@ private fun MyRecruitmentScreenImpl(
                 MyRecruitmentEmptyState()
             }
         } else {
-            val listState = rememberLazyListState()
-
-            LaunchedEffect(listState, hasMore, isLoadingMore, posts.size) {
-                snapshotFlow {
-                    val layoutInfo = listState.layoutInfo
-                    val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-                    lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
-                }
-                    .distinctUntilChanged()
-                    .filter { it }
-                    .collect { if (hasMore && !isLoadingMore) onLoadMore() }
-            }
+            val listState = rememberRecruitmentPaginationListState(
+                hasMore = hasMore,
+                isLoadingMore = isLoadingMore,
+                itemCount = posts.size,
+                onLoadMore = onLoadMore
+            )
 
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
@@ -9,15 +9,19 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -38,8 +42,12 @@ import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.MyRecruitm
 import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.RecruitmentStatus
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
+
+private const val LOAD_MORE_THRESHOLD = 3
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -73,6 +81,9 @@ fun MyRecruitmentScreen(
         MyRecruitmentScreenImpl(
             posts = state.posts,
             isLoading = state.isLoading,
+            isLoadingMore = state.isLoadingMore,
+            hasMore = state.currentPage < state.totalPage,
+            onLoadMore = viewModel::loadMoreMyRecruitmentPosts,
             onApplicantManage = onApplicantManage,
             onCloseRecruitment = { postId -> viewModel.showCloseDialog(postId) },
             onChat = onChat,
@@ -102,6 +113,9 @@ private fun MyRecruitmentScreenImpl(
     posts: ImmutableList<MyRecruitmentPost>,
     isLoading: Boolean,
     modifier: Modifier = Modifier,
+    isLoadingMore: Boolean = false,
+    hasMore: Boolean = false,
+    onLoadMore: () -> Unit = {},
     onApplicantManage: (Int) -> Unit = {},
     onCloseRecruitment: (Int) -> Unit = {},
     onChat: (Int) -> Unit = {},
@@ -138,8 +152,22 @@ private fun MyRecruitmentScreenImpl(
                 MyRecruitmentEmptyState()
             }
         } else {
+            val listState = rememberLazyListState()
+
+            LaunchedEffect(listState, hasMore, isLoadingMore, posts.size) {
+                snapshotFlow {
+                    val layoutInfo = listState.layoutInfo
+                    val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                    lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
+                }
+                    .distinctUntilChanged()
+                    .filter { it }
+                    .collect { if (hasMore && !isLoadingMore) onLoadMore() }
+            }
+
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
+                state = listState,
                 contentPadding = PaddingValues(start = 21.5.dp, end = 21.5.dp, bottom = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
@@ -154,6 +182,18 @@ private fun MyRecruitmentScreenImpl(
                         },
                         onChat = { onChat(post.id) }
                     )
+                }
+                if (isLoadingMore) {
+                    item {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 16.dp),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(24.dp))
+                        }
+                    }
                 }
             }
         }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentScreen.kt
@@ -149,7 +149,6 @@ private fun MyRecruitmentScreenImpl(
             val listState = rememberRecruitmentPaginationListState(
                 hasMore = hasMore,
                 isLoadingMore = isLoadingMore,
-                itemCount = posts.size,
                 onLoadMore = onLoadMore
             )
 

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentState.kt
@@ -10,7 +10,10 @@ import kotlinx.collections.immutable.persistentListOf
 data class MyRecruitmentState(
     val posts: ImmutableList<MyRecruitmentPost> = persistentListOf(),
     val filter: RecruitmentFilterState = RecruitmentFilterState(),
+    val currentPage: Int = 1,
+    val totalPage: Int = 1,
     val isLoading: Boolean = true,
+    val isLoadingMore: Boolean = false,
     val showCloseDialog: Boolean = false,
     val closeTargetPostId: Int? = null,
     val showFilterSheet: Boolean = false

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentViewModel.kt
@@ -50,9 +50,42 @@ class MyRecruitmentViewModel @Inject constructor(
         reduce { state.copy(isLoading = true) }
         getMyRecruitmentPostsUseCase(
             status = filter.status.toApiValue(),
-            sort = filter.sort.toApiValue()
-        ).onSuccess { posts ->
-            reduce { state.copy(isLoading = false, posts = posts.map { it.toMyRecruitmentPost() }.toPersistentList()) }
+            sort = filter.sort.toApiValue(),
+            page = 1,
+            limit = MY_RECRUITMENT_PAGE_SIZE
+        ).onSuccess { result ->
+            reduce {
+                state.copy(
+                    isLoading = false,
+                    posts = result.posts.map { it.toMyRecruitmentPost() }.toPersistentList(),
+                    currentPage = result.currentPage,
+                    totalPage = result.totalPage
+                )
+            }
+        }.onFailure {
+            reduce { state.copy(isLoading = false) }
+        }
+    }
+
+    fun loadMoreMyRecruitmentPosts() = intent {
+        if (state.isLoadingMore || state.currentPage >= state.totalPage) return@intent
+        reduce { state.copy(isLoadingMore = true) }
+        getMyRecruitmentPostsUseCase(
+            status = state.filter.status.toApiValue(),
+            sort = state.filter.sort.toApiValue(),
+            page = state.currentPage + 1,
+            limit = MY_RECRUITMENT_PAGE_SIZE
+        ).onSuccess { result ->
+            reduce {
+                state.copy(
+                    isLoadingMore = false,
+                    posts = (state.posts + result.posts.map { it.toMyRecruitmentPost() }).toPersistentList(),
+                    currentPage = result.currentPage,
+                    totalPage = result.totalPage
+                )
+            }
+        }.onFailure {
+            reduce { state.copy(isLoadingMore = false) }
         }
     }
 
@@ -92,5 +125,9 @@ class MyRecruitmentViewModel @Inject constructor(
         }.onFailure {
             reduce { state.copy(showCloseDialog = false, closeTargetPostId = null) }
         }
+    }
+
+    companion object {
+        private const val MY_RECRUITMENT_PAGE_SIZE = 20
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myrecruitment/MyRecruitmentViewModel.kt
@@ -128,6 +128,6 @@ class MyRecruitmentViewModel @Inject constructor(
     }
 
     companion object {
-        private const val MY_RECRUITMENT_PAGE_SIZE = 20
+        private const val MY_RECRUITMENT_PAGE_SIZE = 10
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
@@ -12,18 +12,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -38,12 +34,11 @@ import `in`.koreatech.koin.core.designsystem.component.snackbar.CustomSnackBarHo
 import `in`.koreatech.koin.core.designsystem.component.topbar.KoinTopAppBar
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.recruitment.R
+import `in`.koreatech.koin.feature.recruitment.ui.component.rememberRecruitmentPaginationListState
 import `in`.koreatech.koin.feature.recruitment.ui.notification.component.RecruitmentNotificationItem
 import `in`.koreatech.koin.feature.recruitment.ui.notification.component.RecruitmentNotificationMenuButton
 import `in`.koreatech.koin.feature.recruitment.ui.notification.model.RecruitmentNotification
 import kotlinx.collections.immutable.ImmutableList
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -55,7 +50,6 @@ internal fun RecruitmentNotificationScreen(
 ) {
     val uiState by viewModel.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
-    val listState = rememberLazyListState()
     val context = LocalContext.current
 
     viewModel.collectSideEffect { sideEffect ->
@@ -110,7 +104,6 @@ internal fun RecruitmentNotificationScreen(
     ) { paddingValues ->
         RecruitmentNotificationScreenImpl(
             modifier = Modifier.padding(paddingValues),
-            listState = listState,
             notifications = uiState.notifications,
             isLoading = uiState.isLoading,
             isLoadingMore = uiState.isLoadingMore,
@@ -123,7 +116,6 @@ internal fun RecruitmentNotificationScreen(
 
 @Composable
 private fun RecruitmentNotificationScreenImpl(
-    listState: LazyListState,
     notifications: ImmutableList<RecruitmentNotification>,
     isLoading: Boolean,
     isLoadingMore: Boolean,
@@ -132,16 +124,12 @@ private fun RecruitmentNotificationScreenImpl(
     onLoadMore: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    LaunchedEffect(listState, hasMore, isLoadingMore, notifications.size) {
-        snapshotFlow {
-            val layoutInfo = listState.layoutInfo
-            val lastVisibleItemIndex = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            lastVisibleItemIndex >= layoutInfo.totalItemsCount - LOAD_MORE_THRESHOLD
-        }
-            .distinctUntilChanged()
-            .filter { it }
-            .collect { if (hasMore && !isLoadingMore) onLoadMore() }
-    }
+    val listState = rememberRecruitmentPaginationListState(
+        hasMore = hasMore,
+        isLoadingMore = isLoadingMore,
+        itemCount = notifications.size,
+        onLoadMore = onLoadMore
+    )
 
     if (isLoading) {
         Box(
@@ -205,5 +193,3 @@ private fun RecruitmentNotificationScreenImpl(
         }
     }
 }
-
-private const val LOAD_MORE_THRESHOLD = 3

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
@@ -127,7 +127,6 @@ private fun RecruitmentNotificationScreenImpl(
     val listState = rememberRecruitmentPaginationListState(
         hasMore = hasMore,
         isLoadingMore = isLoadingMore,
-        itemCount = notifications.size,
         onLoadMore = onLoadMore
     )
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 모집글 메인/내 모집글/내 지원 목록 3개 화면에 무한스크롤 페이지네이션을 추가했습니다.
- `MyRecruitmentPosts`/`MyAppliedRecruitments` API 응답에 이미 내려오던 `total_page`/`current_page`가 repository 계층에서 버려지고 있어서, 이를 그대로 노출하는 도메인 래퍼 모델을 추가하고 `GetMyRecruitmentPostsUseCase`/`GetMyAppliedRecruitmentsUseCase`가 이를 반환하도록 변경했습니다(사용처가 화면별 ViewModel 하나씩이라 영향 범위는 작습니다). 모집글 메인은 기존 `Recruitments` 모델에 이미 있던 페이지 정보를 그대로 사용했습니다.
- 3개 화면 모두 `RecruitmentNotificationScreen`에 이미 있던 `LazyListState` + `snapshotFlow` 기반 스크롤 임계값 트리거 패턴을 그대로 적용해, 하단 근접 시 다음 페이지를 불러오고 로딩 인디케이터를 표시합니다.

### 논의 사항
리뷰 사항에 맞춰 하나의 공통 compose 함수로 구현 후 적용


### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다