### PR TITLE
[Feature] 지원자 관리/상세 화면 mock data를 실제 API 연동으로 교체

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/api/auth/RecruitmentAuthApi.kt
+++ b/data/src/main/java/in/koreatech/koin/data/api/auth/RecruitmentAuthApi.kt
@@ -4,6 +4,9 @@ import `in`.koreatech.koin.data.request.recruitment.RecruitmentUpdateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentApplicationRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentCreateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentProfileRequest
+import `in`.koreatech.koin.data.request.recruitment.UpdateApplicationStatusRequest
+import `in`.koreatech.koin.data.response.recruitment.ApplicantDetailResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicantListResponse
 import `in`.koreatech.koin.data.response.recruitment.MyAppliedRecruitmentListResponse
 import `in`.koreatech.koin.data.response.recruitment.MyRecruitmentListResponse
 import `in`.koreatech.koin.data.response.recruitment.RecruitmentDetailResponse
@@ -106,4 +109,25 @@ interface RecruitmentAuthApi {
         @Path("recruitmentId") recruitmentId: Int,
         @Body request: TeamRecruitmentApplicationRequest
     ): Response<TeamRecruitmentApplicationResponse>
+
+    @GET("team-recruitments/{recruitmentId}/applications")
+    suspend fun getApplicants(
+        @Path("recruitmentId") recruitmentId: Int,
+        @Query("statuses") statuses: List<String>? = null,
+        @Query("page") page: Int? = 1,
+        @Query("limit") limit: Int? = 10
+    ): ApplicantListResponse
+
+    @GET("team-recruitments/{recruitmentId}/applications/{applicationId}")
+    suspend fun getApplicantDetail(
+        @Path("recruitmentId") recruitmentId: Int,
+        @Path("applicationId") applicationId: Int
+    ): ApplicantDetailResponse
+
+    @PUT("team-recruitments/{recruitmentId}/applications/{applicationId}/status")
+    suspend fun updateApplicationStatus(
+        @Path("recruitmentId") recruitmentId: Int,
+        @Path("applicationId") applicationId: Int,
+        @Body request: UpdateApplicationStatusRequest
+    ): Response<Unit>
 }

--- a/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
@@ -3,6 +3,11 @@
 import `in`.koreatech.koin.data.request.recruitment.RecruitmentUpdateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentActivityRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentRoleRequest
+import `in`.koreatech.koin.data.response.recruitment.ApplicantDetailResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicantListResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicantRecruitmentResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicantSummaryResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicationRoleResponse
 import `in`.koreatech.koin.data.response.recruitment.MyAppliedRecruitmentResponse
 import `in`.koreatech.koin.data.response.recruitment.MyRecruitmentPostResponse
 import `in`.koreatech.koin.data.response.recruitment.RecruitmentApplicationResponse
@@ -16,6 +21,12 @@ import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentActivityResp
 import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentApplicationResponse
 import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentApplicationRoleResponse
 import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentProfileResponse
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantDetail
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantList
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantProfileSnapshot
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantRecruitment
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantSummary
+import `in`.koreatech.koin.domain.model.recruitment.ApplicationRole
 import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitment
 import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPost
 import `in`.koreatech.koin.domain.model.recruitment.Recruitment
@@ -215,4 +226,65 @@ fun TeamRecruitmentApplicationResponse.toTeamRecruitmentApplication() = TeamRecr
 fun TeamRecruitmentApplicationRoleResponse.toTeamRecruitmentApplicationRole() = TeamRecruitmentApplicationRole(
     id = id,
     name = name
+)
+
+fun ApplicationRoleResponse.toApplicationRole() = ApplicationRole(
+    id = id,
+    name = name
+)
+
+fun ApplicantRecruitmentResponse.toApplicantRecruitment() = ApplicantRecruitment(
+    id = id,
+    category = category,
+    title = title,
+    meetingType = meetingType,
+    activityStartDate = activityStartDate,
+    activityEndDate = activityEndDate,
+    deadlineDate = deadlineDate,
+    dDay = dDay,
+    status = status,
+    recruitmentType = recruitmentType,
+    currentParticipants = currentParticipants,
+    maxParticipants = maxParticipants,
+    roles = roles.map { it.toRecruitmentRole() },
+    teamChatAvailable = teamChatAvailable,
+    teamChatRoomId = teamChatRoomId
+)
+
+fun ApplicantSummaryResponse.toApplicantSummary() = ApplicantSummary(
+    applicationId = applicationId,
+    nickname = nickname,
+    department = department,
+    studentYear = studentYear,
+    role = role?.toApplicationRole(),
+    status = status,
+    canOpenDirectChat = canOpenDirectChat
+)
+
+fun ApplicantListResponse.toApplicantList() = ApplicantList(
+    recruitment = recruitment.toApplicantRecruitment(),
+    applications = applications.map { it.toApplicantSummary() },
+    totalCount = totalCount,
+    currentCount = currentCount,
+    totalPage = totalPage,
+    currentPage = currentPage
+)
+
+fun ApplicantDetailResponse.toApplicantDetail() = ApplicantDetail(
+    applicationId = applicationId,
+    status = status,
+    profileSnapshot = ApplicantProfileSnapshot(
+        nickname = profileSnapshot.nickname,
+        department = profileSnapshot.department,
+        studentYear = profileSnapshot.studentYear,
+        preferredRole = profileSnapshot.preferredRole,
+        skills = profileSnapshot.skills,
+        activities = profileSnapshot.activities.map { it.toTeamRecruitmentActivity() },
+        selfIntroduction = profileSnapshot.selfIntroduction
+    ),
+    motivation = motivation,
+    availability = availability,
+    role = role?.toApplicationRole(),
+    canDecide = canDecide,
+    canOpenDirectChat = canOpenDirectChat
 )

--- a/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentRepositoryImpl.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.koin.data.repository
 
+import `in`.koreatech.koin.data.mapper.toApplicantDetail
+import `in`.koreatech.koin.data.mapper.toApplicantList
 import `in`.koreatech.koin.data.mapper.toMyAppliedRecruitments
 import `in`.koreatech.koin.data.mapper.toMyRecruitmentPosts
 import `in`.koreatech.koin.data.mapper.toRecruitmentDetail
@@ -13,9 +15,12 @@ import `in`.koreatech.koin.data.mapper.toTeamRecruitmentRoleRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentApplicationRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentCreateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentProfileRequest
+import `in`.koreatech.koin.data.request.recruitment.UpdateApplicationStatusRequest
 import `in`.koreatech.koin.data.source.remote.RecruitmentRemoteDataSource
 import `in`.koreatech.koin.data.util.mapHttpFailure
 import `in`.koreatech.koin.domain.error.recruitment.KoinRecruitmentException
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantDetail
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantList
 import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
 import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentDetail
@@ -282,6 +287,59 @@ class RecruitmentRepositoryImpl @Inject constructor(
             on(409, "TEAM_RECRUITMENT_APPLICATION_DUPLICATE") throws
                 KoinRecruitmentException.ApplicationDuplicateException(errorResponse.message)
             on(409, "REQUEST_TOO_FAST") throws KoinRecruitmentException.RequestTooFastException(errorResponse.message)
+        }
+    }
+
+    override suspend fun getApplicants(
+        recruitmentId: Int,
+        statuses: List<String>?,
+        page: Int,
+        limit: Int
+    ): Result<ApplicantList> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.getApplicants(
+                recruitmentId = recruitmentId,
+                statuses = statuses,
+                page = page,
+                limit = limit
+            ).toApplicantList()
+        }.mapHttpFailure {
+            on(400, "ILLEGAL_ARGUMENT") throws KoinRecruitmentException.InvalidArgumentException(errorResponse.message)
+            on(401) throws KoinRecruitmentException.UnauthorizedUserException(errorResponse.message)
+            on(403, "TEAM_RECRUITMENT_FORBIDDEN") throws
+                KoinRecruitmentException.RecruitmentForbiddenException(errorResponse.message)
+        }
+    }
+
+    override suspend fun getApplicantDetail(recruitmentId: Int, applicationId: Int): Result<ApplicantDetail> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.getApplicantDetail(
+                recruitmentId = recruitmentId,
+                applicationId = applicationId
+            ).toApplicantDetail()
+        }.mapHttpFailure {
+            on(400, "ILLEGAL_ARGUMENT") throws KoinRecruitmentException.InvalidArgumentException(errorResponse.message)
+            on(401) throws KoinRecruitmentException.UnauthorizedUserException(errorResponse.message)
+            on(403, "TEAM_RECRUITMENT_FORBIDDEN") throws
+                KoinRecruitmentException.RecruitmentForbiddenException(errorResponse.message)
+        }
+    }
+
+    override suspend fun updateApplicationStatus(recruitmentId: Int, applicationId: Int, status: String): Result<Unit> {
+        return suspendRunCatching {
+            recruitmentRemoteDataSource.updateApplicationStatus(
+                recruitmentId = recruitmentId,
+                applicationId = applicationId,
+                request = UpdateApplicationStatusRequest(status = status)
+            )
+        }.mapHttpFailure {
+            on(400, "ILLEGAL_ARGUMENT") throws KoinRecruitmentException.InvalidArgumentException(errorResponse.message)
+            on(400, "INVALID_REQUEST_BODY") throws KoinRecruitmentException.InvalidRequestBodyException(errorResponse.message)
+            on(400, "NOT_READABLE_HTTP_MESSAGE") throws
+                KoinRecruitmentException.NotReadableHttpMessageException(errorResponse.message)
+            on(401) throws KoinRecruitmentException.UnauthorizedUserException(errorResponse.message)
+            on(403, "TEAM_RECRUITMENT_FORBIDDEN") throws
+                KoinRecruitmentException.RecruitmentForbiddenException(errorResponse.message)
         }
     }
 

--- a/data/src/main/java/in/koreatech/koin/data/request/recruitment/UpdateApplicationStatusRequest.kt
+++ b/data/src/main/java/in/koreatech/koin/data/request/recruitment/UpdateApplicationStatusRequest.kt
@@ -1,0 +1,7 @@
+package `in`.koreatech.koin.data.request.recruitment
+
+import com.google.gson.annotations.SerializedName
+
+data class UpdateApplicationStatusRequest(
+    @SerializedName("status") val status: String
+)

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/ApplicantDetailResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/ApplicantDetailResponse.kt
@@ -1,0 +1,39 @@
+package `in`.koreatech.koin.data.response.recruitment
+
+import com.google.gson.annotations.SerializedName
+
+data class ApplicantDetailResponse(
+    @SerializedName("application_id")
+    val applicationId: Int,
+    @SerializedName("status")
+    val status: String,
+    @SerializedName("profile_snapshot")
+    val profileSnapshot: ProfileSnapshotResponse,
+    @SerializedName("motivation")
+    val motivation: String,
+    @SerializedName("availability")
+    val availability: String,
+    @SerializedName("role")
+    val role: ApplicationRoleResponse?,
+    @SerializedName("can_decide")
+    val canDecide: Boolean,
+    @SerializedName("can_open_direct_chat")
+    val canOpenDirectChat: Boolean
+)
+
+data class ProfileSnapshotResponse(
+    @SerializedName("nickname")
+    val nickname: String,
+    @SerializedName("department")
+    val department: String,
+    @SerializedName("student_year")
+    val studentYear: Int,
+    @SerializedName("preferred_role")
+    val preferredRole: String,
+    @SerializedName("skills")
+    val skills: List<String>,
+    @SerializedName("activities")
+    val activities: List<TeamRecruitmentActivityResponse>,
+    @SerializedName("self_introduction")
+    val selfIntroduction: String
+)

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/ApplicantListResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/ApplicantListResponse.kt
@@ -1,0 +1,75 @@
+package `in`.koreatech.koin.data.response.recruitment
+
+import com.google.gson.annotations.SerializedName
+
+data class ApplicantListResponse(
+    @SerializedName("recruitment")
+    val recruitment: ApplicantRecruitmentResponse,
+    @SerializedName("applications")
+    val applications: List<ApplicantSummaryResponse>,
+    @SerializedName("total_count")
+    val totalCount: Int,
+    @SerializedName("current_count")
+    val currentCount: Int,
+    @SerializedName("total_page")
+    val totalPage: Int,
+    @SerializedName("current_page")
+    val currentPage: Int
+)
+
+data class ApplicantRecruitmentResponse(
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("category")
+    val category: String,
+    @SerializedName("title")
+    val title: String,
+    @SerializedName("meeting_type")
+    val meetingType: String,
+    @SerializedName("activity_start_date")
+    val activityStartDate: String,
+    @SerializedName("activity_end_date")
+    val activityEndDate: String,
+    @SerializedName("deadline_date")
+    val deadlineDate: String,
+    @SerializedName("d_day")
+    val dDay: Int?,
+    @SerializedName("status")
+    val status: String,
+    @SerializedName("recruitment_type")
+    val recruitmentType: String,
+    @SerializedName("current_participants")
+    val currentParticipants: Int,
+    @SerializedName("max_participants")
+    val maxParticipants: Int,
+    @SerializedName("roles")
+    val roles: List<RecruitmentRoleResponse>,
+    @SerializedName("team_chat_available")
+    val teamChatAvailable: Boolean,
+    @SerializedName("team_chat_room_id")
+    val teamChatRoomId: Int?
+)
+
+data class ApplicantSummaryResponse(
+    @SerializedName("application_id")
+    val applicationId: Int,
+    @SerializedName("nickname")
+    val nickname: String,
+    @SerializedName("department")
+    val department: String,
+    @SerializedName("student_year")
+    val studentYear: Int,
+    @SerializedName("role")
+    val role: ApplicationRoleResponse?,
+    @SerializedName("status")
+    val status: String,
+    @SerializedName("can_open_direct_chat")
+    val canOpenDirectChat: Boolean
+)
+
+data class ApplicationRoleResponse(
+    @SerializedName("id")
+    val id: Int,
+    @SerializedName("name")
+    val name: String
+)

--- a/data/src/main/java/in/koreatech/koin/data/source/remote/RecruitmentRemoteDataSource.kt
+++ b/data/src/main/java/in/koreatech/koin/data/source/remote/RecruitmentRemoteDataSource.kt
@@ -5,6 +5,9 @@ import `in`.koreatech.koin.data.request.recruitment.RecruitmentUpdateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentApplicationRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentCreateRequest
 import `in`.koreatech.koin.data.request.recruitment.TeamRecruitmentProfileRequest
+import `in`.koreatech.koin.data.request.recruitment.UpdateApplicationStatusRequest
+import `in`.koreatech.koin.data.response.recruitment.ApplicantDetailResponse
+import `in`.koreatech.koin.data.response.recruitment.ApplicantListResponse
 import `in`.koreatech.koin.data.response.recruitment.MyAppliedRecruitmentListResponse
 import `in`.koreatech.koin.data.response.recruitment.MyRecruitmentListResponse
 import `in`.koreatech.koin.data.response.recruitment.TeamRecruitmentApplicationResponse
@@ -120,5 +123,38 @@ class RecruitmentRemoteDataSource @Inject constructor(
         val response = recruitmentAuthApi.applyTeamRecruitment(recruitmentId, request)
         if (!response.isSuccessful) throw HttpException(response)
         return response.body()!!
+    }
+
+    suspend fun getApplicants(
+        recruitmentId: Int,
+        statuses: List<String>?,
+        page: Int?,
+        limit: Int?
+    ): ApplicantListResponse = recruitmentAuthApi.getApplicants(
+        recruitmentId = recruitmentId,
+        statuses = statuses,
+        page = page,
+        limit = limit
+    )
+
+    suspend fun getApplicantDetail(
+        recruitmentId: Int,
+        applicationId: Int
+    ): ApplicantDetailResponse = recruitmentAuthApi.getApplicantDetail(
+        recruitmentId = recruitmentId,
+        applicationId = applicationId
+    )
+
+    suspend fun updateApplicationStatus(
+        recruitmentId: Int,
+        applicationId: Int,
+        request: UpdateApplicationStatusRequest
+    ) {
+        val response = recruitmentAuthApi.updateApplicationStatus(
+            recruitmentId = recruitmentId,
+            applicationId = applicationId,
+            request = request
+        )
+        if (!response.isSuccessful) throw HttpException(response)
     }
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/Applicant.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/Applicant.kt
@@ -1,0 +1,64 @@
+package `in`.koreatech.koin.domain.model.recruitment
+
+data class ApplicationRole(
+    val id: Int,
+    val name: String
+)
+
+data class ApplicantRecruitment(
+    val id: Int,
+    val category: String,
+    val title: String,
+    val meetingType: String,
+    val activityStartDate: String,
+    val activityEndDate: String,
+    val deadlineDate: String,
+    val dDay: Int?,
+    val status: String,
+    val recruitmentType: String,
+    val currentParticipants: Int,
+    val maxParticipants: Int,
+    val roles: List<RecruitmentRole>,
+    val teamChatAvailable: Boolean,
+    val teamChatRoomId: Int?
+)
+
+data class ApplicantSummary(
+    val applicationId: Int,
+    val nickname: String,
+    val department: String,
+    val studentYear: Int,
+    val role: ApplicationRole?,
+    val status: String,
+    val canOpenDirectChat: Boolean
+)
+
+data class ApplicantList(
+    val recruitment: ApplicantRecruitment,
+    val applications: List<ApplicantSummary>,
+    val totalCount: Int,
+    val currentCount: Int,
+    val totalPage: Int,
+    val currentPage: Int
+)
+
+data class ApplicantProfileSnapshot(
+    val nickname: String,
+    val department: String,
+    val studentYear: Int,
+    val preferredRole: String,
+    val skills: List<String>,
+    val activities: List<TeamRecruitmentActivity>,
+    val selfIntroduction: String
+)
+
+data class ApplicantDetail(
+    val applicationId: Int,
+    val status: String,
+    val profileSnapshot: ApplicantProfileSnapshot,
+    val motivation: String,
+    val availability: String,
+    val role: ApplicationRole?,
+    val canDecide: Boolean,
+    val canOpenDirectChat: Boolean
+)

--- a/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/repository/RecruitmentRepository.kt
@@ -1,5 +1,7 @@
 package `in`.koreatech.koin.domain.repository
 
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantDetail
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantList
 import `in`.koreatech.koin.domain.model.recruitment.MyAppliedRecruitments
 import `in`.koreatech.koin.domain.model.recruitment.MyRecruitmentPosts
 import `in`.koreatech.koin.domain.model.recruitment.RecruitmentDetail
@@ -84,4 +86,15 @@ interface RecruitmentRepository {
         motivation: String,
         availability: String
     ): Result<TeamRecruitmentApplication>
+
+    suspend fun getApplicants(
+        recruitmentId: Int,
+        statuses: List<String>?,
+        page: Int,
+        limit: Int
+    ): Result<ApplicantList>
+
+    suspend fun getApplicantDetail(recruitmentId: Int, applicationId: Int): Result<ApplicantDetail>
+
+    suspend fun updateApplicationStatus(recruitmentId: Int, applicationId: Int, status: String): Result<Unit>
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetApplicantDetailUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetApplicantDetailUseCase.kt
@@ -1,0 +1,12 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantDetail
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class GetApplicantDetailUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(recruitmentId: Int, applicationId: Int): Result<ApplicantDetail> =
+        recruitmentRepository.getApplicantDetail(recruitmentId = recruitmentId, applicationId = applicationId)
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetApplicantsUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/GetApplicantsUseCase.kt
@@ -1,0 +1,21 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantList
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class GetApplicantsUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(
+        recruitmentId: Int,
+        statuses: List<String>? = null,
+        page: Int = 1,
+        limit: Int = 20
+    ): Result<ApplicantList> = recruitmentRepository.getApplicants(
+        recruitmentId = recruitmentId,
+        statuses = statuses,
+        page = page,
+        limit = limit
+    )
+}

--- a/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/UpdateApplicationStatusUseCase.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/usecase/recruitment/UpdateApplicationStatusUseCase.kt
@@ -1,0 +1,15 @@
+package `in`.koreatech.koin.domain.usecase.recruitment
+
+import `in`.koreatech.koin.domain.repository.RecruitmentRepository
+import javax.inject.Inject
+
+class UpdateApplicationStatusUseCase @Inject constructor(
+    private val recruitmentRepository: RecruitmentRepository
+) {
+    suspend operator fun invoke(recruitmentId: Int, applicationId: Int, status: String): Result<Unit> =
+        recruitmentRepository.updateApplicationStatus(
+            recruitmentId = recruitmentId,
+            applicationId = applicationId,
+            status = status
+        )
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailScreen.kt
@@ -55,7 +55,7 @@ fun ApplicantDetailScreen(
             )
         },
         bottomBar = {
-            if (applicant != null) {
+            if (applicant != null && applicant.canDecide) {
                 ApplicantDecisionButtons(
                     onReject = { viewModel.showRejectDialog() },
                     onApprove = { viewModel.showApproveDialog() },

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailSideEffect.kt
@@ -1,3 +1,5 @@
 package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail
 
-sealed interface ApplicantDetailSideEffect
+sealed interface ApplicantDetailSideEffect {
+    data object Error : ApplicantDetailSideEffect
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailState.kt
@@ -6,6 +6,7 @@ import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.Applican
 @Immutable
 data class ApplicantDetailState(
     val applicant: ApplicantDetail? = null,
+    val isLoading: Boolean = false,
     val showApproveDialog: Boolean = false,
     val showRejectDialog: Boolean = false
 )

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/ApplicantDetailViewModel.kt
@@ -4,47 +4,46 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.domain.usecase.recruitment.GetApplicantDetailUseCase
+import `in`.koreatech.koin.domain.usecase.recruitment.UpdateApplicationStatusUseCase
 import `in`.koreatech.koin.feature.recruitment.navigation.RecruitmentNavType
-import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantActivity
-import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.ApplicantDetail
+import `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model.toUiModel
 import javax.inject.Inject
-import kotlinx.collections.immutable.persistentListOf
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
 
+private const val STATUS_ACCEPTED = "ACCEPTED"
+private const val STATUS_REJECTED = "REJECTED"
+
 @HiltViewModel
 class ApplicantDetailViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val getApplicantDetailUseCase: GetApplicantDetailUseCase,
+    private val updateApplicationStatusUseCase: UpdateApplicationStatusUseCase
 ) : ViewModel(), ContainerHost<ApplicantDetailState, ApplicantDetailSideEffect> {
 
     private val route = savedStateHandle.toRoute<RecruitmentNavType.ApplicantDetail>()
 
     override val container = container<ApplicantDetailState, ApplicantDetailSideEffect>(
-        ApplicantDetailState(
-            applicant = ApplicantDetail(
-                id = route.applicantId,
-                name = "김철수",
-                role = "프론트엔드",
-                department = "컴퓨터공학부",
-                studentNumber = "23학번",
-                status = ApplicantStatus.PENDING,
-                skills = persistentListOf("정보처리기사"),
-                activities = persistentListOf(
-                    ApplicantActivity(
-                        title = "AI 공모전",
-                        period = "2026.03.23 - 2026.04.06",
-                        content = "AI 공모전에서 기획을 담당했고 @@@를 주제로 @@@를 만들었습니다"
-                    )
-                ),
-                introduction = "안녕하세요.",
-                motivation = "안녕하세요.",
-                availableTime = "월 수 금 20시 이후"
-            )
-        )
-    )
+        ApplicantDetailState()
+    ) {
+        loadApplicantDetail()
+    }
+
+    fun loadApplicantDetail() = intent {
+        reduce { state.copy(isLoading = true) }
+        getApplicantDetailUseCase(recruitmentId = route.postId, applicationId = route.applicantId)
+            .onSuccess { applicantDetail ->
+                reduce { state.copy(applicant = applicantDetail.toUiModel(), isLoading = false) }
+            }
+            .onFailure {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(ApplicantDetailSideEffect.Error)
+            }
+    }
 
     fun showApproveDialog() = intent {
         reduce { state.copy(showApproveDialog = true) }
@@ -63,20 +62,30 @@ class ApplicantDetailViewModel @Inject constructor(
     }
 
     fun approve() = intent {
-        reduce {
-            state.copy(
-                showApproveDialog = false,
-                applicant = state.applicant?.copy(status = ApplicantStatus.APPROVED)
-            )
-        }
+        reduce { state.copy(showApproveDialog = false) }
+        updateApplicationStatusUseCase(
+            recruitmentId = route.postId,
+            applicationId = route.applicantId,
+            status = STATUS_ACCEPTED
+        )
+            .onSuccess {
+                getApplicantDetailUseCase(recruitmentId = route.postId, applicationId = route.applicantId)
+                    .onSuccess { applicantDetail -> reduce { state.copy(applicant = applicantDetail.toUiModel()) } }
+            }
+            .onFailure { postSideEffect(ApplicantDetailSideEffect.Error) }
     }
 
     fun reject() = intent {
-        reduce {
-            state.copy(
-                showRejectDialog = false,
-                applicant = state.applicant?.copy(status = ApplicantStatus.REJECTED)
-            )
-        }
+        reduce { state.copy(showRejectDialog = false) }
+        updateApplicationStatusUseCase(
+            recruitmentId = route.postId,
+            applicationId = route.applicantId,
+            status = STATUS_REJECTED
+        )
+            .onSuccess {
+                getApplicantDetailUseCase(recruitmentId = route.postId, applicationId = route.applicantId)
+                    .onSuccess { applicantDetail -> reduce { state.copy(applicant = applicantDetail.toUiModel()) } }
+            }
+            .onFailure { postSideEffect(ApplicantDetailSideEffect.Error) }
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/model/ApplicantDetail.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantdetail/model/ApplicantDetail.kt
@@ -1,8 +1,13 @@
 package `in`.koreatech.koin.feature.recruitment.ui.applicantdetail.model
 
 import androidx.compose.runtime.Immutable
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantDetail as DomainApplicantDetail
+import `in`.koreatech.koin.domain.model.recruitment.TeamRecruitmentActivity
 import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model.toApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model.toStudentNumberLabel
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 
 @Immutable
 data class ApplicantDetail(
@@ -16,7 +21,8 @@ data class ApplicantDetail(
     val activities: ImmutableList<ApplicantActivity>,
     val introduction: String,
     val motivation: String,
-    val availableTime: String
+    val availableTime: String,
+    val canDecide: Boolean = true
 )
 
 @Immutable
@@ -25,3 +31,29 @@ data class ApplicantActivity(
     val period: String,
     val content: String
 )
+
+fun DomainApplicantDetail.toUiModel(): ApplicantDetail {
+    val profile = profileSnapshot
+    return ApplicantDetail(
+        id = applicationId,
+        name = profile.nickname,
+        role = role?.name ?: profile.preferredRole,
+        department = profile.department,
+        studentNumber = profile.studentYear.toStudentNumberLabel(),
+        status = status.toApplicantStatus(),
+        skills = profile.skills.toImmutableList(),
+        activities = profile.activities.map { it.toApplicantActivity() }.toImmutableList(),
+        introduction = profile.selfIntroduction,
+        motivation = motivation,
+        availableTime = availability,
+        canDecide = canDecide
+    )
+}
+
+private fun TeamRecruitmentActivity.toApplicantActivity() = ApplicantActivity(
+    title = title,
+    period = "${startedAt.toDotDate()} - ${endedAt?.toDotDate() ?: "진행중"}",
+    content = description
+)
+
+private fun String.toDotDate(): String = replace("-", ".")

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementSideEffect.kt
@@ -1,3 +1,5 @@
 package `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement
 
-sealed interface ApplicantManagementSideEffect
+sealed interface ApplicantManagementSideEffect {
+    data object Error : ApplicantManagementSideEffect
+}

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementState.kt
@@ -9,5 +9,6 @@ import kotlinx.collections.immutable.persistentListOf
 @Immutable
 data class ApplicantManagementState(
     val post: MyRecruitmentPost? = null,
-    val applicants: ImmutableList<Applicant> = persistentListOf()
+    val applicants: ImmutableList<Applicant> = persistentListOf(),
+    val isLoading: Boolean = false
 )

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementViewModel.kt
@@ -4,46 +4,49 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.navigation.toRoute
 import dagger.hilt.android.lifecycle.HiltViewModel
-import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
-import `in`.koreatech.koin.feature.recruitment.model.RecruitmentCategory
+import `in`.koreatech.koin.domain.usecase.recruitment.GetApplicantsUseCase
 import `in`.koreatech.koin.feature.recruitment.navigation.RecruitmentNavType
-import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model.Applicant
-import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.MyRecruitmentPost
-import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.RecruitmentStatus
+import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model.toApplicant
+import `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model.toMyRecruitmentPost
 import javax.inject.Inject
-import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
+
+private const val APPLICANTS_PAGE_SIZE = 20
 
 @HiltViewModel
 class ApplicantManagementViewModel @Inject constructor(
-    savedStateHandle: SavedStateHandle
+    savedStateHandle: SavedStateHandle,
+    private val getApplicantsUseCase: GetApplicantsUseCase
 ) : ViewModel(), ContainerHost<ApplicantManagementState, ApplicantManagementSideEffect> {
 
     private val postId = savedStateHandle.toRoute<RecruitmentNavType.ApplicantManagement>().postId
 
     override val container = container<ApplicantManagementState, ApplicantManagementSideEffect>(
-        ApplicantManagementState(
-            post = MyRecruitmentPost(
-                id = postId,
-                category = RecruitmentCategory.CONTEST,
-                status = RecruitmentStatus.Recruiting(daysLeft = 5),
-                title = "AI 아이디어 공모전 팀원 모집",
-                location = "온라인",
-                dateRange = "2026.07.26 ~ 2026.08.07",
-                currentApplicants = 0,
-                maxApplicants = 3
-            ),
-            applicants = persistentListOf(
-                Applicant(
-                    id = 1,
-                    name = "김철수",
-                    role = "프론트엔드",
-                    department = "컴퓨터공학부",
-                    studentNumber = "23학번",
-                    status = ApplicantStatus.PENDING
-                )
-            )
-        )
-    )
+        ApplicantManagementState()
+    ) {
+        loadApplicants()
+    }
+
+    fun loadApplicants() = intent {
+        reduce { state.copy(isLoading = true) }
+        getApplicantsUseCase(recruitmentId = postId, page = 1, limit = APPLICANTS_PAGE_SIZE)
+            .onSuccess { applicantList ->
+                reduce {
+                    state.copy(
+                        post = applicantList.recruitment.toMyRecruitmentPost(),
+                        applicants = applicantList.applications.map { it.toApplicant() }.toImmutableList(),
+                        isLoading = false
+                    )
+                }
+            }
+            .onFailure {
+                reduce { state.copy(isLoading = false) }
+                postSideEffect(ApplicantManagementSideEffect.Error)
+            }
+    }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/model/Applicant.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/model/Applicant.kt
@@ -1,7 +1,14 @@
 package `in`.koreatech.koin.feature.recruitment.ui.applicantmanagement.model
 
 import androidx.compose.runtime.Immutable
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantRecruitment as DomainApplicantRecruitment
+import `in`.koreatech.koin.domain.model.recruitment.ApplicantSummary as DomainApplicantSummary
 import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
+import `in`.koreatech.koin.feature.recruitment.model.toDateRange
+import `in`.koreatech.koin.feature.recruitment.model.toRecruitmentCategory
+import `in`.koreatech.koin.feature.recruitment.model.toRecruitmentLocation
+import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.MyRecruitmentPost
+import `in`.koreatech.koin.feature.recruitment.ui.myrecruitment.model.RecruitmentStatus
 
 @Immutable
 data class Applicant(
@@ -12,4 +19,35 @@ data class Applicant(
     val studentNumber: String,
     val status: ApplicantStatus,
     val hasChatRoom: Boolean = false
+)
+
+fun DomainApplicantSummary.toApplicant() = Applicant(
+    id = applicationId,
+    name = nickname,
+    role = role?.name.orEmpty(),
+    department = department,
+    studentNumber = studentYear.toStudentNumberLabel(),
+    status = status.toApplicantStatus(),
+    hasChatRoom = canOpenDirectChat
+)
+
+internal fun Int.toStudentNumberLabel(): String = "${this % 100}학번"
+
+internal fun String.toApplicantStatus(): ApplicantStatus = when (this) {
+    "ACCEPTED" -> ApplicantStatus.APPROVED
+    "REJECTED" -> ApplicantStatus.REJECTED
+    else -> ApplicantStatus.PENDING
+}
+
+fun DomainApplicantRecruitment.toMyRecruitmentPost() = MyRecruitmentPost(
+    id = id,
+    category = category.toRecruitmentCategory(),
+    status = dDay?.takeIf { status == "RECRUITING" }
+        ?.let { RecruitmentStatus.Recruiting(it) }
+        ?: RecruitmentStatus.Complete,
+    title = title,
+    location = meetingType.toRecruitmentLocation(),
+    dateRange = activityStartDate.toDateRange(activityEndDate),
+    currentApplicants = currentParticipants,
+    maxApplicants = maxParticipants
 )


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [ ] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
지원자 관리 화면과 지원자 상세 화면에 남아있던 mock data를 실제 API 연동으로 교체했습니다.
- `GET /team-recruitments/{recruitmentId}/applications` 연동 (지원자 목록)
- `GET /team-recruitments/{recruitmentId}/applications/{applicationId}` 연동 (지원자 상세)
- `PUT /team-recruitments/{recruitmentId}/applications/{applicationId}/status` 연동 (승인/거절)
- 위 API에 대응하는 domain 모델, UseCase(`GetApplicantsUseCase`, `GetApplicantDetailUseCase`, `UpdateApplicationStatusUseCase`), data DTO/Mapper/RemoteDataSource/RepositoryImpl 추가
- `ApplicantManagementViewModel`, `ApplicantDetailViewModel`을 Orbit MVI로 재배선

### 논의 사항

### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다