### PR TITLE
[Fix] 내가 지원한 모집글 API 오류 수정 및 빈 화면/채팅 이동 추가

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentMapper.kt
@@ -47,7 +47,7 @@ fun MyAppliedRecruitmentResponse.toMyAppliedRecruitment() = MyAppliedRecruitment
     teamChatAvailable = teamChatAvailable,
     teamChatRoomId = teamChatRoomId,
     directChatRoomId = directChatRoomId,
-    roleName = roleName,
+    role = role?.toTeamRecruitmentApplicationRole(),
     recruitment = recruitment.toRecruitment()
 )
 

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/MyAppliedRecruitmentResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/MyAppliedRecruitmentResponse.kt
@@ -16,6 +16,6 @@ data class MyAppliedRecruitmentResponse(
     @SerializedName("team_chat_available") val teamChatAvailable: Boolean,
     @SerializedName("team_chat_room_id") val teamChatRoomId: Int?,
     @SerializedName("direct_chat_room_id") val directChatRoomId: Int?,
-    @SerializedName("role_name") val roleName: String,
+    @SerializedName("role") val role: TeamRecruitmentApplicationRoleResponse?,
     @SerializedName("recruitment") val recruitment: RecruitmentResponse
 )

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyAppliedRecruitment.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/MyAppliedRecruitment.kt
@@ -6,6 +6,6 @@ data class MyAppliedRecruitment(
     val teamChatAvailable: Boolean,
     val teamChatRoomId: Int?,
     val directChatRoomId: Int?,
-    val roleName: String,
+    val role: TeamRecruitmentApplicationRole?,
     val recruitment: Recruitment
 )

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/navigation/Navigation.kt
@@ -176,6 +176,14 @@ fun NavGraphBuilder.koinRecruitmentGraph(
                 navigator.navigateToSignIn(context).apply {
                     context.startActivity(this)
                 }
+            },
+            onNavigateToMain = {
+                navController.popBackStack(RecruitmentNavType.RecruitmentMain, inclusive = false)
+            },
+            onNavigateToGroupChat = { recruitmentId, chatRoomId ->
+                navController.navigate(
+                    RecruitmentNavType.RecruitmentGroupChat(recruitmentId = recruitmentId, chatRoomId = chatRoomId)
+                )
             }
         )
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentEmptyState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/component/RecruitmentEmptyState.kt
@@ -1,15 +1,21 @@
 package `in`.koreatech.koin.feature.recruitment.ui.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.style.TextAlign
@@ -22,7 +28,9 @@ import `in`.koreatech.koin.feature.recruitment.R
 fun RecruitmentEmptyState(
     title: String,
     subtitle: String,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    buttonText: String? = null,
+    onButtonClick: () -> Unit = {}
 ) {
     Column(
         modifier = modifier,
@@ -48,6 +56,24 @@ fun RecruitmentEmptyState(
             color = RebrandKoinTheme.colors.neutral500,
             textAlign = TextAlign.Center
         )
+        if (buttonText != null) {
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = buttonText,
+                style = RebrandKoinTheme.typography.medium16,
+                color = RebrandKoinTheme.colors.primary600,
+                modifier = Modifier
+                    .clip(RoundedCornerShape(999.dp))
+                    .background(RebrandKoinTheme.colors.neutral50)
+                    .border(
+                        width = 1.dp,
+                        color = RebrandKoinTheme.colors.primary400,
+                        shape = RoundedCornerShape(999.dp)
+                    )
+                    .clickable(onClick = onButtonClick)
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            )
+        }
     }
 }
 
@@ -58,6 +84,19 @@ private fun RecruitmentEmptyStatePreview() {
         RecruitmentEmptyState(
             title = "작성한 모집글이 없어요.",
             subtitle = "직접 모집글을 작성하여 팀원을 모집해보세요."
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xFFF8F8FA)
+@Composable
+private fun RecruitmentEmptyStateWithButtonPreview() {
+    RebrandKoinTheme {
+        RecruitmentEmptyState(
+            title = "지원한 모집글이 없어요.",
+            subtitle = "다양한 모집글에 지원해 보세요.",
+            buttonText = "모집글 둘러보기",
+            onButtonClick = {}
         )
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/MyAppliedRecruitmentScreen.kt
@@ -47,7 +47,9 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun MyAppliedRecruitmentScreen(
     viewModel: MyAppliedRecruitmentViewModel = hiltViewModel(),
     onNavigateUp: () -> Unit = {},
-    onNavigateToLogin: () -> Unit = {}
+    onNavigateToLogin: () -> Unit = {},
+    onNavigateToMain: () -> Unit = {},
+    onNavigateToGroupChat: (recruitmentId: Int, chatRoomId: Int) -> Unit = { _, _ -> }
 ) {
     val state by viewModel.collectAsState()
 
@@ -75,6 +77,8 @@ fun MyAppliedRecruitmentScreen(
             hasMore = state.currentPage < state.totalPage,
             onLoadMore = viewModel::loadMoreMyAppliedRecruitments,
             onFilter = { viewModel.showFilterSheet() },
+            onNavigateToMain = onNavigateToMain,
+            onNavigateToGroupChat = onNavigateToGroupChat,
             modifier = Modifier.padding(innerPadding)
         )
     }
@@ -95,7 +99,9 @@ private fun MyAppliedRecruitmentScreenImpl(
     isLoadingMore: Boolean = false,
     hasMore: Boolean = false,
     onLoadMore: () -> Unit = {},
-    onFilter: () -> Unit = {}
+    onFilter: () -> Unit = {},
+    onNavigateToMain: () -> Unit = {},
+    onNavigateToGroupChat: (recruitmentId: Int, chatRoomId: Int) -> Unit = { _, _ -> }
 ) {
     Column(modifier = modifier.fillMaxSize()) {
         Row(
@@ -120,7 +126,9 @@ private fun MyAppliedRecruitmentScreenImpl(
             ) {
                 RecruitmentEmptyState(
                     title = stringResource(R.string.recruitment_applied_empty_title),
-                    subtitle = stringResource(R.string.recruitment_applied_empty_subtitle)
+                    subtitle = stringResource(R.string.recruitment_applied_empty_subtitle),
+                    buttonText = stringResource(R.string.recruitment_applied_empty_button),
+                    onButtonClick = onNavigateToMain
                 )
             }
         } else {
@@ -137,7 +145,14 @@ private fun MyAppliedRecruitmentScreenImpl(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(posts, key = { it.id }) { post ->
-                    AppliedRecruitmentPostCard(post = post)
+                    AppliedRecruitmentPostCard(
+                        post = post,
+                        onChatClick = {
+                            post.teamChatRoomId?.let { chatRoomId ->
+                                onNavigateToGroupChat(post.recruitmentId, chatRoomId)
+                            }
+                        }
+                    )
                 }
                 if (isLoadingMore) {
                     item {
@@ -166,6 +181,7 @@ private fun MyAppliedRecruitmentScreenWithPostsPreview() {
             posts = persistentListOf(
                 AppliedRecruitmentPost(
                     id = 1,
+                    recruitmentId = 17,
                     category = RecruitmentCategory.CONTEST,
                     applicationStatus = AppliedRecruitmentStatus.Approved,
                     daysLeft = 5,
@@ -177,10 +193,12 @@ private fun MyAppliedRecruitmentScreenWithPostsPreview() {
                     location = "온라인",
                     dateRange = PREVIEW_DATE_RANGE,
                     currentApplicants = 2,
-                    maxApplicants = 3
+                    maxApplicants = 3,
+                    teamChatRoomId = 31
                 ),
                 AppliedRecruitmentPost(
                     id = 2,
+                    recruitmentId = 18,
                     category = RecruitmentCategory.STUDY,
                     applicationStatus = AppliedRecruitmentStatus.Pending,
                     daysLeft = 3,
@@ -192,6 +210,7 @@ private fun MyAppliedRecruitmentScreenWithPostsPreview() {
                 ),
                 AppliedRecruitmentPost(
                     id = 3,
+                    recruitmentId = 19,
                     category = RecruitmentCategory.EXTERNAL_ACTIVITY,
                     applicationStatus = AppliedRecruitmentStatus.Rejected,
                     daysLeft = null,
@@ -201,7 +220,8 @@ private fun MyAppliedRecruitmentScreenWithPostsPreview() {
                     currentApplicants = 5,
                     maxApplicants = 5
                 )
-            )
+            ),
+            onNavigateToGroupChat = { _, _ -> }
         )
     }
 }
@@ -210,6 +230,6 @@ private fun MyAppliedRecruitmentScreenWithPostsPreview() {
 @Composable
 private fun MyAppliedRecruitmentScreenEmptyPreview() {
     RebrandKoinTheme {
-        MyAppliedRecruitmentScreenImpl(posts = persistentListOf())
+        MyAppliedRecruitmentScreenImpl(posts = persistentListOf(), onNavigateToMain = {})
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/component/AppliedRecruitmentPostCard.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/component/AppliedRecruitmentPostCard.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
@@ -42,7 +43,8 @@ import kotlinx.collections.immutable.persistentListOf
 @Composable
 fun AppliedRecruitmentPostCard(
     post: AppliedRecruitmentPost,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onChatClick: () -> Unit = {}
 ) {
     val isApproved = remember(post.applicationStatus) { post.applicationStatus is AppliedRecruitmentStatus.Approved }
 
@@ -110,12 +112,17 @@ fun AppliedRecruitmentPostCard(
                 )
                 if (isApproved) {
                     Spacer(modifier = Modifier.weight(1f))
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ic_recruitment_chat),
-                        contentDescription = null,
-                        tint = RebrandKoinTheme.colors.primary500,
-                        modifier = Modifier.size(24.dp)
-                    )
+                    IconButton(
+                        onClick = onChatClick,
+                        modifier = Modifier.size(36.dp)
+                    ) {
+                        Icon(
+                            imageVector = ImageVector.vectorResource(R.drawable.ic_recruitment_chat),
+                            contentDescription = null,
+                            tint = RebrandKoinTheme.colors.primary500,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
                 }
             }
         }
@@ -156,6 +163,7 @@ private fun AppliedPostCardApprovedPreview() {
         AppliedRecruitmentPostCard(
             post = AppliedRecruitmentPost(
                 id = 1,
+                recruitmentId = 17,
                 category = RecruitmentCategory.CONTEST,
                 applicationStatus = AppliedRecruitmentStatus.Approved,
                 daysLeft = 5,
@@ -167,9 +175,11 @@ private fun AppliedPostCardApprovedPreview() {
                 location = "온라인",
                 dateRange = PREVIEW_DATE_RANGE,
                 currentApplicants = 2,
-                maxApplicants = 3
+                maxApplicants = 3,
+                teamChatRoomId = 31
             ),
-            modifier = Modifier.padding(16.dp)
+            modifier = Modifier.padding(16.dp),
+            onChatClick = {}
         )
     }
 }
@@ -181,6 +191,7 @@ private fun AppliedPostCardPendingPreview() {
         AppliedRecruitmentPostCard(
             post = AppliedRecruitmentPost(
                 id = 2,
+                recruitmentId = 18,
                 category = RecruitmentCategory.STUDY,
                 applicationStatus = AppliedRecruitmentStatus.Pending,
                 daysLeft = 3,
@@ -202,6 +213,7 @@ private fun AppliedPostCardRejectedPreview() {
         AppliedRecruitmentPostCard(
             post = AppliedRecruitmentPost(
                 id = 3,
+                recruitmentId = 19,
                 category = RecruitmentCategory.EXTERNAL_ACTIVITY,
                 applicationStatus = AppliedRecruitmentStatus.Rejected,
                 daysLeft = null,

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/model/AppliedRecruitmentPost.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/myappliedrecruitment/model/AppliedRecruitmentPost.kt
@@ -13,6 +13,7 @@ import kotlinx.collections.immutable.toPersistentList
 
 data class AppliedRecruitmentPost(
     val id: Int,
+    val recruitmentId: Int,
     val category: RecruitmentCategory,
     val applicationStatus: AppliedRecruitmentStatus,
     val daysLeft: Int?,
@@ -21,11 +22,13 @@ data class AppliedRecruitmentPost(
     val location: String,
     val dateRange: String,
     val currentApplicants: Int,
-    val maxApplicants: Int
+    val maxApplicants: Int,
+    val teamChatRoomId: Int? = null
 )
 
 fun MyAppliedRecruitment.toAppliedRecruitmentPost() = AppliedRecruitmentPost(
     id = applicationId,
+    recruitmentId = recruitment.id,
     category = recruitment.category.toRecruitmentCategory(),
     applicationStatus = when (status) {
         "ACCEPTED" -> AppliedRecruitmentStatus.Approved
@@ -38,5 +41,6 @@ fun MyAppliedRecruitment.toAppliedRecruitmentPost() = AppliedRecruitmentPost(
     location = recruitment.meetingType.toRecruitmentLocation(),
     dateRange = recruitment.activityStartDate.toDateRange(recruitment.activityEndDate),
     currentApplicants = recruitment.currentParticipants,
-    maxApplicants = recruitment.maxParticipants
+    maxApplicants = recruitment.maxParticipants,
+    teamChatRoomId = teamChatRoomId
 )

--- a/feature/recruitment/src/main/res/values/strings.xml
+++ b/feature/recruitment/src/main/res/values/strings.xml
@@ -199,6 +199,7 @@
     <string name="recruitment_applied_filter_status_section">지원 상태</string>
     <string name="recruitment_applied_empty_title">지원한 모집글이 없어요.</string>
     <string name="recruitment_applied_empty_subtitle">다양한 모집글에 지원해 보세요.</string>
+    <string name="recruitment_applied_empty_button">모집글 둘러보기</string>
 
     <string name="recruitment_profile_create_title">팀원 모집 프로필 작성</string>
     <string name="recruitment_profile_create_edit_title">팀원 모집 프로필 수정</string>


### PR DESCRIPTION
## PR 개요
이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [x] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- `getMyApplications` API 응답의 `role` 필드가 중첩 객체(`{id, name}`)인데 클라이언트는 존재하지 않는 `role_name` 문자열 필드를 기대하고 있던 DTO 불일치 수정 (기존 `TeamRecruitmentApplicationRoleResponse`/`TeamRecruitmentApplicationRole` 재사용)
- "내가 지원한 모집글" 빈 화면에 Figma 디자인 기준 "모집글 둘러보기" 버튼 추가 → 클릭 시 모집 메인 화면으로 이동
- 승인된 지원 카드의 채팅 아이콘 클릭 시 해당 모집글의 그룹 채팅방으로 이동하도록 연결

### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다