### PR TITLE
[Feature] 채용 알림 화면 채팅방/내 지원 목록 이동 연결

### DIFF
--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -108,8 +108,20 @@ fun NavGraphBuilder.koinRecruitmentGraph(
             onBack = { navController.popBackStack() },
             onNavigateToApplicantManagement = { recruitmentId ->
                 navController.navigate(RecruitmentNavType.ApplicantManagement(recruitmentId))
+            },
+            onNavigateToGroupChat = { recruitmentId, chatRoomId ->
+                navController.navigate(
+                    RecruitmentNavType.RecruitmentGroupChat(recruitmentId = recruitmentId, chatRoomId = chatRoomId)
+                )
+            },
+            onNavigateToDirectChat = { recruitmentId, applicationId ->
+                navController.navigate(
+                    RecruitmentNavType.RecruitmentDirectChat(recruitmentId = recruitmentId, applicationId = applicationId)
+                )
+            },
+            onNavigateToMyAppliedRecruitment = {
+                navController.navigate(RecruitmentNavType.MyAppliedRecruitment)
             }
-            // TODO: CHAT_ROOM / MY_APPLICATIONS / 모집글 상세 라우트가 추가되면 콜백을 추가 연결한다.
         )
     }
     composable<RecruitmentNavType.ApplicantManagement> { backStackEntry ->

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationScreen.kt
@@ -46,6 +46,9 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 internal fun RecruitmentNotificationScreen(
     onBack: () -> Unit = {},
     onNavigateToApplicantManagement: (Int) -> Unit = {},
+    onNavigateToGroupChat: (recruitmentId: Int, chatRoomId: Int) -> Unit = { _, _ -> },
+    onNavigateToDirectChat: (recruitmentId: Int, applicationId: Int) -> Unit = { _, _ -> },
+    onNavigateToMyAppliedRecruitment: () -> Unit = {},
     viewModel: RecruitmentNotificationViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.collectAsState()
@@ -60,6 +63,18 @@ internal fun RecruitmentNotificationScreen(
 
             is RecruitmentNotificationSideEffect.NavigateToApplicantManagement -> {
                 onNavigateToApplicantManagement(sideEffect.recruitmentId)
+            }
+
+            is RecruitmentNotificationSideEffect.NavigateToGroupChat -> {
+                onNavigateToGroupChat(sideEffect.recruitmentId, sideEffect.chatRoomId)
+            }
+
+            is RecruitmentNotificationSideEffect.NavigateToDirectChat -> {
+                onNavigateToDirectChat(sideEffect.recruitmentId, sideEffect.applicationId)
+            }
+
+            RecruitmentNotificationSideEffect.NavigateToMyAppliedRecruitment -> {
+                onNavigateToMyAppliedRecruitment()
             }
 
             RecruitmentNotificationSideEffect.Deleted -> {

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationSideEffect.kt
@@ -3,5 +3,8 @@ package `in`.koreatech.koin.feature.recruitment.ui.notification
 internal sealed class RecruitmentNotificationSideEffect {
     data object Error : RecruitmentNotificationSideEffect()
     data class NavigateToApplicantManagement(val recruitmentId: Int) : RecruitmentNotificationSideEffect()
+    data class NavigateToGroupChat(val recruitmentId: Int, val chatRoomId: Int) : RecruitmentNotificationSideEffect()
+    data class NavigateToDirectChat(val recruitmentId: Int, val applicationId: Int) : RecruitmentNotificationSideEffect()
+    data object NavigateToMyAppliedRecruitment : RecruitmentNotificationSideEffect()
     data object Deleted : RecruitmentNotificationSideEffect()
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/RecruitmentNotificationViewModel.kt
@@ -91,8 +91,24 @@ internal class RecruitmentNotificationViewModel @Inject constructor(
             "APPLICANT_MANAGEMENT" -> postSideEffect(
                 RecruitmentNotificationSideEffect.NavigateToApplicantManagement(notification.recruitmentId)
             )
-            // TODO: CHAT_ROOM / MY_APPLICATIONS 라우트가 추가되면 연결한다.
-            "CHAT_ROOM", "MY_APPLICATIONS", "NONE" -> Unit
+            "CHAT_ROOM" -> when {
+                // 지원서 기준 알림(승인/거절 등)은 1:1 다이렉트 채팅으로, 그 외 채팅 알림은 팀 그룹 채팅으로 연결한다.
+                notification.applicationId != null -> postSideEffect(
+                    RecruitmentNotificationSideEffect.NavigateToDirectChat(
+                        recruitmentId = notification.recruitmentId,
+                        applicationId = notification.applicationId
+                    )
+                )
+                notification.chatRoomId != null -> postSideEffect(
+                    RecruitmentNotificationSideEffect.NavigateToGroupChat(
+                        recruitmentId = notification.recruitmentId,
+                        chatRoomId = notification.chatRoomId
+                    )
+                )
+                else -> Unit
+            }
+            "MY_APPLICATIONS" -> postSideEffect(RecruitmentNotificationSideEffect.NavigateToMyAppliedRecruitment)
+            "NONE" -> Unit
         }
     }
 

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/notification/model/RecruitmentNotification.kt
@@ -13,7 +13,9 @@ internal data class RecruitmentNotification(
     val senderNickname: String?,
     val content: String,
     val timestamp: String,
-    val isRead: Boolean
+    val isRead: Boolean,
+    val applicationId: Int?,
+    val chatRoomId: Int?
 )
 
 internal fun DomainRecruitmentNotification.toUiModel(): RecruitmentNotification {
@@ -26,7 +28,9 @@ internal fun DomainRecruitmentNotification.toUiModel(): RecruitmentNotification 
         senderNickname = senderNickname,
         content = messagePreview,
         timestamp = createdAt.toDatetimeDiff(),
-        isRead = isRead
+        isRead = isRead,
+        applicationId = applicationId,
+        chatRoomId = chatRoomId
     )
 }
 


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
채용 알림 화면에서 미구현으로 남아있던 TODO(채팅방/내 지원 목록 이동)를 실제 네비게이션으로 연결했습니다.
- `applicationId` 존재 시 1:1 채팅으로, `chatRoomId` 존재 시 그룹 채팅으로 이동
- `MY_APPLICATIONS` 알림은 내 지원 목록 화면으로 이동

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다