### PR TITLE
[Feature] 지원자 목록 채팅 아이콘 noRippleClickable 적용 및 1:1 채팅 연결

### DIFF
--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -118,6 +118,11 @@ fun NavGraphBuilder.koinRecruitmentGraph(
             onNavigateUp = { navController.navigateUp() },
             onApplicantDetail = { applicantId ->
                 navController.navigate(RecruitmentNavType.ApplicantDetail(route.postId, applicantId))
+            },
+            onApplicantChat = { applicantId ->
+                navController.navigate(
+                    RecruitmentNavType.RecruitmentDirectChat(recruitmentId = route.postId, applicationId = applicantId)
+                )
             }
         )
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/ApplicantManagementScreen.kt
@@ -46,6 +46,7 @@ fun ApplicantManagementScreen(
     onNavigateUp: () -> Unit = {},
     onChat: () -> Unit = {},
     onApplicantDetail: (Int) -> Unit = {},
+    onApplicantChat: (Int) -> Unit = {},
     onMoreOptions: () -> Unit = {}
 ) {
     val state by viewModel.collectAsState()
@@ -76,6 +77,7 @@ fun ApplicantManagementScreen(
             applicants = state.applicants,
             onChat = onChat,
             onApplicantDetail = onApplicantDetail,
+            onApplicantChat = onApplicantChat,
             modifier = Modifier.padding(innerPadding)
         )
     }
@@ -87,7 +89,8 @@ private fun ApplicantManagementScreenImpl(
     applicants: ImmutableList<Applicant>,
     modifier: Modifier = Modifier,
     onChat: () -> Unit = {},
-    onApplicantDetail: (Int) -> Unit = {}
+    onApplicantDetail: (Int) -> Unit = {},
+    onApplicantChat: (Int) -> Unit = {}
 ) {
     LazyColumn(
         modifier = modifier.fillMaxSize(),
@@ -126,7 +129,8 @@ private fun ApplicantManagementScreenImpl(
             items(applicants, key = { it.id }) { applicant ->
                 ApplicantListItem(
                     applicant = applicant,
-                    onClick = { onApplicantDetail(applicant.id) }
+                    onClick = { onApplicantDetail(applicant.id) },
+                    onChatClick = { onApplicantChat(applicant.id) }
                 )
             }
         }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/component/ApplicantListItem.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/applicantmanagement/component/ApplicantListItem.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import `in`.koreatech.koin.core.designsystem.noRippleClickable
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
 import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.model.ApplicantStatus
@@ -31,7 +32,8 @@ import `in`.koreatech.koin.feature.recruitment.ui.component.ApplicantStatusText
 fun ApplicantListItem(
     applicant: Applicant,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onChatClick: () -> Unit = {}
 ) {
     Row(
         modifier = modifier
@@ -68,7 +70,9 @@ fun ApplicantListItem(
                         imageVector = ImageVector.vectorResource(R.drawable.ic_recruitment_chat),
                         contentDescription = null,
                         tint = RebrandKoinTheme.colors.primary500,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier
+                            .size(20.dp)
+                            .noRippleClickable { onChatClick() }
                     )
                 }
             }


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
지원자 관리 화면의 지원자별 채팅 아이콘에 클릭 핸들러가 없던 것을 `noRippleClickable`로 연결하고, 해당 지원자와의 1:1 채팅 화면으로 이동하도록 네비게이션을 연결했습니다.

### 논의 사항

### 스크린샷

## 추가내용
- [ ] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다