### PR TITLE
[Fix] 채팅 ReadOnly 삭제

### DIFF
--- a/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentChatMapper.kt
+++ b/data/src/main/java/in/koreatech/koin/data/mapper/RecruitmentChatMapper.kt
@@ -5,7 +5,6 @@ import `in`.koreatech.koin.data.response.recruitment.chat.RecruitmentChatRoomRes
 import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatCounterpart
 import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatMessage
 import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoom
-import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomStatus
 import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomType
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
@@ -21,7 +20,6 @@ fun RecruitmentChatRoomResponse.toRecruitmentChatRoom(): RecruitmentChatRoom = R
     chatRoomId = chatRoomId,
     roomName = roomName,
     roomType = RecruitmentChatRoomType.fromString(roomType),
-    status = RecruitmentChatRoomStatus.fromString(status),
     memberCount = memberCount,
     maxMemberCount = maxMemberCount,
     counterpart = counterpart?.let {

--- a/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentChatRepositoryImpl.kt
+++ b/data/src/main/java/in/koreatech/koin/data/repository/RecruitmentChatRepositoryImpl.kt
@@ -77,7 +77,6 @@ class RecruitmentChatRepositoryImpl @Inject constructor(
             on(401) throws KoinRecruitmentChatException.UnauthorizedException()
             on(403) throws KoinRecruitmentChatException.ChatMemberForbiddenException()
             on(404) throws KoinRecruitmentChatException.ChatRoomNotFoundException()
-            on(409, "TEAM_RECRUITMENT_CHAT_READ_ONLY") throws KoinRecruitmentChatException.ChatReadOnlyException()
             on(409, "REQUEST_TOO_FAST") throws KoinRecruitmentChatException.RequestTooFastException()
         }
     }

--- a/data/src/main/java/in/koreatech/koin/data/response/recruitment/chat/RecruitmentChatRoomResponse.kt
+++ b/data/src/main/java/in/koreatech/koin/data/response/recruitment/chat/RecruitmentChatRoomResponse.kt
@@ -9,8 +9,6 @@ data class RecruitmentChatRoomResponse(
     val roomName: String,
     @SerializedName("room_type")
     val roomType: String,
-    @SerializedName("status")
-    val status: String,
     @SerializedName("member_count")
     val memberCount: Int,
     @SerializedName("max_member_count")

--- a/domain/src/main/java/in/koreatech/koin/domain/error/recruitment/KoinRecruitmentChatException.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/error/recruitment/KoinRecruitmentChatException.kt
@@ -31,6 +31,5 @@ sealed class KoinRecruitmentChatException : KoinErrorException() {
      * Exceptions for 409
      */
     class DirectChatConflictException : KoinRecruitmentChatException()
-    class ChatReadOnlyException : KoinRecruitmentChatException()
     class RequestTooFastException : KoinRecruitmentChatException()
 }

--- a/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/chat/RecruitmentChatRoom.kt
+++ b/domain/src/main/java/in/koreatech/koin/domain/model/recruitment/chat/RecruitmentChatRoom.kt
@@ -4,7 +4,6 @@ data class RecruitmentChatRoom(
     val chatRoomId: Int,
     val roomName: String,
     val roomType: RecruitmentChatRoomType,
-    val status: RecruitmentChatRoomStatus,
     val memberCount: Int,
     val maxMemberCount: Int,
     val counterpart: RecruitmentChatCounterpart?
@@ -17,17 +16,6 @@ enum class RecruitmentChatRoomType {
 
     companion object {
         fun fromString(value: String): RecruitmentChatRoomType =
-            entries.find { it.name == value } ?: UNKNOWN
-    }
-}
-
-enum class RecruitmentChatRoomStatus {
-    ACTIVE,
-    READ_ONLY,
-    UNKNOWN;
-
-    companion object {
-        fun fromString(value: String): RecruitmentChatRoomStatus =
             entries.find { it.name == value } ?: UNKNOWN
     }
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatScreen.kt
@@ -202,7 +202,6 @@ private fun handleSideEffect(
         RecruitmentDirectChatSideEffect.FailedToLoadMessages -> R.string.recruitment_chat_failed_to_load_messages
         RecruitmentDirectChatSideEffect.FailedToSendMessage -> R.string.recruitment_chat_failed_to_send_message
         RecruitmentDirectChatSideEffect.FailedToUploadImage -> R.string.recruitment_chat_failed_to_upload_image
-        RecruitmentDirectChatSideEffect.ChatRoomReadOnly -> R.string.recruitment_chat_read_only
         RecruitmentDirectChatSideEffect.MessageTooFast -> R.string.recruitment_chat_message_too_fast
         RecruitmentDirectChatSideEffect.DirectChatUnavailable -> R.string.recruitment_direct_chat_unavailable
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatScreen.kt
@@ -33,7 +33,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
-import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomStatus
 import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.ui.chat.components.RecruitmentChatDateChip
 import `in`.koreatech.koin.feature.recruitment.ui.chat.components.RecruitmentChatInput
@@ -91,7 +90,6 @@ fun RecruitmentDirectChatScreen(
 
     RecruitmentDirectChatScreenImpl(
         partnerNickname = uiState.partnerNickname,
-        isReadOnly = uiState.status == RecruitmentChatRoomStatus.READ_ONLY,
         isLoading = uiState.isLoading,
         isUploadingImage = uiState.isUploadingImage,
         messages = uiState.messages,
@@ -108,7 +106,6 @@ fun RecruitmentDirectChatScreen(
 @Composable
 private fun RecruitmentDirectChatScreenImpl(
     partnerNickname: String,
-    isReadOnly: Boolean,
     isLoading: Boolean,
     isUploadingImage: Boolean,
     messages: ImmutableList<RecruitmentChatMessageGroup>,
@@ -136,7 +133,7 @@ private fun RecruitmentDirectChatScreenImpl(
                 onValueChange = onChatInputValueChange,
                 onImageButtonClick = onImageButtonClick,
                 onSendClick = onSendClick,
-                enabled = !isLoading && !isReadOnly && !isUploadingImage
+                enabled = !isLoading && !isUploadingImage
             )
         },
         containerColor = RebrandKoinTheme.colors.neutral0
@@ -221,7 +218,6 @@ private fun RecruitmentDirectChatScreenPreview() {
     RebrandKoinTheme {
         RecruitmentDirectChatScreenImpl(
             partnerNickname = RecruitmentDirectChatPreviewData.PARTNER_NICKNAME,
-            isReadOnly = false,
             isLoading = false,
             isUploadingImage = false,
             messages = RecruitmentDirectChatPreviewData.messages(),
@@ -236,7 +232,6 @@ private fun RecruitmentDirectChatScreenEmptyPreview() {
     RebrandKoinTheme {
         RecruitmentDirectChatScreenImpl(
             partnerNickname = RecruitmentDirectChatPreviewData.PARTNER_NICKNAME,
-            isReadOnly = false,
             isLoading = false,
             isUploadingImage = false,
             messages = persistentListOf(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatSideEffect.kt
@@ -6,6 +6,5 @@ sealed class RecruitmentDirectChatSideEffect {
     data object FailedToLoadMessages : RecruitmentDirectChatSideEffect()
     data object FailedToSendMessage : RecruitmentDirectChatSideEffect()
     data object FailedToUploadImage : RecruitmentDirectChatSideEffect()
-    data object ChatRoomReadOnly : RecruitmentDirectChatSideEffect()
     data object MessageTooFast : RecruitmentDirectChatSideEffect()
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatState.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.feature.recruitment.ui.chat.directchat
 
 import androidx.compose.runtime.Immutable
-import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomStatus
 import `in`.koreatech.koin.feature.recruitment.ui.chat.model.RecruitmentChatMessageGroup
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -12,7 +11,6 @@ data class RecruitmentDirectChatState(
     val applicationId: Int = 0,
     val chatRoomId: Int? = null,
     val partnerNickname: String = "",
-    val status: RecruitmentChatRoomStatus = RecruitmentChatRoomStatus.ACTIVE,
     val isLoading: Boolean = true,
     val currentUserId: Int = 0,
     val messages: ImmutableList<RecruitmentChatMessageGroup> = persistentListOf(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
@@ -198,7 +198,6 @@ class RecruitmentDirectChatViewModel @Inject constructor(
     }
 
     private fun Throwable.toSendMessageSideEffect(): RecruitmentDirectChatSideEffect = when (this) {
-        is KoinRecruitmentChatException.ChatReadOnlyException -> RecruitmentDirectChatSideEffect.ChatRoomReadOnly
         is KoinRecruitmentChatException.RequestTooFastException -> RecruitmentDirectChatSideEffect.MessageTooFast
         else -> RecruitmentDirectChatSideEffect.FailedToSendMessage
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
@@ -73,7 +73,7 @@ class RecruitmentDirectChatViewModel @Inject constructor(
                     state.copy(
                         isLoading = false,
                         chatRoomId = room.chatRoomId,
-                        partnerNickname = room.counterpart?.nickname.orEmpty(),
+                        partnerNickname = room.counterpart?.nickname.orEmpty()
                     )
                 }
                 loadMessages()

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/directchat/RecruitmentDirectChatViewModel.kt
@@ -74,7 +74,6 @@ class RecruitmentDirectChatViewModel @Inject constructor(
                         isLoading = false,
                         chatRoomId = room.chatRoomId,
                         partnerNickname = room.counterpart?.nickname.orEmpty(),
-                        status = room.status
                     )
                 }
                 loadMessages()

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatScreen.kt
@@ -43,7 +43,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import `in`.koreatech.koin.core.designsystem.theme.RebrandKoinTheme
-import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomStatus
 import `in`.koreatech.koin.feature.recruitment.R
 import `in`.koreatech.koin.feature.recruitment.ui.chat.components.RecruitmentChatDateChip
 import `in`.koreatech.koin.feature.recruitment.ui.chat.components.RecruitmentChatInput
@@ -98,7 +97,6 @@ fun RecruitmentGroupChatScreen(
         title = uiState.title,
         currentMemberCount = uiState.currentMemberCount,
         maxMemberCount = uiState.maxMemberCount,
-        isReadOnly = uiState.status == RecruitmentChatRoomStatus.READ_ONLY,
         isLoading = uiState.isLoading,
         isUploadingImage = uiState.isUploadingImage,
         messages = uiState.messages,
@@ -117,7 +115,6 @@ private fun RecruitmentGroupChatScreenImpl(
     title: String,
     currentMemberCount: Int,
     maxMemberCount: Int,
-    isReadOnly: Boolean,
     isLoading: Boolean,
     isUploadingImage: Boolean,
     messages: ImmutableList<RecruitmentChatMessageGroup>,
@@ -166,7 +163,7 @@ private fun RecruitmentGroupChatScreenImpl(
                 onValueChange = onChatInputValueChange,
                 onImageButtonClick = onImageButtonClick,
                 onSendClick = onSendClick,
-                enabled = !isLoading && !isReadOnly && !isUploadingImage
+                enabled = !isLoading && !isUploadingImage
             )
         },
         containerColor = RebrandKoinTheme.colors.neutral0
@@ -247,7 +244,6 @@ private fun RecruitmentGroupChatScreenPreview() {
             title = RecruitmentGroupChatPreviewData.TITLE,
             currentMemberCount = RecruitmentGroupChatPreviewData.CURRENT_MEMBER_COUNT,
             maxMemberCount = RecruitmentGroupChatPreviewData.MAX_MEMBER_COUNT,
-            isReadOnly = false,
             isLoading = false,
             isUploadingImage = false,
             messages = RecruitmentGroupChatPreviewData.messages(),
@@ -264,7 +260,6 @@ private fun RecruitmentGroupChatScreenEmptyPreview() {
             title = RecruitmentGroupChatPreviewData.TITLE,
             currentMemberCount = RecruitmentGroupChatPreviewData.CURRENT_MEMBER_COUNT,
             maxMemberCount = RecruitmentGroupChatPreviewData.MAX_MEMBER_COUNT,
-            isReadOnly = false,
             isLoading = false,
             isUploadingImage = false,
             messages = persistentListOf(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatScreen.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatScreen.kt
@@ -230,7 +230,6 @@ private fun handleSideEffect(
         RecruitmentGroupChatSideEffect.FailedToLoadMessages -> R.string.recruitment_chat_failed_to_load_messages
         RecruitmentGroupChatSideEffect.FailedToSendMessage -> R.string.recruitment_chat_failed_to_send_message
         RecruitmentGroupChatSideEffect.FailedToUploadImage -> R.string.recruitment_chat_failed_to_upload_image
-        RecruitmentGroupChatSideEffect.ChatRoomReadOnly -> R.string.recruitment_chat_read_only
         RecruitmentGroupChatSideEffect.MessageTooFast -> R.string.recruitment_chat_message_too_fast
     }
     Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatSideEffect.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatSideEffect.kt
@@ -5,6 +5,5 @@ sealed class RecruitmentGroupChatSideEffect {
     data object FailedToLoadMessages : RecruitmentGroupChatSideEffect()
     data object FailedToSendMessage : RecruitmentGroupChatSideEffect()
     data object FailedToUploadImage : RecruitmentGroupChatSideEffect()
-    data object ChatRoomReadOnly : RecruitmentGroupChatSideEffect()
     data object MessageTooFast : RecruitmentGroupChatSideEffect()
 }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatState.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatState.kt
@@ -1,7 +1,6 @@
 package `in`.koreatech.koin.feature.recruitment.ui.chat.groupchat
 
 import androidx.compose.runtime.Immutable
-import `in`.koreatech.koin.domain.model.recruitment.chat.RecruitmentChatRoomStatus
 import `in`.koreatech.koin.feature.recruitment.ui.chat.model.RecruitmentChatMessageGroup
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -13,7 +12,6 @@ data class RecruitmentGroupChatState(
     val title: String = "",
     val currentMemberCount: Int = 0,
     val maxMemberCount: Int = 0,
-    val status: RecruitmentChatRoomStatus = RecruitmentChatRoomStatus.ACTIVE,
     val isLoading: Boolean = true,
     val currentUserId: Int = 0,
     val messages: ImmutableList<RecruitmentChatMessageGroup> = persistentListOf(),

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
@@ -190,7 +190,6 @@ class RecruitmentGroupChatViewModel @Inject constructor(
     }
 
     private fun Throwable.toSendMessageSideEffect(): RecruitmentGroupChatSideEffect = when (this) {
-        is KoinRecruitmentChatException.ChatReadOnlyException -> RecruitmentGroupChatSideEffect.ChatRoomReadOnly
         is KoinRecruitmentChatException.RequestTooFastException -> RecruitmentGroupChatSideEffect.MessageTooFast
         else -> RecruitmentGroupChatSideEffect.FailedToSendMessage
     }

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
@@ -74,7 +74,7 @@ class RecruitmentGroupChatViewModel @Inject constructor(
                         isLoading = false,
                         title = room.roomName,
                         currentMemberCount = room.memberCount,
-                        maxMemberCount = room.maxMemberCount,
+                        maxMemberCount = room.maxMemberCount
                     )
                 }
                 loadMessages()

--- a/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
+++ b/feature/recruitment/src/main/java/in/koreatech/koin/feature/recruitment/ui/chat/groupchat/RecruitmentGroupChatViewModel.kt
@@ -75,7 +75,6 @@ class RecruitmentGroupChatViewModel @Inject constructor(
                         title = room.roomName,
                         currentMemberCount = room.memberCount,
                         maxMemberCount = room.maxMemberCount,
-                        status = room.status
                     )
                 }
                 loadMessages()

--- a/feature/recruitment/src/main/res/values/strings.xml
+++ b/feature/recruitment/src/main/res/values/strings.xml
@@ -41,7 +41,6 @@
     <string name="recruitment_chat_failed_to_load_messages">메시지를 불러오지 못했습니다.</string>
     <string name="recruitment_chat_failed_to_send_message">메시지 전송에 실패했습니다.</string>
     <string name="recruitment_chat_failed_to_upload_image">이미지 업로드에 실패했습니다.</string>
-    <string name="recruitment_chat_read_only">마감된 채팅방에는 메시지를 보낼 수 없습니다.</string>
     <string name="recruitment_chat_message_too_fast">메시지를 너무 빠르게 보내고 있어요. 잠시 후 다시 시도해주세요.</string>
     <string name="recruitment_direct_chat_unavailable">채팅방을 이용할 수 없습니다.</string>
     <string name="recruitment_notification_title">알림</string>


### PR DESCRIPTION
## PR 개요
- 이슈 번호: #1583

## PR 체크리스트
- [x] Code convention을 잘 지켰나요?
- [x] Lint check를 수행하였나요?
- [x] Assignees를 추가했나요?

## 작업사항
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 코드 스타일 수정 (포맷팅 등)
- [ ] 리팩토링 (기능 수정 X, API 수정 X)
- [ ] 기타

### 작업사항의 상세한 설명
- 채팅 readonly 삭제
### 논의 사항

### 스크린샷

## 추가내용
- [x] develop, sprint 브랜치를 향하고 있습니다
- [ ] production 브랜치를 향하고 있습니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **변경 사항**
  - 채팅방 상태 정보와 읽기 전용 모드가 제거되었습니다.
  - 읽기 전용 채팅방에서도 메시지 입력과 이미지 업로드를 사용할 수 있습니다.
  - 채팅방 상태에 따른 입력 제한 및 안내 메시지가 더 이상 표시되지 않습니다.
  - 읽기 전용 채팅방 관련 오류는 일반 메시지 전송 실패로 처리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->