### PR TITLE
[Feature] 모집글 메인 화면 뒤로가기·로딩 처리 및 카테고리 칩 색상 통일

### DIFF
--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -1,5 +1,6 @@
 package `in`.koreatech.koin.feature.recruitment.navigation
 
+import android.app.Activity
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -29,8 +30,14 @@ fun NavGraphBuilder.koinRecruitmentGraph(
         )
     }
     composable<RecruitmentNavType.RecruitmentMain> {
+        val context = LocalContext.current
+
         RecruitmentMainScreen(
-            onTopbarBackClick = { navController.navigateUp() },
+            onTopbarBackClick = {
+                if (!navController.popBackStack()) {
+                    (context as? Activity)?.finish()
+                }
+            },
             onItemClick = { postId ->
                 navController.navigate(RecruitmentNavType.RecruitmentDetail(postId))
             }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentCategoryBadge.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentCategoryBadge.kt
@@ -37,14 +37,12 @@ fun RecruitmentCategoryBadge(
             textColor = RebrandKoinTheme.colors.primary600
         }
         RecruitmentCategory.PROJECT -> {
-            // TODO: 색상 미정 - 스터디 색상 임시 적용
-            bgColor = RebrandKoinTheme.colors.primary100
-            textColor = RebrandKoinTheme.colors.primary600
+            bgColor = RebrandKoinTheme.colors.warning100
+            textColor = RebrandKoinTheme.colors.warning600
         }
         RecruitmentCategory.ETC -> {
-            // TODO: 색상 미정 - neutral 임시 적용
-            bgColor = RebrandKoinTheme.colors.neutral200
-            textColor = RebrandKoinTheme.colors.neutral600
+            bgColor = RebrandKoinTheme.colors.danger200
+            textColor = RebrandKoinTheme.colors.danger600
         }
     }
     Box(

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/detail/component/RecruitmentTitleSection.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/detail/component/RecruitmentTitleSection.kt
@@ -2,9 +2,7 @@ package `in`.koreatech.koin.feature.recruitment.ui.detail.component
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -13,10 +11,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import `in`.koreatech.koin.core.designsystem.component.chip.ReadOnlyTextChip
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
+import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentCategoryBadge
 
 @Composable
 fun RecruitmentTitleSection(
@@ -34,16 +32,7 @@ fun RecruitmentTitleSection(
             horizontalArrangement = Arrangement.spacedBy(4.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            ReadOnlyTextChip(
-                title = stringResource(category.labelRes),
-                containerColor = RebrandKoinTheme.colors.info200,
-                textStyle = RebrandKoinTheme.typography.regular10.copy(
-                    fontWeight = FontWeight.Medium,
-                    color = RebrandKoinTheme.colors.info700
-                ),
-                shape = RoundedCornerShape(percent = 50),
-                contentPadding = PaddingValues(horizontal = 8.dp, vertical = 1.dp)
-            )
+            RecruitmentCategoryBadge(category = category)
             Text(
                 text = dDayText(dDay = dDay, isClosed = isClosed),
                 style = RebrandKoinTheme.typography.regular10.copy(

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/RecruitmentMainScreen.kt
@@ -107,6 +107,7 @@ fun RecruitmentMainScreen(
         searchValue = state.searchValue,
         items = state.items,
         totalCount = state.totalCount,
+        isLoading = state.isLoading,
         isRefreshing = state.isRefreshing,
         onRefresh = { viewModel.fetchRecruitments(isRefresh = true) },
         isLoadingMore = state.isLoadingMore,
@@ -134,6 +135,7 @@ private fun RecruitmentMainScreenImpl(
     items: ImmutableList<RecruitmentItemModel>,
     totalCount: Long,
     filterState: RecruitmentFilterState,
+    isLoading: Boolean = false,
     isRefreshing: Boolean = false,
     onRefresh: () -> Unit = {},
     isLoadingMore: Boolean = false,
@@ -268,7 +270,14 @@ private fun RecruitmentMainScreenImpl(
                     )
                 }
             ) {
-                if (items.isEmpty()) {
+                if (isLoading) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator(color = RebrandKoinTheme.colors.primary500)
+                    }
+                } else if (items.isEmpty()) {
                     Box(
                         modifier = Modifier
                             .fillMaxSize()

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/component/RecruitmentChip.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/component/RecruitmentChip.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -21,15 +20,12 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
-import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
 
 @Immutable
 data class RecruitmentChipColors(
@@ -51,18 +47,6 @@ object RecruitmentChipDefaults {
         containerColor = containerColor,
         contentColor = contentColor
     )
-
-    @Composable
-    fun categoryColors(category: RecruitmentCategory): RecruitmentChipColors {
-        val palette = RebrandKoinTheme.colors
-        return when (category) {
-            RecruitmentCategory.CONTEST -> colors(palette.info200, palette.info700)
-            RecruitmentCategory.EXTERNAL_ACTIVITY -> colors(palette.success200, palette.success700)
-            RecruitmentCategory.STUDY -> colors(palette.primary100, palette.primary600)
-            RecruitmentCategory.PROJECT -> colors(palette.warning100, palette.warning700)
-            RecruitmentCategory.ETC -> colors(palette.neutral200, palette.neutral600)
-        }
-    }
 
     @Composable
     fun selectableColors(isSelected: Boolean): RecruitmentChipColors = colors(
@@ -137,19 +121,6 @@ fun RecruitmentChip(
 @Composable
 private fun RecruitmentChipPreview() {
     RebrandKoinTheme {
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-            RecruitmentChip(text = "프론트엔드 1명")
-            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                RecruitmentCategory.ALL.forEach { category ->
-                    RecruitmentChip(
-                        text = stringResource(category.labelRes),
-                        colors = RecruitmentChipDefaults.categoryColors(category),
-                        textStyle = RebrandKoinTheme.typography.regular10.copy(
-                            fontWeight = FontWeight.Medium
-                        )
-                    )
-                }
-            }
-        }
+        RecruitmentChip(text = "프론트엔드 1명")
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/component/RecruitmentMainItem.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/main/component/RecruitmentMainItem.kt
@@ -30,6 +30,7 @@ import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentLocation
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentRoleModel
 import `in`.koreatech.koin.feature.recruitment.model.RecruitmentStatus
+import `in`.koreatech.koin.feature.recruitment.ui.component.RecruitmentCategoryBadge
 import `in`.koreatech.koin.feature.recruitment.ui.main.model.RecruitmentItemModel
 import kotlinx.collections.immutable.persistentListOf
 
@@ -140,11 +141,7 @@ private fun RecruitmentItemHeader(
         horizontalArrangement = Arrangement.spacedBy(4.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        RecruitmentChip(
-            text = stringResource(item.category.labelRes),
-            colors = RecruitmentChipDefaults.categoryColors(item.category),
-            textStyle = labelStyle
-        )
+        RecruitmentCategoryBadge(category = item.category)
         Text(
             text = statusText,
             style = labelStyle,


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `RecruitmentMain`이 모집글 NavHost의 시작 화면이라 `navController.navigateUp()`이 pop할 대상이 없어 상단바 뒤로가기가 동작하지 않던 문제를, 다른 화면(club 등)과 동일하게 `popBackStack()` 실패 시 `Activity.finish()`로 처리하도록 수정했습니다.
- `RecruitmentMainState.isLoading`이 화면에 전달되지 않아 최초 로딩 중에도 "결과 없음" 빈 화면이 잠깐 보이던 문제를 로딩 스피너 분기 추가로 해결했습니다.
- 모집글 메인/상세 화면의 카테고리 칩 색상이 서로 달랐던 문제를 공용 `RecruitmentCategoryBadge` 컴포넌트로 통일했습니다. 더 이상 쓰이지 않는 `RecruitmentChipDefaults.categoryColors()`와 상세 화면의 하드코딩된 `ReadOnlyTextChip` 사용은 제거했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다